### PR TITLE
Strongly typed Identifiers.

### DIFF
--- a/configs/configs.go
+++ b/configs/configs.go
@@ -8,9 +8,12 @@ import (
 	"github.com/remind101/empire/apps"
 )
 
+// Version represents a unique identifier for a Config version.
+type Version string
+
 // Config represents a collection of environment variables.
 type Config struct {
-	Version string
+	Version Version
 	App     *apps.App
 	Vars    Vars
 }
@@ -27,7 +30,7 @@ type Repository interface {
 	Head(apps.ID) (*Config, error)
 
 	// Version returns the specific version of a Config for an app.
-	Version(apps.ID, string) (*Config, error)
+	Version(apps.ID, Version) (*Config, error)
 
 	// Store stores the Config for the app.
 	Push(*Config) (*Config, error)
@@ -59,7 +62,7 @@ func (r *repository) Head(appID apps.ID) (*Config, error) {
 }
 
 // Version implements Repository Version.
-func (r *repository) Version(appID apps.ID, version string) (*Config, error) {
+func (r *repository) Version(appID apps.ID, version Version) (*Config, error) {
 	for _, c := range r.s[appID] {
 		if c.Version == version {
 			return c, nil
@@ -110,7 +113,7 @@ func newConfig(config *Config, vars Vars) *Config {
 	v := mergeVars(config.Vars, vars)
 
 	return &Config{
-		Version: hash(v),
+		Version: Version(hash(v)),
 		App:     config.App,
 		Vars:    v,
 	}

--- a/deploys/deploys.go
+++ b/deploys/deploys.go
@@ -7,9 +7,12 @@ import (
 	"github.com/remind101/empire/slugs"
 )
 
+// ID represents the unique identifier for a Deploy.
+type ID string
+
 // Deploy represents a deployment to the platform.
 type Deploy struct {
-	ID      string
+	ID      ID
 	Status  string
 	Release *releases.Release
 }

--- a/releases/releases.go
+++ b/releases/releases.go
@@ -10,11 +10,18 @@ import (
 	"github.com/remind101/empire/slugs"
 )
 
+// ID represents the unique identifier for a Release.
+type ID string
+
+// Version represents the auto incremented human friendly version number of the
+// release.
+type Version string
+
 // Release is a combination of a Config and a Slug, which form a deployable
 // release.
 type Release struct {
-	ID        string
-	Version   string
+	ID        ID
+	Version   Version
 	App       *apps.App
 	Config    *configs.Config
 	Slug      *slugs.Slug
@@ -68,9 +75,9 @@ func (p *repository) Create(app *apps.App, config *configs.Config, slug *slugs.S
 	}
 
 	r := &Release{
-		ID:        strconv.Itoa(p.id),
+		ID:        ID(strconv.Itoa(p.id)),
+		Version:   Version(fmt.Sprintf("v%d", version)),
 		App:       app,
-		Version:   fmt.Sprintf("v%d", version),
 		Config:    config,
 		Slug:      slug,
 		CreatedAt: createdAt.UTC(),

--- a/slugs/slugs.go
+++ b/slugs/slugs.go
@@ -28,9 +28,12 @@ type Image struct {
 	ID   string
 }
 
+// ID represents the unique identifier of a Slug.
+type ID string
+
 // Slug represents a container image with the extracted ProcessTypes.
 type Slug struct {
-	ID           string
+	ID           ID
 	Image        *Image
 	ProcessTypes ProcessMap
 }
@@ -38,34 +41,33 @@ type Slug struct {
 // Repository represents an interface for creating and finding slugs.
 type Repository interface {
 	Create(*Slug) (*Slug, error)
-	FindByID(id string) (*Slug, error)
+	FindByID(ID) (*Slug, error)
 	FindByImage(*Image) (*Slug, error)
 }
 
 // repository is a fake implementation of the Repository interface.
 type repository struct {
-	// map[slug.ID]*Slug
-	slugs map[string]*Slug
+	slugs map[ID]*Slug
 	id    int
 }
 
 // newRepository returns a new repository instance.
 func newRepository() *repository {
 	return &repository{
-		slugs: make(map[string]*Slug),
+		slugs: make(map[ID]*Slug),
 	}
 }
 
 // Create implements Repository Create.
 func (r *repository) Create(slug *Slug) (*Slug, error) {
 	r.id++
-	slug.ID = strconv.Itoa(r.id)
+	slug.ID = ID(strconv.Itoa(r.id))
 	r.slugs[slug.ID] = slug
 	return slug, nil
 }
 
 // FindByID implements Repository FindByID.
-func (r *repository) FindByID(id string) (*Slug, error) {
+func (r *repository) FindByID(id ID) (*Slug, error) {
 	return r.slugs[id], nil
 }
 
@@ -80,7 +82,7 @@ func (r *repository) FindByImage(image *Image) (*Slug, error) {
 }
 
 func (r *repository) Reset() {
-	r.slugs = make(map[string]*Slug)
+	r.slugs = make(map[ID]*Slug)
 	r.id = 0
 }
 


### PR DESCRIPTION
I think there's a couple of advantages to doing this:
1. **Documentation**: It's easier to understand, for example, `map[ID]*Release` than `map[string]*Release`. Also has benefits when defining interfaces, because you can forgoe the argument name, in favor of the type `Find(id string)` vs `Find(ID)`.
2. **Correctness**: Since Go isn't going to implicitly convert types, you'll get compiler warnings if you, for example, provide a `releases.ID` when the method is expecting a `slugs.ID`.
