### PR TITLE
Remove jobs from jobs repository on unschedule

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -93,7 +93,7 @@ func CreateJob(db Inserter, job *Job) (*Job, error) {
 	return job, db.Insert(job)
 }
 
-// DestroyJob removes a Job from he database.
+// DestroyJob removes a Job from the database.
 func DestroyJob(db Deleter, job *Job) error {
 	_, err := db.Delete(job)
 	return err


### PR DESCRIPTION
Not the most efficient method of removing jobs (having to first look them up before deleting them), but it gets the job done. Manager needs a refactoring pass after this.
