### PR TITLE
Set KillMode=none.

### DIFF
--- a/empire/scheduler/scheduler.go
+++ b/empire/scheduler/scheduler.go
@@ -202,6 +202,11 @@ func (s *FleetScheduler) buildUnit(j *Job) *schema.Unit {
 		},
 		{
 			Section: "Service",
+			Name:    "KillMode",
+			Value:   "none",
+		},
+		{
+			Section: "Service",
 			Name:    "ExecStartPre",
 			Value:   fmt.Sprintf(`/bin/bash -c "/usr/bin/docker inspect %s &> /dev/null || /usr/bin/docker pull %s"`, img, img),
 		},


### PR DESCRIPTION
This prevents systemd from thinking that `docker stop` failed, which seems to be the cause of the failed processes. Found this at https://www.digitalocean.com/community/tutorials/how-to-create-and-run-a-service-on-a-coreos-cluster.
