### PR TITLE
Add updated_at to jobs table.

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -2,8 +2,10 @@ package empire
 
 import (
 	"database/sql/driver"
+	"time"
 
 	"github.com/remind101/empire/scheduler"
+	"gopkg.in/gorp.v1"
 )
 
 // JobID represents a unique identifier for a Job.
@@ -35,6 +37,15 @@ type Job struct {
 	Environment Vars  `db:"environment"`
 	Image       Image `db:"image"`
 	Command     `db:"command"`
+
+	// UpdatedAt indicates when this job last changed state.
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// PreInsert implements a pre insert hook for the db interface
+func (j *Job) PreInsert(s gorp.SqlExecutor) error {
+	j.UpdatedAt = Now()
+	return nil
 }
 
 type JobState struct {

--- a/migrations/0001_initial_schema.up.sql
+++ b/migrations/0001_initial_schema.up.sql
@@ -47,7 +47,8 @@ CREATE TABLE jobs (
 
   environment hstore NOT NULL,
   image text NOT NULL,
-  command text NOT NULL
+  command text NOT NULL,
+  updated_at timestamp without time zone default (now() at time zone 'utc')
 );
 
 CREATE UNIQUE INDEX index_apps_on_name ON apps USING btree (name);

--- a/server.go
+++ b/server.go
@@ -439,9 +439,10 @@ type GetProcesses struct {
 
 // dyno is a heroku compatible response struct to the hk dynos command.
 type dyno struct {
-	Command string `json:"command"`
-	Name    string `json:"name"`
-	State   string `json:"state"`
+	Command   string    `json:"command"`
+	Name      string    `json:"name"`
+	State     string    `json:"state"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 func (h *GetProcesses) Serve(req *Request) (int, interface{}, error) {
@@ -466,9 +467,10 @@ func (h *GetProcesses) Serve(req *Request) (int, interface{}, error) {
 	dynos := make([]dyno, len(js))
 	for i, j := range js {
 		dynos[i] = dyno{
-			Command: string(j.Job.Command),
-			Name:    string(j.Name),
-			State:   j.State,
+			Command:   string(j.Job.Command),
+			Name:      string(j.Name),
+			State:     j.State,
+			UpdatedAt: j.Job.UpdatedAt,
 		}
 	}
 

--- a/tests/hk/hk_test.go
+++ b/tests/hk/hk_test.go
@@ -89,6 +89,9 @@ func TestDeploy(t *testing.T) {
 }
 
 func TestScale(t *testing.T) {
+	now(time.Now().AddDate(0, 0, -5))
+	defer resetNow()
+
 	run(t, []Command{
 		{
 			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
@@ -100,8 +103,8 @@ func TestScale(t *testing.T) {
 		},
 		{
 			"dynos -a acme-inc",
-			`acme-inc.1.web.1    unknown  -106751d  "./bin/web"
-acme-inc.1.web.2    unknown  -106751d  "./bin/web"`,
+			`acme-inc.1.web.1    unknown   5d  "./bin/web"
+acme-inc.1.web.2    unknown   5d  "./bin/web"`,
 		},
 
 		{
@@ -110,7 +113,7 @@ acme-inc.1.web.2    unknown  -106751d  "./bin/web"`,
 		},
 		{
 			"dynos -a acme-inc",
-			"acme-inc.1.web.1    unknown  -106751d  \"./bin/web\"",
+			"acme-inc.1.web.1    unknown   5d  \"./bin/web\"",
 		},
 	})
 }
@@ -121,11 +124,22 @@ func TestMain(m *testing.M) {
 	empiretest.Run(m)
 }
 
+var fakeNow = time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC)
+
 // Stubs out time.Now in empire.
 func init() {
+	now(fakeNow)
+}
+
+// now stubs out empire.Now.
+func now(t time.Time) {
 	empire.Now = func() time.Time {
-		return time.Date(2015, time.January, 1, 1, 1, 1, 1, time.UTC)
+		return t
 	}
+}
+
+func resetNow() {
+	now(fakeNow)
 }
 
 // hk runs an hk command against a server.


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/96

We'd probably want to tie into fleet in some way here to update the value of this if a process goes from one state to another, but this should work for now.

Maybe we'll have a goroutine that runs through the jobs table and asks fleet for the state every 10 mins or so.
