### PR TITLE
tests each peer before adding it to the list

### DIFF
--- a/etcd_peers/.gitignore
+++ b/etcd_peers/.gitignore
@@ -1,2 +1,1 @@
 build
-etcd_peers

--- a/etcd_peers/Makefile
+++ b/etcd_peers/Makefile
@@ -1,8 +1,10 @@
+.PHONY: docker
+
+build/etcd_peers: cmd/etcd_peers/main.go etcd_peers.go
+	go build -o build/etcd_peers ./cmd/etcd_peers
+
 docker: Dockerfile
 	docker build --no-cache -t quay.io/remind/etcd_peers .
 
-etcd_peers: etcd_peers.go
-	go build
-
 clean:
-	rm -rf etcd_peers
+	rm -rf build

--- a/etcd_peers/cmd/etcd_peers/main.go
+++ b/etcd_peers/cmd/etcd_peers/main.go
@@ -1,0 +1,83 @@
+// Given a discoveryURL, this is meant to continually query that till it gets
+// a valid set of etcd peers.  Once it has a set (at least one) it will then
+// output, either to a file or stdout, with an environment variable.
+//
+// Meant to be used in a systemd unit that will block the launching of fleet
+// on worker/minion servers until it can join the cluster.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/remind101/empire/etcd_peers"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Printf("syntax: %s [OPTIONS] discoveryURL\n\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	var envVar = flag.String("envVar", "FLEET_ETCD_SERVERS", "The environment variable to write.")
+	var outputFile = flag.String("output", "-", "The file to dump the variable to. Setting to - dumps to stdout.")
+	var onePeer = flag.Bool("1", false, "If set, only dump the peer with the longest TTL (the most recent).")
+	var sleep = flag.Duration("sleep", time.Duration(5)*time.Second, "Time to sleep between attempts to discover nodes.")
+	flag.Parse()
+
+	discoveryURL := flag.Arg(0)
+	if discoveryURL == "" {
+		fmt.Printf("Error: Missing discoveryURL arg.\n\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+
+	for {
+		nodes, err := etcd_peers.DiscoverEtcdNodes(discoveryURL)
+		if err != nil {
+			time.Sleep(*sleep)
+			continue
+		}
+		if len(nodes) < 1 {
+			log.Printf("Got no peers from %s. Retrying.", discoveryURL)
+			time.Sleep(*sleep)
+			continue
+		}
+		urls, err := etcd_peers.NodesToClientUrls(nodes)
+		if err != nil {
+			etcd_peers.LogErr(err, "Error transforming peers.")
+			time.Sleep(*sleep)
+			continue
+		}
+		// 0 means no max number of hosts, return all that are alive
+		count := 0
+		if *onePeer {
+			count = 1
+		}
+
+		livePeers, err := etcd_peers.FindLivePeers(urls, count)
+
+		fd, err := etcd_peers.GetOutput(*outputFile)
+		if err != nil {
+			msg := fmt.Sprintf("Unable to open -output '%s'", *outputFile)
+			etcd_peers.LogErr(err, msg)
+			time.Sleep(*sleep)
+			continue
+		}
+
+		_, err = fd.WriteString(fmt.Sprintf("%s=\"%s\"\n", *envVar, strings.Join(livePeers, ",")))
+		if err != nil {
+			msg := fmt.Sprintf("Unable to write to %s", *outputFile)
+			etcd_peers.LogErr(err, msg)
+			time.Sleep(*sleep)
+			continue
+		}
+		break
+	}
+}

--- a/etcd_peers/etcd_peers_test.go
+++ b/etcd_peers/etcd_peers_test.go
@@ -1,0 +1,50 @@
+package etcd_peers
+
+import (
+	"os"
+	"testing"
+
+	"code.google.com/p/go-uuid/uuid"
+)
+
+func randomFileName(base string, length int) string {
+	i := uuid.NewRandom()
+	return base + string(i)[0:length]
+}
+
+func TestGetOutputStdout(t *testing.T) {
+	fd, err := GetOutput("-")
+	if err != nil {
+		panic(err)
+	}
+	defer fd.Close()
+	defer os.Remove(fd.Name())
+
+	name := fd.Name()
+	if err != nil {
+		panic(err)
+	}
+
+	if name != "/dev/stdout" {
+		t.Errorf("getOutput(\"-\") did not return stdout, instead returned: %s", name)
+	}
+}
+
+func TestGetOutputFile(t *testing.T) {
+	fname := randomFileName("/tmp/.etcd_peers_test.", 8)
+	fd, err := GetOutput(fname)
+	if err != nil {
+		panic(err)
+	}
+	defer fd.Close()
+	defer os.Remove(fd.Name())
+
+	name := fd.Name()
+	if err != nil {
+		panic(err)
+	}
+
+	if name != fname {
+		t.Errorf("getOutput(%s) did not return %s, instead returned: %s", fname, fname, name)
+	}
+}


### PR DESCRIPTION
This also does away with my need for GoDeps, which is nice.  This also
adds the ability to only return a single peer, rather than all of them,
and addresses all off @benmarini's comments from GH-148.

```
core@ip-10-128-6-131 ~ $ ./etcd_peers https://discovery.etcd.io/9b59af7d585bcab6fffbd70480eebeb5
FLEET_ETCD_SERVERS="http://10.128.14.183:4001/,http://10.128.6.131:4001/,http://10.128.9.184:4001/"
core@ip-10-128-6-131 ~ $ ./etcd_peers -1 https://discovery.etcd.io/9b59af7d585bcab6fffbd70480eebeb5
FLEET_ETCD_SERVERS="http://10.128.14.183:4001/"
```

Note: The above output is with 4 servers listed in the discovery URL, but the first of them (.48) being dead.
