### PR TITLE
WIP Manager package.

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1,0 +1,128 @@
+// package manager is responsible for scheduling releases onto the cluster.
+package manager
+
+import (
+	"fmt"
+
+	"github.com/remind101/empire/apps"
+	"github.com/remind101/empire/configs"
+	"github.com/remind101/empire/formations"
+	"github.com/remind101/empire/releases"
+	"github.com/remind101/empire/slugs"
+)
+
+// Name represents the (unique) name of a job. The convention is <app>.<type>.<instance>:
+//
+//	589611bf-4e6c-4fc2-a77a-d61dca412289.web.1
+type Name string
+
+// NewName returns a new Name with the proper format.
+func NewName(id apps.ID, pt formations.ProcessType, i int) Name {
+	return Name(fmt.Sprintf("%s.%s.%d", id, pt, i))
+}
+
+// Job is a job that can be scheduled.
+type Job struct {
+	// The unique name of the job.
+	Name Name
+
+	// A map of environment variables to set.
+	Environment map[string]string
+
+	// The command to run.
+	Command string
+}
+
+// State represents the state of a job.
+type State int
+
+// Various states that a job can be in.
+const (
+	StatePending State = iota
+	StateRunning
+	StateFailed
+)
+
+// JobState represents the status of a job.
+type JobState struct {
+	Job   *Job
+	State State
+}
+
+// Scheduler is an interface that represents something that can schedule Jobs
+// onto the cluster.
+type Scheduler interface {
+	// Schedule schedules a job to run on the cluster.
+	Schedule(*Job) error
+
+	// TODO Jobs returns all of the jobs currently scheduled onto the
+	// cluster and their state..
+	// JobStates() ([]*JobState, error)
+
+	// TODO Depending on the scheduler, we'd probably need to unschedule old
+	// jobs.
+	// Unschedule(Name) error
+}
+
+// Service provides a layer of convenience over a Scheduler.
+type Service struct {
+	Scheduler
+}
+
+// ScheduleRelease creates jobs for every process and instance count and
+// schedules them onto the cluster.
+func (s *Service) ScheduleRelease(release *releases.Release, formation formations.Formations) error {
+	return s.scheduleApp(
+		release.App,
+		release.Config,
+		release.Slug,
+		formation,
+	)
+}
+
+func (s *Service) scheduleApp(app *apps.App, config *configs.Config, slug *slugs.Slug, formation formations.Formations) error {
+	var jobs []*Job
+
+	// Build jobs for each process type
+	for _, f := range formation {
+		// We don't want to create jobs for process types that weren't
+		// defined in the Procfile.
+		if _, found := slug.ProcessTypes[f.ProcessType]; !found {
+			continue
+		}
+
+		command := string(slug.ProcessTypes[f.ProcessType])
+		env := environment(config.Vars)
+
+		// Build a Job for each instance of the process.
+		for i := 1; i <= f.Count; i++ {
+			j := &Job{
+				Name:        NewName(app.ID, f.ProcessType, i),
+				Environment: env,
+				Command:     command,
+			}
+
+			jobs = append(jobs, j)
+		}
+	}
+
+	// Schedule all of the jobs.
+	for _, j := range jobs {
+		if err := s.Scheduler.Schedule(j); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// environment coerces a configs.Vars into a map[string]string.
+func environment(vars configs.Vars) map[string]string {
+	env := make(map[string]string)
+
+	for k, v := range vars {
+		env[string(k)] = string(v)
+	}
+
+	return env
+}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,0 +1,11 @@
+package manager
+
+import "testing"
+
+func TestNewName(t *testing.T) {
+	n := NewName("1234", "web", 1)
+
+	if got, want := n, Name("1234.web.1"); got != want {
+		t.Fatal("Name => %v; want %v", got, want)
+	}
+}


### PR DESCRIPTION
This is a WIP for a `manager` package, which is responsible for scheduling jobs onto the cluster by talking to the scheduler in some way. This would replace the current `units` package.

I've defined a `Scheduler` interface here that currently just has a `Schedule(*Job)` method for scheduling something onto the cluster, and a `Service` that provides a layer of convenience for scheduling releases onto the cluster. My intentions are to allow us to swap in any underlying scheduler, whether it be fleet, legion, or docker swarm.

We should also think about how we schedule one off jobs, like migrations onto the cluster. I think that would be pretty easy with the interface that I've defined here, but might need to handle cleaning those up from the scheduler when they've exited (Maybe `Job` needs a field to represent long running "keep me alive" tasks from one off processes).

I haven't provided a `Scheduler` implementation yet. I was thinking the legion scheduler could provide a client library that abstracts away the details about how to format the consul keys/values.

/cc @bmarini 
