### PR TITLE
Fix a bug in ReleasesService.Create

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -203,7 +203,8 @@ func (s *releasesService) Head(app *App) (*Release, error) {
 
 func (s *releasesService) createFormation(release *Release, slug *Slug) (Formation, error) {
 	// Get the old release, so we can copy the Formation.
-	last, err := s.ReleasesRepository.Head(release.AppName)
+	prev := int(release.Ver) - 1
+	last, err := s.ReleasesRepository.FindByAppNameAndVersion(release.AppName, ReleaseVersion(prev))
 	if err != nil {
 		return nil, err
 	}

--- a/releases_test.go
+++ b/releases_test.go
@@ -37,13 +37,22 @@ func TestReleasesServiceCreate(t *testing.T) {
 type mockReleasesRepository struct {
 	ReleasesRepository // Just to satisfy the interface.
 
-	HeadFunc   func(AppName) (*Release, error)
-	CreateFunc func(*Release) (*Release, error)
+	HeadFunc                    func(AppName) (*Release, error)
+	CreateFunc                  func(*Release) (*Release, error)
+	FindByAppNameAndVersionFunc func(AppName, ReleaseVersion) (*Release, error)
 }
 
 func (s *mockReleasesRepository) Head(name AppName) (*Release, error) {
 	if s.HeadFunc != nil {
 		return s.HeadFunc(name)
+	}
+
+	return nil, nil
+}
+
+func (s *mockReleasesRepository) FindByAppNameAndVersion(a AppName, v ReleaseVersion) (*Release, error) {
+	if s.FindByAppNameAndVersionFunc != nil {
+		return s.FindByAppNameAndVersionFunc(a, v)
 	}
 
 	return nil, nil

--- a/tests/hk/hk_test.go
+++ b/tests/hk/hk_test.go
@@ -67,6 +67,42 @@ func TestConfig(t *testing.T) {
 	})
 }
 
+func TestUpdateConfigNewReleaseSameFormation(t *testing.T) {
+	now(time.Now().AddDate(0, 0, -5))
+	defer resetNow()
+
+	run(t, []Command{
+		{
+			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"Deployed ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+		},
+		{
+			"dynos -a acme-inc",
+			"acme-inc.1.web.1    unknown   5d  \"./bin/web\"",
+		},
+		{
+			"scale web=2 -a acme-inc",
+			"Scaled acme-inc to web=2:1X.",
+		},
+		{
+			"dynos -a acme-inc",
+			`acme-inc.1.web.1    unknown   5d  "./bin/web"
+acme-inc.1.web.2    unknown   5d  "./bin/web"`,
+		},
+		{
+			"set DATABASE_URL=postgres://localhost AUTH=foo -a acme-inc",
+			"Set env vars and restarted acme-inc.",
+		},
+		{
+			"dynos -a acme-inc",
+			`acme-inc.1.web.1    unknown   5d  "./bin/web"
+acme-inc.1.web.2    unknown   5d  "./bin/web"
+acme-inc.2.web.1    unknown   5d  "./bin/web"
+acme-inc.2.web.2    unknown   5d  "./bin/web"`,
+		},
+	})
+}
+
 func TestDeploy(t *testing.T) {
 	run(t, []Command{
 		{


### PR DESCRIPTION
We were grabbing the Head release to determine the old formation,
but at the time we were making the query, the Head release had
already become the new release, so the formation was always the
default formation.

I can wait to rebase this off of the reorg PR @ejholmes 
