### PR TITLE
Rename scheduler.Job to scheduler.Container.

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -40,12 +40,12 @@ type Job struct {
 type JobState struct {
 	Job       *Job
 	MachineID string
-	Name      scheduler.JobName
+	Name      scheduler.ContainerName
 	State     string
 }
 
-func (j *Job) JobName() scheduler.JobName {
-	return newJobName(
+func (j *Job) ContainerName() scheduler.ContainerName {
+	return newContainerName(
 		j.AppName,
 		j.ReleaseVersion,
 		j.ProcessType,

--- a/manager_test.go
+++ b/manager_test.go
@@ -14,7 +14,7 @@ func TestManagerScheduleRelease(t *testing.T) {
 	)
 
 	s := &mockScheduler{
-		ScheduleFunc: func(j *scheduler.Job) error {
+		ScheduleFunc: func(c *scheduler.Container) error {
 			scheduled = true
 			return nil
 		},
@@ -69,10 +69,10 @@ func TestManagerScheduleReleaseScaleDown(t *testing.T) {
 	var unscheduled bool
 
 	s := &mockScheduler{
-		UnscheduleFunc: func(n scheduler.JobName) error {
+		UnscheduleFunc: func(n scheduler.ContainerName) error {
 			unscheduled = true
 
-			if got, want := n, scheduler.JobName("r101-api.1.web.2"); got != want {
+			if got, want := n, scheduler.ContainerName("r101-api.1.web.2"); got != want {
 				t.Fatalf("Job name => %s; want %s", got, want)
 			}
 
@@ -137,11 +137,11 @@ func TestManagerScheduleReleaseScaleDown(t *testing.T) {
 	}
 }
 
-func TestNewJobName(t *testing.T) {
-	n := newJobName("r101-api", 1, "web", 1)
+func TestNewContainerName(t *testing.T) {
+	n := newContainerName("r101-api", 1, "web", 1)
 
-	if got, want := n, scheduler.JobName("r101-api.1.web.1"); got != want {
-		t.Fatalf("newJobName => %s; want %s", got, want)
+	if got, want := n, scheduler.ContainerName("r101-api.1.web.1"); got != want {
+		t.Fatalf("newContainerName => %s; want %s", got, want)
 	}
 }
 
@@ -193,20 +193,20 @@ func TestBuildJobs(t *testing.T) {
 }
 
 type mockScheduler struct {
-	ScheduleFunc   func(*scheduler.Job) error
-	UnscheduleFunc func(scheduler.JobName) error
-	JobStatesFunc  func() ([]*scheduler.JobState, error)
+	ScheduleFunc        func(*scheduler.Container) error
+	UnscheduleFunc      func(scheduler.ContainerName) error
+	ContainerStatesFunc func() ([]*scheduler.ContainerState, error)
 }
 
-func (s *mockScheduler) Schedule(j *scheduler.Job) error {
+func (s *mockScheduler) Schedule(c *scheduler.Container) error {
 	if s.ScheduleFunc != nil {
-		return s.ScheduleFunc(j)
+		return s.ScheduleFunc(c)
 	}
 
 	return nil
 }
 
-func (s *mockScheduler) Unschedule(n scheduler.JobName) error {
+func (s *mockScheduler) Unschedule(n scheduler.ContainerName) error {
 	if s.UnscheduleFunc != nil {
 		s.UnscheduleFunc(n)
 	}
@@ -214,9 +214,9 @@ func (s *mockScheduler) Unschedule(n scheduler.JobName) error {
 	return nil
 }
 
-func (s *mockScheduler) JobStates() ([]*scheduler.JobState, error) {
-	if s.JobStatesFunc != nil {
-		return s.JobStatesFunc()
+func (s *mockScheduler) ContainerStates() ([]*scheduler.ContainerState, error) {
+	if s.ContainerStatesFunc != nil {
+		return s.ContainerStatesFunc()
 	}
 
 	return nil, nil

--- a/scheduler/fleet.go
+++ b/scheduler/fleet.go
@@ -1,0 +1,154 @@
+package scheduler
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coreos/fleet/client"
+	"github.com/coreos/fleet/schema"
+)
+
+// FleetScheduler is an implementation of the Scheduler interface that schedules
+// jobs onto a coreos cluster via the fleet api.
+type FleetScheduler struct {
+	client client.API
+}
+
+// newFleetScheduler returns a new FleetScheduler with a configured fleet api
+// client.
+func newFleetScheduler(fleet string) (*FleetScheduler, error) {
+	u, err := url.Parse(fleet)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := client.NewHTTPClient(
+		http.DefaultClient,
+		*u,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return &FleetScheduler{
+		client: c,
+	}, nil
+}
+
+// Schedule implements Scheduler Schedule and builds an appropritate systemd
+// unit definition to run the container.
+func (s *FleetScheduler) Schedule(c *Container) error {
+	u := s.buildUnit(c)
+	return s.client.CreateUnit(u)
+}
+
+func (s *FleetScheduler) Unschedule(n ContainerName) error {
+	return s.client.DestroyUnit(unitNameFromContainerName(n))
+}
+
+func (s *FleetScheduler) ContainerStates() ([]*ContainerState, error) {
+	states, err := s.client.UnitStates()
+	if err != nil {
+		return nil, err
+	}
+
+	js := make([]*ContainerState, len(states))
+	for i, st := range states {
+		js[i] = &ContainerState{
+			MachineID: st.MachineID,
+			Name:      jobNameFromUnitName(st.Name),
+			State:     st.SystemdActiveState,
+		}
+	}
+
+	return js, nil
+}
+
+func unitNameFromContainerName(n ContainerName) string {
+	return string(n) + ".service"
+}
+
+func jobNameFromUnitName(un string) ContainerName {
+	return ContainerName(strings.TrimSuffix(un, ".service"))
+}
+
+// buildUnit builds a Unit file that looks like this:
+//
+// [Unit]
+// Description=app.v1.web.1
+// After=discovery.service
+//
+// [Service]
+// TimeoutStartSec=30m
+//
+// ExecStartPre=/bin/bash -c "/usr/bin/docker inspect remind101/app &> /dev/null || /usr/bin/docker pull remind101/app"
+// ExecStartPre=/bin/bash -c "/usr/bin/docker rm app.v1.web.1 &> /dev/null; exit 0"
+// ExecStart=/usr/bin/docker run --name app.v1.web.1 --rm -h %H remind101/app
+// ExecStop=/usr/bin/docker stop app.v1.web.1
+
+func (s *FleetScheduler) buildUnit(c *Container) *schema.Unit {
+	img := image(c.Image)
+	opts := []*schema.UnitOption{
+		{
+			Section: "Unit",
+			Name:    "Description",
+			Value:   string(c.Name),
+		},
+		{
+			Section: "Unit",
+			Name:    "After",
+			Value:   "discovery.service",
+		},
+		{
+			Section: "Service",
+			Name:    "TimeoutStartSec",
+			Value:   "30m",
+		},
+		{
+			Section: "Service",
+			Name:    "Restart",
+			Value:   "on-failure",
+		},
+		{
+			Section: "Service",
+			Name:    "ExecStartPre",
+			Value:   fmt.Sprintf(`/bin/bash -c "/usr/bin/docker inspect %s &> /dev/null || /usr/bin/docker pull %s"`, img, img),
+		},
+		{
+			Section: "Service",
+			Name:    "ExecStartPre",
+			Value:   fmt.Sprintf(`/bin/bash -c "/usr/bin/docker rm %s &> /dev/null; exit 0"`, c.Name),
+		},
+		{
+			Section: "Service",
+			Name:    "ExecStart",
+			Value:   fmt.Sprintf(`/usr/bin/docker run --name %s %s --rm -h %%H -P %s %s`, c.Name, env(c), img, c.Command),
+		},
+		{
+			Section: "Service",
+			Name:    "ExecStop",
+			Value:   fmt.Sprintf(`/usr/bin/docker stop %s`, c.Name),
+		},
+	}
+
+	return &schema.Unit{
+		Name:         string(c.Name) + ".service",
+		DesiredState: "launched",
+		Options:      opts,
+	}
+}
+
+func image(i Image) string {
+	return fmt.Sprintf("quay.io/%s:%s", i.Repo, i.ID)
+}
+
+func env(c *Container) string {
+	envs := []string{}
+	for k, v := range c.Environment {
+		envs = append(envs, fmt.Sprintf("-e %s=%s", k, v))
+	}
+
+	return strings.Join(envs, " ")
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,19 +1,7 @@
 package scheduler
 
-import (
-	"fmt"
-	"net/http"
-	"net/url"
-	"strings"
-
-	"github.com/coreos/fleet/client"
-	"github.com/coreos/fleet/schema"
-)
-
-// JobName represents the (unique) name of a job. The convention is <app>.<type>.<instance>.service:
-//
-//	my-sweet-app.v1.web.1.service
-type JobName string
+// ContainerName represents the (unique) name of a container.
+type ContainerName string
 
 // Image represents a container image, which is tied to a repository.
 type Image struct {
@@ -21,52 +9,49 @@ type Image struct {
 	ID   string
 }
 
-// Execute represents a command to execute inside and image.
-type Execute struct {
-	Command string
-	Image   Image
-}
-
-// Job is a job that can be scheduled.
-type Job struct {
-	// The unique name of the job.
-	Name JobName
+// Container represents a container to schedule onto the cluster.
+type Container struct {
+	// The unique name of the container.
+	Name ContainerName
 
 	// A map of environment variables to set.
 	Environment map[string]string
 
 	// The command to run.
-	Execute Execute
+	Command string
+
+	// The image that this container will be built from.
+	Image Image
 }
 
-// State represents the state of a job.
+// State represents the state of a container.
 type State int
 
-// Various states that a job can be in.
+// Various states that a container can be in.
 const (
 	StatePending State = iota
 	StateRunning
 	StateFailed
 )
 
-// JobState represents the status of a job.
-type JobState struct {
+// ContainerState represents the status of a container.
+type ContainerState struct {
 	MachineID string
-	Name      JobName
+	Name      ContainerName
 	State     string // TODO use State type
 }
 
 // Scheduler is an interface that represents something that can schedule Jobs
 // onto the cluster.
 type Scheduler interface {
-	// Schedule schedules a job to run on the cluster.
-	Schedule(*Job) error
+	// Schedule schedules a container to run on the cluster.
+	Schedule(*Container) error
 
-	// Unschedule unschedules a job from the cluster by its name.
-	Unschedule(JobName) error
+	// Unschedule unschedules a container from the cluster by its name.
+	Unschedule(ContainerName) error
 
-	// List JobStates
-	JobStates() ([]*JobState, error)
+	// List ContainerStates
+	ContainerStates() ([]*ContainerState, error)
 }
 
 // NewScheduler is a factory method for generating a new Scheduler instance.
@@ -86,158 +71,15 @@ func newScheduler() *scheduler {
 }
 
 // Schedule implements Scheduler Schedule.
-func (s *scheduler) Schedule(j *Job) error {
+func (s *scheduler) Schedule(c *Container) error {
 	return nil
 }
 
 // Unschedule implements Scheduler Unschedule.
-func (s *scheduler) Unschedule(n JobName) error {
+func (s *scheduler) Unschedule(n ContainerName) error {
 	return nil
 }
 
-func (s *scheduler) JobStates() ([]*JobState, error) {
+func (s *scheduler) ContainerStates() ([]*ContainerState, error) {
 	return nil, nil
-}
-
-// FleetScheduler is an implementation of the Scheduler interface that schedules
-// jobs onto a coreos cluster via the fleet api.
-type FleetScheduler struct {
-	client client.API
-}
-
-// newFleetScheduler returns a new FleetScheduler with a configured fleet api
-// client.
-func newFleetScheduler(fleet string) (*FleetScheduler, error) {
-	u, err := url.Parse(fleet)
-	if err != nil {
-		return nil, err
-	}
-
-	c, err := client.NewHTTPClient(
-		http.DefaultClient,
-		*u,
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	return &FleetScheduler{
-		client: c,
-	}, nil
-}
-
-// Schedule implements Scheduler Schedule and builds an appropritate systemd
-// unit definition to run the container.
-func (s *FleetScheduler) Schedule(j *Job) error {
-	u := s.buildUnit(j)
-	return s.client.CreateUnit(u)
-}
-
-func (s *FleetScheduler) Unschedule(n JobName) error {
-	return s.client.DestroyUnit(unitNameFromJobName(n))
-}
-
-func (s *FleetScheduler) JobStates() ([]*JobState, error) {
-	states, err := s.client.UnitStates()
-	if err != nil {
-		return nil, err
-	}
-
-	js := make([]*JobState, len(states))
-	for i, st := range states {
-		js[i] = &JobState{
-			MachineID: st.MachineID,
-			Name:      jobNameFromUnitName(st.Name),
-			State:     st.SystemdActiveState,
-		}
-	}
-
-	return js, nil
-}
-
-func unitNameFromJobName(n JobName) string {
-	return string(n) + ".service"
-}
-
-func jobNameFromUnitName(un string) JobName {
-	return JobName(strings.TrimSuffix(un, ".service"))
-}
-
-// buildUnit builds a Unit file that looks like this:
-//
-// [Unit]
-// Description=app.v1.web.1
-// After=discovery.service
-//
-// [Service]
-// TimeoutStartSec=30m
-//
-// ExecStartPre=/bin/bash -c "/usr/bin/docker inspect remind101/app &> /dev/null || /usr/bin/docker pull remind101/app"
-// ExecStartPre=/bin/bash -c "/usr/bin/docker rm app.v1.web.1 &> /dev/null; exit 0"
-// ExecStart=/usr/bin/docker run --name app.v1.web.1 --rm -h %H remind101/app
-// ExecStop=/usr/bin/docker stop app.v1.web.1
-
-func (s *FleetScheduler) buildUnit(j *Job) *schema.Unit {
-	img := image(j.Execute.Image)
-	opts := []*schema.UnitOption{
-		{
-			Section: "Unit",
-			Name:    "Description",
-			Value:   string(j.Name),
-		},
-		{
-			Section: "Unit",
-			Name:    "After",
-			Value:   "discovery.service",
-		},
-		{
-			Section: "Service",
-			Name:    "TimeoutStartSec",
-			Value:   "30m",
-		},
-		{
-			Section: "Service",
-			Name:    "Restart",
-			Value:   "on-failure",
-		},
-		{
-			Section: "Service",
-			Name:    "ExecStartPre",
-			Value:   fmt.Sprintf(`/bin/bash -c "/usr/bin/docker inspect %s &> /dev/null || /usr/bin/docker pull %s"`, img, img),
-		},
-		{
-			Section: "Service",
-			Name:    "ExecStartPre",
-			Value:   fmt.Sprintf(`/bin/bash -c "/usr/bin/docker rm %s &> /dev/null; exit 0"`, j.Name),
-		},
-		{
-			Section: "Service",
-			Name:    "ExecStart",
-			Value:   fmt.Sprintf(`/usr/bin/docker run --name %s %s --rm -h %%H -P %s %s`, j.Name, env(j), img, j.Execute.Command),
-		},
-		{
-			Section: "Service",
-			Name:    "ExecStop",
-			Value:   fmt.Sprintf(`/usr/bin/docker stop %s`, j.Name),
-		},
-	}
-
-	return &schema.Unit{
-		Name:         string(j.Name) + ".service",
-		DesiredState: "launched",
-		Options:      opts,
-	}
-}
-
-func image(i Image) string {
-	return fmt.Sprintf("quay.io/%s:%s", i.Repo, i.ID)
-}
-
-func env(j *Job) string {
-	envs := []string{}
-	for k, v := range j.Environment {
-		envs = append(envs, fmt.Sprintf("-e %s=%s", k, v))
-	}
-
-	return strings.Join(envs, " ")
 }


### PR DESCRIPTION
Just a thought, no need to merge if we don't like it, but I think `Container` might be better terminology than `Job` inside `package scheduler` (maybe even within `package empire` too), since It's inherently coupled to the idea of running a container, because it needs to know the image to run.

This changes:

``` go
// Job is a job that can be scheduled.
type Job struct {
    // The unique name of the job.
    Name JobName

    // A map of environment variables to set.
    Environment map[string]string

    // The command to run.
    Execute Execute
}
```

to:

``` go
// Container represents a container to schedule onto the cluster.
type Container struct {
        // The unique name of the container.
        Name ContainerName

        // A map of environment variables to set.
        Environment map[string]string

        // The command to run.
        Command string

        // The image that this container will be built from.
        Image Image
}
```

I think this is nice because it aligns better with `docker run` and will probably make more sense if we start adding support for other flags (e.g. `docker run -m 500m`).
