### PR TITLE
Ensure jobs are only run on minions

### DIFF
--- a/cluster/user-data.template
+++ b/cluster/user-data.template
@@ -9,6 +9,7 @@ coreos:
     peer-addr: $public_ipv4:7001
   fleet:
     public-ip: $public_ipv4
+    metadata: role=empire_minion
   units:
     - name: etcd.service
       command: start

--- a/empire/scheduler/scheduler.go
+++ b/empire/scheduler/scheduler.go
@@ -225,6 +225,11 @@ func (s *FleetScheduler) buildUnit(j *Job) *schema.Unit {
 			Name:    "ExecStop",
 			Value:   fmt.Sprintf(`/usr/bin/docker stop %s`, j.Name),
 		},
+		{
+			Section: "X-Fleet",
+			Name:    "MachineMetadata",
+			Value:   "role=empire_minion",
+		},
 	}
 
 	return &schema.Unit{


### PR DESCRIPTION
It'd probably be nice to store more metadata with the job itself, but
I'm really new to Gorp and I figure I'd discuss that with folks first.

This should work for the bare minimum case - we only want to run jobs on
machines with their role set to 'empire_minion'.

Also not sure how to make this work in the single vagrant box
environment.  I've added the metadata to make the Vagrant box an
empire_minion since we don't currently use empire_controller for
anything in the system, but I could see that changing.
