### PR TITLE
Better vagrant setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap build cmd
+.PHONY: bootstrap build cmd vagrant
 
 cmd:
 	$(MAKE) -C empire cmd
@@ -9,3 +9,8 @@ bootstrap:
 build:
 	$(MAKE) -C empire build
 	$(MAKE) -C etcd_peers build
+
+vagrant:
+	vagrant destroy
+	sed -e "s,# discovery:,discovery:," -e "s,discovery: https://discovery.etcd.io/.*,discovery: $$(curl -s -w '\n' https://discovery.etcd.io/new)," cluster/user-data.template > cluster/user-data
+	vagrant up

--- a/README.md
+++ b/README.md
@@ -51,17 +51,20 @@ hk rollback
 ## Quickstart
 
 ```console
-boot2docker up
-vagrant up
-./build/empire server -docker.registry=quay.io -fleet.api=http://172.20.20.10:49153
-http --timeout=300 http://localhost:8080/deploys image:='{"id":"ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02", "repo":"ejholmes/acme-inc"}'
-HEROKU_API_URL=http://localhost:8080 hk apps
-HEROKU_API_URL=http://localhost:8080 hk releases -a acme-inc
-HEROKU_API_URL=http://localhost:8080 hk env -a acme-inc
-HEROKU_API_URL=http://localhost:8080 hk set RAILS_ENV=production -a acme-inc
-HEROKU_API_URL=http://localhost:8080 hk releases -a acme-inc
-HEROKU_API_URL=http://localhost:8080 hk rollback V1 -a acme-inc
-HEROKU_API_URL=http://localhost:8080 hk releases -a acme-inc
+$ make vagrant
+$ cp hk-plugins/* /usr/local/lib/hk/plugin
+$ cat <<EOF > /usr/local/bin/empire && chmod +x empire
+#!/bin/bash
+ 
+EMPIRE_URL=\${EMPIRE_URL:-"http://localhost:8080"}
+HEROKU_API_URL="\$EMPIRE_URL" hk "\$@"
+EOF
+$ empire deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02
+$ empire apps
+$ empire releases -a acme-inc
+$ empire env -a acme-inc
+$ empire rollback V1 -a acme-inc
+$ empire releases -a acme-inc
 ```
 
 ## Components

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,6 +36,7 @@ Vagrant.configure('2') do |config|
   config.vm.define 'c1' do |c1|
     c1.vm.hostname = 'c1'
     c1.vm.network :private_network, ip: '172.20.20.10'
+    c1.vm.network :forwarded_port, guest: 8080, host: 8080
 
     cloud_config c1
     docker_auth c1

--- a/cluster/.gitignore
+++ b/cluster/.gitignore
@@ -1,0 +1,1 @@
+user-data

--- a/cluster/user-data.template
+++ b/cluster/user-data.template
@@ -4,7 +4,7 @@ coreos:
   etcd:
     # generate a new token for each unique cluster from https://discovery.etcd.io/new
     # WARNING: replace each time you 'vagrant destroy'
-    discovery: https://discovery.etcd.io/067d19eb67c15cbb94d5cc3d921ddc38
+    # discovery: https://discovery.etcd.io/12345693838asdfasfadf13939923
     addr: $public_ipv4:4001
     peer-addr: $public_ipv4:7001
   fleet:
@@ -47,11 +47,33 @@ coreos:
         TimeoutStartSec=30m
         EnvironmentFile=/etc/environment
         User=core
+        Restart=on-failure
 
-        ExecStartPre=/bin/bash -c "/usr/bin/docker inspect progrium/registrator &> /dev/null || /usr/bin/docker pull progrium/registrator"
-        ExecStartPre=/bin/bash -c "/usr/bin/docker rm registrator &> /dev/null; exit 0"
+        ExecStartPre=-/bin/bash -c "/usr/bin/docker inspect progrium/registrator &> /dev/null || /usr/bin/docker pull progrium/registrator"
+        ExecStartPre=-/bin/bash -c "/usr/bin/docker rm registrator &> /dev/null; exit 0"
         ExecStart=/usr/bin/docker run --name registrator --rm -h %H -v /var/run/docker.sock:/tmp/docker.sock progrium/registrator -ip=${COREOS_PRIVATE_IPV4} etcd://${COREOS_PRIVATE_IPV4}:4001/services
         ExecStop=/usr/bin/docker stop registrator
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: postgres.service
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=Postgres
+        After=discovery.service
+
+        [Service]
+        TimeoutStartSec=30m
+        EnvironmentFile=/etc/environment
+        User=core
+        Restart=on-failure
+
+        ExecStartPre=-/bin/bash -c "/usr/bin/docker inspect postgres &> /dev/null || /usr/bin/docker pull postgres"
+        ExecStartPre=-/bin/bash -c "/usr/bin/docker rm postgres &> /dev/null; exit 0"
+        ExecStart=/usr/bin/docker run --name postgres --rm -h %H -p 5432:5432 postgres
+        ExecStop=/usr/bin/docker stop postgres
 
         [Install]
         WantedBy=multi-user.target
@@ -61,16 +83,18 @@ coreos:
       content: |
         [Unit]
         Description=Empire
-        After=discovery.service
+        After=discovery.service postgres.service
 
         [Service]
         TimeoutStartSec=30m
         EnvironmentFile=/etc/environment
         User=core
+        Restart=on-failure
 
-        ExecStartPre=/bin/bash -c "/usr/bin/docker inspect quay.io/remind/empire &> /dev/null || /usr/bin/docker pull quay.io/remind/empire"
-        ExecStartPre=/bin/bash -c "/usr/bin/docker rm empire &> /dev/null; exit 0"
-        ExecStart=/usr/bin/docker run --name empire --rm -h %H -P -v /var/run/docker.sock:/tmp/docker.sock quay.io/remind/empire server -docker.socket=unix:///tmp/docker.sock -docker.registry=quay.io -fleet.api=http://${COREOS_PRIVATE_IPV4}:49153
+        ExecStartPre=-/bin/bash -c "cd /home/core/share/empire && docker build -t quay.io/remind/empire ."
+        ExecStartPre=-/bin/bash -c "/usr/bin/docker rm empire &> /dev/null; exit 0"
+        ExecStartPre=/usr/bin/docker run quay.io/remind/empire migrate -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
+        ExecStart=/usr/bin/docker run --name empire --rm -h %H -p 8080:8080 -v /var/run/docker.sock:/tmp/docker.sock quay.io/remind/empire server -docker.socket=unix:///tmp/docker.sock -docker.registry=quay.io -fleet.api=http://${COREOS_PRIVATE_IPV4}:49153 -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
         ExecStop=/usr/bin/docker stop empire
 
         [Install]

--- a/empire/Dockerfile
+++ b/empire/Dockerfile
@@ -1,7 +1,7 @@
 FROM remind101/go:1.4-onbuild
 MAINTAINER Eric Holmes <eric@remind101.com>
 
-WORKDIR /go/src/github.com/remind101/empire
+WORKDIR /go/src/github.com/remind101/empire/empire
 ENTRYPOINT ["/go/bin/empire"]
 CMD ["server"]
 


### PR DESCRIPTION
This makes it trivial to bring up a new vagrant machine.
1. `make vagrant` will generate a new etcd discovery url.
2. Postgres is packaged in the user-data and started on boot. Empires migrations are automatically run.
3. Empire gets exposed to the outside world on port 8080 (http://localhost:8080).
4. Added info about creating an `empire` cli in the readme. 

So, just 4 steps and things should just work:

``` console
$ make vagrant
$ cp hk-plugins/* /usr/local/lib/hk/plugin
$ cat <<EOF > /usr/local/bin/empire && chmod +x empire
#!/bin/bash

EMPIRE_URL=\${EMPIRE_URL:-"http://localhost:8080"}
HEROKU_API_URL="\$EMPIRE_URL" hk "\$@"
EOF
$ empire deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02
```
