### PR TITLE
Bunch of cleanup around units interface

### DIFF
--- a/units/repository_test.go
+++ b/units/repository_test.go
@@ -7,18 +7,6 @@ import (
 	"github.com/remind101/empire/slugs"
 )
 
-func TestConsulCreate(t *testing.T) {
-	c, s := consulutil.MakeClient(t)
-	defer s.Stop()
-	service := NewConsulRepository(c)
-
-	err := service.Create(buildRelease("api", "1", slugs.ProcessMap{"web": "./bin/web"}))
-
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestConsulFindByApp(t *testing.T) {
 	c, s := consulutil.MakeClient(t)
 	defer s.Stop()
@@ -30,7 +18,6 @@ func TestConsulFindByApp(t *testing.T) {
 		"worker":   "./bin/worker",
 		"consumer": "./bin/consumer",
 	})
-	service.Create(rel)
 	service.Put(NewUnit(rel, "web", 10))
 	service.Put(NewUnit(rel, "worker", 5))
 	service.Put(NewUnit(rel, "consumer", 3))
@@ -81,7 +68,6 @@ func TestConsulDelete(t *testing.T) {
 		"worker":   "./bin/worker",
 		"consumer": "./bin/consumer",
 	})
-	service.Create(rel)
 	service.Put(NewUnit(rel, "web", 10))
 	service.Put(NewUnit(rel, "worker", 5))
 	service.Put(NewUnit(rel, "consumer", 3))

--- a/units/units_test.go
+++ b/units/units_test.go
@@ -54,7 +54,7 @@ func TestScale(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = ps.Scale("api", "web", 3)
+	_, err = ps.Scale(GenName("api", "web"), 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,14 +120,14 @@ func buildRelease(appID string, releaseID string, proctypes slugs.ProcessMap) *r
 }
 
 func testUnitsEql(t *testing.T, s Repository, id apps.ID, unitStrings []string) {
-	foundUnits, err := s.FindByApp(id)
+	unitmap, err := s.FindByApp(id)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	foundStrings := make([]string, len(foundUnits))
-	for i, u := range foundUnits {
-		foundStrings[i] = u.String()
+	var foundStrings []string
+	for _, u := range unitmap {
+		foundStrings = append(foundStrings, u.String())
 	}
 
 	sort.Strings(unitStrings)


### PR DESCRIPTION
Main motivation here is to have better parity with legion (which works with process maps keyed off of a process name, which looks like `api.web` or `api.worker`.

So I introduced `unit.Name` type and `unit.UnitMap` type. This simplified a bunch of things.
