### PR TITLE
No -docker.registry flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ cat <<EOF > /usr/local/bin/empire && chmod +x empire
 EMPIRE_URL=\${EMPIRE_URL:-"http://localhost:8080"}
 HEROKU_API_URL="\$EMPIRE_URL" hk "\$@"
 EOF
-$ empire deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02
+$ empire deploy quay.io/ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02
 $ empire apps
 $ empire releases -a acme-inc
 $ empire env -a acme-inc

--- a/empire/apps.go
+++ b/empire/apps.go
@@ -44,7 +44,7 @@ func NewAppNameFromRepo(repo Repo) AppName {
 type App struct {
 	Name AppName `json:"name" db:"name"`
 
-	// The associated GitHub/Docker repo.
+	// The associated Docker repo.
 	Repo Repo `json:"repo" db:"repo"`
 
 	CreatedAt time.Time `json:"created_at" db:"created_at"`

--- a/empire/cmd/empire/main.go
+++ b/empire/cmd/empire/main.go
@@ -52,12 +52,6 @@ var EmpireFlags = []cli.Flag{
 		EnvVar: "DOCKER_HOST",
 	},
 	cli.StringFlag{
-		Name:   "docker.registry",
-		Value:  "",
-		Usage:  "The docker registry to pull container images from",
-		EnvVar: "DOCKER_REGISTRY",
-	},
-	cli.StringFlag{
 		Name:   "docker.cert",
 		Value:  "",
 		Usage:  "If using TLS, a path to a certificate to use",
@@ -85,7 +79,6 @@ func empireOptions(c *cli.Context) empire.Options {
 	opts := empire.Options{}
 
 	opts.Docker.Socket = c.String("docker.socket")
-	opts.Docker.Registry = c.String("docker.registry")
 	opts.Docker.CertPath = c.String("docker.cert")
 	opts.Fleet.API = c.String("fleet.api")
 	opts.DB = c.String("db")

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -22,9 +22,6 @@ type DockerOptions struct {
 	// The unix socket to connect to the docker api.
 	Socket string
 
-	// The docker registry to pull container images from.
-	Registry string
-
 	// Path to a certificate to use for TLS connections.
 	CertPath string
 }
@@ -72,7 +69,6 @@ func New(options Options) (*Empire, error) {
 
 	extractor, err := NewExtractor(
 		options.Docker.Socket,
-		options.Docker.Registry,
 		options.Docker.CertPath,
 	)
 	if err != nil {

--- a/empire/scheduler/scheduler.go
+++ b/empire/scheduler/scheduler.go
@@ -21,6 +21,10 @@ type Image struct {
 	ID   string
 }
 
+func (i Image) String() string {
+	return fmt.Sprintf("%s:%s", i.Repo, i.ID)
+}
+
 // Execute represents a command to execute inside and image.
 type Execute struct {
 	Command string
@@ -178,7 +182,7 @@ func jobNameFromUnitName(un string) JobName {
 // ExecStop=/usr/bin/docker stop app.v1.web.1
 
 func (s *FleetScheduler) buildUnit(j *Job) *schema.Unit {
-	img := image(j.Execute.Image)
+	img := j.Execute.Image.String()
 	opts := []*schema.UnitOption{
 		{
 			Section: "Unit",
@@ -237,10 +241,6 @@ func (s *FleetScheduler) buildUnit(j *Job) *schema.Unit {
 		DesiredState: "launched",
 		Options:      opts,
 	}
-}
-
-func image(i Image) string {
-	return fmt.Sprintf("quay.io/%s:%s", i.Repo, i.ID)
 }
 
 func env(j *Job) string {


### PR DESCRIPTION
Having this flag just adds an unnecessary amount of complexity. After this change, it's expected that the `repo` value in POST /deploys is a fully qualified docker repo. After this, it's possible to deploy an image from any docker registry.
