### PR TITLE
DB backed SlugsRepository.

### DIFF
--- a/db.go
+++ b/db.go
@@ -35,6 +35,7 @@ func NewDB(uri string) (DB, error) {
 
 	db.AddTableWithName(dbApp{}, "apps")
 	db.AddTableWithName(dbConfig{}, "configs")
+	db.AddTableWithName(dbSlug{}, "slugs").SetKeys(true, "ID")
 
 	return db, nil
 }

--- a/empire.go
+++ b/empire.go
@@ -52,6 +52,20 @@ func New(options Options) (*Empire, error) {
 		return nil, err
 	}
 
+	slugsRepository, err := NewSlugsRepository(db)
+	if err != nil {
+		return nil, err
+	}
+
+	extractor, err := NewExtractor(
+		options.Docker.Socket,
+		options.Docker.Registry,
+		options.Docker.CertPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	appsRepository, err := NewAppsRepository(db)
 	if err != nil {
 		return nil, err
@@ -82,7 +96,7 @@ func New(options Options) (*Empire, error) {
 		return nil, err
 	}
 
-	slugs, err := NewSlugsService(options)
+	slugs, err := NewSlugsService(slugsRepository, extractor)
 	if err != nil {
 		return nil, err
 	}

--- a/migrations/0001_initial_schema.up.sql
+++ b/migrations/0001_initial_schema.up.sql
@@ -31,5 +31,12 @@ CREATE TABLE processes (
   command text NOT NULL
 );
 
+CREATE TABLE slugs (
+  id uuid NOT NULL DEFAULT uuid_generate_v4() primary key,
+  image_repo text NOT NULL,
+  image_id text NOT NULL,
+  process_types hstore NOT NULL
+);
+
 CREATE UNIQUE INDEX index_apps_on_name ON apps USING btree (name);
 CREATE UNIQUE INDEX index_processes_on_formation_id_and_type ON processes USING btree (formation_id, "type");


### PR DESCRIPTION
Changes the `slugsRepository` to be backed by DB. It persists the process types in an hstore column:

``` sql
empire [local] =# select * from slugs;
+-[ RECORD 1 ]--+--------------------------------------+
| id            | 45b2cdc5-d3c1-45db-9411-3e14c06eae4f |
| image_repo    | foo                                  |
| image_id      | 1234                                 |
| process_types | "web"=>"./bin/web"                   |
+---------------+--------------------------------------+
```

I'm just changing the initial migration for now, so you'll need to `dropdb empire && make bootstrap`.
