### PR TITLE
DB backed ConfigsRepository.

### DIFF
--- a/configs_test.go
+++ b/configs_test.go
@@ -5,20 +5,6 @@ import (
 	"testing"
 )
 
-func TestRepository(t *testing.T) {
-	r := NewConfigsRepository()
-	app := &App{Name: "abcd"}
-
-	c, _ := r.Push(&Config{App: app})
-	if h, _ := r.Head(app.Name); !reflect.DeepEqual(c, h) {
-		t.Fatalf("Head => %q; want %q", h, c)
-	}
-
-	if v, _ := r.Version(app.Name, c.Version); !reflect.DeepEqual(c, v) {
-		t.Fatalf("Version(%s) => %q; want %q", c.Version, v, c)
-	}
-}
-
 func TestMergeVars(t *testing.T) {
 	// Old vars
 	vars := Vars{

--- a/db.go
+++ b/db.go
@@ -30,6 +30,7 @@ func NewDB(uri string) (DB, error) {
 	}
 
 	db.AddTableWithName(dbApp{}, "apps")
+	db.AddTableWithName(dbConfig{}, "configs")
 
 	return db, nil
 }

--- a/empire.go
+++ b/empire.go
@@ -57,12 +57,17 @@ func New(options Options) (*Empire, error) {
 		return nil, err
 	}
 
+	configsRepository, err := NewConfigsRepository(db)
+	if err != nil {
+		return nil, err
+	}
+
 	apps, err := NewAppsService(appsRepository)
 	if err != nil {
 		return nil, err
 	}
 
-	configs, err := NewConfigsService(options)
+	configs, err := NewConfigsService(configsRepository)
 	if err != nil {
 		return nil, err
 	}

--- a/migrations/0001_initial_schema.up.sql
+++ b/migrations/0001_initial_schema.up.sql
@@ -7,7 +7,7 @@ CREATE TABLE apps (
 );
 
 CREATE TABLE configs (
-  version text NOT NULL primary key,
+  id text NOT NULL primary key,
   app_id text NOT NULL references apps(name),
   vars hstore
 );


### PR DESCRIPTION
Changes `configsRepository` to be backed by a DB. Vars are persisted in an hstore column:

``` sql
empire [local] =# select * from configs;
+-[ RECORD 1 ]--------------------------------------+
| id     | 20f3b833ad1f83353b1ae1d24ea6833693ce067c |
| app_id | api                                      |
| vars   | "RAILS_ENV"=>"production"                |
+--------+------------------------------------------+
```
