### PR TITLE
Cleanup ServeHTTP interface.

### DIFF
--- a/empire/server/deploys.go
+++ b/empire/server/deploys.go
@@ -20,11 +20,11 @@ type PostDeployForm struct {
 }
 
 // Serve implements the Handler interface.
-func (h *PostDeploys) Serve(req *Request) (int, interface{}, error) {
+func (h *PostDeploys) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
 	var form PostDeployForm
 
-	if err := req.Decode(&form); err != nil {
-		return http.StatusInternalServerError, nil, err
+	if err := Decode(r, &form); err != nil {
+		return err
 	}
 
 	d, err := h.Deploy(empire.Image{
@@ -32,8 +32,9 @@ func (h *PostDeploys) Serve(req *Request) (int, interface{}, error) {
 		ID:   form.Image.ID,
 	})
 	if err != nil {
-		return http.StatusInternalServerError, nil, err
+		return err
 	}
 
-	return 201, d, nil
+	w.WriteHeader(201)
+	return Encode(w, d)
 }

--- a/empire/server/server_test.go
+++ b/empire/server/server_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		in  interface{}
+		out string
+	}{
+		{nil, "{}\n"},
+		{map[string]string{"foo": "bar"}, `{"foo":"bar"}` + "\n"},
+	}
+
+	for _, tt := range tests {
+		w := httptest.NewRecorder()
+
+		if err := Encode(w, tt.in); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := w.Body.String(), tt.out; got != want {
+			t.Errorf("Encode(%v) => %q; want %q", tt.in, got, want)
+		}
+	}
+}
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		err    error
+		status int
+
+		out  string
+		code int
+	}{
+		{errors.New("fuck"), 400, `{"id":"","message":"fuck","url":""}` + "\n", 400},
+		{ErrNotFound, 400, `{"id":"not_found","message":"Request failed, the specified resource does not exist","url":""}` + "\n", 404},
+		{&ErrorResource{Message: "custom"}, 400, `{"id":"","message":"custom","url":""}` + "\n", 400},
+	}
+
+	for _, tt := range tests {
+		w := httptest.NewRecorder()
+
+		if err := Error(w, tt.err, tt.status); err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := w.Body.String(), tt.out; got != want {
+			t.Errorf("Error(%v, %d) => %s; want %s", tt.err, tt.status, got, want)
+		}
+
+		if got, want := w.Code, tt.code; got != want {
+			t.Errorf("Error(%v, %d) Status => %d; want %d", tt.err, tt.status, tt.status, tt.code)
+		}
+	}
+}


### PR DESCRIPTION
I'm really digging this. This defines the following interface within `package server`:

``` go
type Handler interface {
        ServeHTTP(w http.ResponseWriter, r *http.Request) error
}
```

Some benefits of this:
1. You can just return an `error` and the error will be encoded properly into the response, based on the [heroku api spec](https://devcenter.heroku.com/articles/platform-api-reference#errors).
2. Because you still get passed an `http.ResponseWriter` and `http.Request`, we can still do everything like setting headers and doing streaming responses.
3. Since ErrorResource implements the `error` interface, we can just define named errors (e.g. ErrBadRequest, ErrNotFound) for the [standard heroku error codes](https://devcenter.heroku.com/articles/platform-api-reference#error-responses), and return those when appropriate.
