### PR TITLE
Initial stab at apps service.

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -1,0 +1,41 @@
+package apps
+
+import "github.com/remind101/empire/repos"
+
+// ID represents the unique identifier for an App.
+type ID string
+
+// App represents an app.
+type App struct {
+	ID ID
+
+	// The associated GitHub/Docker repo.
+	Repo repos.Repo
+}
+
+// Repository represents a repository for creating and finding Apps.
+type Repository interface {
+	Create(*App) (*App, error)
+	FindByID(ID) (*App, error)
+	FindByRepo(repos.Repo) (*App, error)
+}
+
+// Service provides methods for interacting with Apps.
+type Service struct {
+	Repository
+}
+
+func (s *Service) FindOrCreateByRepo(repo repos.Repo) (*App, error) {
+	a, err := s.Repository.FindByRepo(repo)
+	if err != nil {
+		return a, err
+	}
+
+	if a == nil {
+		return s.Repository.Create(&App{
+			Repo: repo,
+		})
+	}
+
+	return a, nil
+}

--- a/configs/configs_test.go
+++ b/configs/configs_test.go
@@ -4,11 +4,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/remind101/empire/repos"
+	"github.com/remind101/empire/apps"
 )
 
 func TestServiceApply(t *testing.T) {
-	repo := repos.Repo("remind101/r101-api")
+	app := &apps.App{ID: "1234"}
 	s := &Service{
 		Repository: newRepository(),
 	}
@@ -23,7 +23,7 @@ func TestServiceApply(t *testing.T) {
 			},
 			&Config{
 				Version: "20f3b833ad1f83353b1ae1d24ea6833693ce067c",
-				Repo:    repo,
+				App:     app,
 				Vars: Vars{
 					"RAILS_ENV": "production",
 				},
@@ -36,7 +36,7 @@ func TestServiceApply(t *testing.T) {
 			},
 			&Config{
 				Version: "94a8e2be1e57b07526fee99473255a619563d551",
-				Repo:    repo,
+				App:     app,
 				Vars: Vars{
 					"RAILS_ENV":    "production",
 					"DATABASE_URL": "postgres://localhost",
@@ -49,7 +49,7 @@ func TestServiceApply(t *testing.T) {
 			},
 			&Config{
 				Version: "aaa6f356d1507b0f5e14bb9adfddbea04d2569eb",
-				Repo:    repo,
+				App:     app,
 				Vars: Vars{
 					"DATABASE_URL": "postgres://localhost",
 				},
@@ -58,7 +58,7 @@ func TestServiceApply(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		c, err := s.Apply(repo, tt.in)
+		c, err := s.Apply(app, tt.in)
 
 		if err != nil {
 			t.Fatal(err)
@@ -72,14 +72,14 @@ func TestServiceApply(t *testing.T) {
 
 func TestRepository(t *testing.T) {
 	r := newRepository()
-	repo := repos.Repo("r101-api")
+	app := &apps.App{ID: "1234"}
 
-	c, _ := r.Push(repo, &Config{})
-	if h, _ := r.Head(repo); h != c {
+	c, _ := r.Push(&Config{App: app})
+	if h, _ := r.Head(app.ID); h != c {
 		t.Fatal("Head => %q; want %q", h, c)
 	}
 
-	if v, _ := r.Version(repo, c.Version); v != c {
+	if v, _ := r.Version(app.ID, c.Version); v != c {
 		t.Fatal("Version(%s) => %q; want %q", c.Version, v, c)
 	}
 }

--- a/deploys/deploys.go
+++ b/deploys/deploys.go
@@ -1,6 +1,7 @@
 package deploys
 
 import (
+	"github.com/remind101/empire/apps"
 	"github.com/remind101/empire/configs"
 	"github.com/remind101/empire/releases"
 	"github.com/remind101/empire/slugs"
@@ -14,6 +15,7 @@ type Deploy struct {
 }
 
 type Service struct {
+	AppsService     *apps.Service
 	ConfigsService  *configs.Service
 	SlugsService    *slugs.Service
 	ReleasesService *releases.Service
@@ -21,8 +23,13 @@ type Service struct {
 
 // Deploy deploys an Image to the platform.
 func (s *Service) Deploy(image *slugs.Image) (*Deploy, error) {
+	app, err := s.AppsService.FindOrCreateByRepo(image.Repo)
+	if err != nil {
+		return nil, err
+	}
+
 	// Grab the latest config.
-	config, err := s.ConfigsService.Head(image.Repo)
+	config, err := s.ConfigsService.Head(app.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +46,7 @@ func (s *Service) Deploy(image *slugs.Image) (*Deploy, error) {
 
 	// Create a new release for the Config
 	// and Slug.
-	release, err := s.ReleasesService.Create(config, slug)
+	release, err := s.ReleasesService.Create(app, config, slug)
 	if err != nil {
 		return nil, err
 	}

--- a/empire.go
+++ b/empire.go
@@ -1,17 +1,23 @@
 package empire
 
 import (
+	"github.com/remind101/empire/apps"
 	"github.com/remind101/empire/configs"
 	"github.com/remind101/empire/deploys"
 )
 
 type Empire struct {
+	appsService    *apps.Service
 	configsService *configs.Service
 	deploysService *deploys.Service
 }
 
 func New() *Empire {
 	return &Empire{}
+}
+
+func (e *Empire) AppsService() *apps.Service {
+	return e.appsService
 }
 
 func (e *Empire) ConfigsService() *configs.Service {


### PR DESCRIPTION
This introduces an `App` domain model and associated service. Instead of using the GitHub/Docker repo as an id, we use `App.ID`. The Configs and Releases service are changed to be associated with an `App`, instead of a `Repo`.

The `App` can be linked to a `Repo`, which makes deployment easy, because if we have parity between the GitHub/Docker registry orgs, then we can simply deploy an image and it will be associated with the correct app:

```
POST /deploys
```

``` json
{
  "image": {
    "repo": "remind101/r101-api",
    "id": "0b21...3466b3"
  }
}
```

If we ever get to the point where we want to deploy a certain image to a different App, then we could introduce another endpoint for that:

```
POST /apps/:app/deploys
```

``` json
{
  "image": {
    "repo": "remind101/r101-api",
    "id": "0b21...3466b3"
  }
}
```

If you guys are fine with the direction of this, I'll add an in memory apps repository and some tests.
