### PR TITLE
empire.Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 Empire is Remind's next generation PaaS, which we will eventually use to migrate
 away from Heroku.
 
+## Usage
+
+```console
+Usage of ./build/empire:
+  -docker.cert="": Path to certificate to use for TLS.
+  -docker.registry="": The docker registry to pull container images from. Leave blank to use the official docker registry.
+  -docker.socket="tcp://localhost:2375": The docker socket to connect to the docker api. Leave blank to use a fake extractor.
+  -port="8080": The port to run the API on.
+```
+
 ## Components
 
 **DISCLAIMER**: Empire is incredibly young and a lot of things will most likely

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -4,16 +4,29 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/remind101/empire"
 )
 
 func main() {
+	opts := empire.Options{}
+
 	var (
 		port = flag.String("port", "8080", "The port to run the API on.")
 	)
 
-	e := empire.New()
+	flag.StringVar(&opts.Docker.Socket, "docker.socket", os.Getenv("DOCKER_HOST"), "The docker socket to connect to the docker api. Leave blank to use a fake extractor.")
+	flag.StringVar(&opts.Docker.Registry, "docker.registry", "", "The docker registry to pull container images from. Leave blank to use the official docker registry.")
+	flag.StringVar(&opts.Docker.CertPath, "docker.cert", os.Getenv("DOCKER_CERT_PATH"), "Path to certificate to use for TLS.")
+
+	flag.Parse()
+
+	e, err := empire.New(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	s := empire.NewServer(e)
 
 	log.Printf("Starting on port %s", *port)

--- a/integration_test.go
+++ b/integration_test.go
@@ -16,7 +16,11 @@ type TestClient struct {
 }
 
 func NewTestClient(t testing.TB) *TestClient {
-	e := empire.New()
+	e, err := empire.New(empire.DefaultOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	s := httptest.NewServer(empire.NewServer(e))
 	c := client.NewService(nil)
 	c.URL = s.URL

--- a/slugs/slugs.go
+++ b/slugs/slugs.go
@@ -45,6 +45,11 @@ type Repository interface {
 	FindByImage(*Image) (*Slug, error)
 }
 
+// NewRepository returns a new Repository instance.
+func NewRepository() (Repository, error) {
+	return nil, nil
+}
+
 // repository is a fake implementation of the Repository interface.
 type repository struct {
 	slugs map[ID]*Slug


### PR DESCRIPTION
`empire.New` now takes an Options struct to configure what service implementations get used. 
