### PR TITLE
Cleanup server flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ USAGE:
 OPTIONS:
    --port '8080'                                        The port to run the server on
    --docker.socket 'unix:///var/run/docker.sock'        The location of the docker api [$DOCKER_HOST]
-   --docker.registry                                    The docker registry to pull container images from [$DOCKER_HOST]
+   --docker.registry                                    The docker registry to pull container images from [$DOCKER_REGISTRY]
    --docker.cert                                        If using TLS, a path to a certificate to use [$DOCKER_CERT_PATH]
-   --fleet.api 'http://127.0.0.1:49153'                 The location of the fleet api
+   --fleet.api                                          The location of the fleet api [$FLEET_URL]
    --db 'postgres://localhost/empire?sslmode=disable'   SQL connection string for the database
 
 ```

--- a/empire/cmd/empire/main.go
+++ b/empire/cmd/empire/main.go
@@ -55,7 +55,7 @@ var EmpireFlags = []cli.Flag{
 		Name:   "docker.registry",
 		Value:  "",
 		Usage:  "The docker registry to pull container images from",
-		EnvVar: "DOCKER_HOST",
+		EnvVar: "DOCKER_REGISTRY",
 	},
 	cli.StringFlag{
 		Name:   "docker.cert",
@@ -64,9 +64,10 @@ var EmpireFlags = []cli.Flag{
 		EnvVar: "DOCKER_CERT_PATH",
 	},
 	cli.StringFlag{
-		Name:  "fleet.api",
-		Value: "http://127.0.0.1:49153",
-		Usage: "The location of the fleet api",
+		Name:   "fleet.api",
+		Value:  "",
+		Usage:  "The location of the fleet api",
+		EnvVar: "FLEET_URL",
 	},
 }
 


### PR DESCRIPTION
This removes the defaults from `docker.socket` and `fleet.api`. Seems like I'm always running `./build/empire -docker.host='' -fleet.api=''` in development. I'd rather just run `./build/empire`. Also fixes a type where `docker.registry` was using the DOCKER_HOST env var.
