### PR TITLE
Fix BTSync duplicate folder

### DIFF
--- a/packer/scripts/setup.sh
+++ b/packer/scripts/setup.sh
@@ -52,8 +52,7 @@ fi
 
 if [ ! -d $SYNCDIR ]
 then
-    echo "# Creating $SYNCDIR"
-    mkdir -p $SYNCDIR
+    # Downloading BTSync
     curl --location -o /tmp/btsync.dmg http://download.getsyncapp.com/endpoint/btsync/os/osx/track/stable
     echo "# Opening BTSync .dmg file.  Please drag btsync into your "
     echo "# Applications folder and then launch it. "


### PR DESCRIPTION
 No need to create the folder since BTSync will create it when opening the link. On my machine when opening the link it would create a `remind-sync(1)` folder which would screw up https://github.com/remind101/empire/blob/master/Vagrantfile#L17
