### PR TITLE
Set proper path to .dockercfg in vagrant unit file.

### DIFF
--- a/cluster/user-data.template
+++ b/cluster/user-data.template
@@ -89,6 +89,7 @@ coreos:
         [Service]
         TimeoutStartSec=30m
         EnvironmentFile=/etc/environment
+        Environment=DOCKER_AUTH_PATH=/tmp/.dockercfg
         User=core
         Restart=on-failure
 
@@ -96,7 +97,7 @@ coreos:
         ExecStartPre=-/bin/bash -c "/usr/bin/docker rm empire &> /dev/null; exit 0"
         ExecStartPre=/usr/bin/docker run quay.io/remind/empire migrate -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
 
-        ExecStart=/usr/bin/docker run --name empire --rm -h %H -p 8080:8080 -v /var/run/docker.sock:/tmp/docker.sock quay.io/remind/empire server -docker.socket=unix:///tmp/docker.sock -fleet.api=http://${COREOS_PRIVATE_IPV4}:49153 -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
+        ExecStart=/usr/bin/docker run --name empire --rm -h %H -p 8080:8080 -e DOCKER_AUTH_PATH=${DOCKER_AUTH_PATH} -v /var/run/docker.sock:/tmp/docker.sock -v /home/core/.dockercfg:${DOCKER_AUTH_PATH} quay.io/remind/empire server -docker.socket=unix:///tmp/docker.sock -fleet.api=http://${COREOS_PRIVATE_IPV4}:49153 -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
 
         ExecStop=/usr/bin/docker stop empire
 


### PR DESCRIPTION
This bind mounts `/home/core/.dockercfg` to `/tmp/.dockercfg` within the empire container and sets the DOCKER_AUTH_PATH to `/tmp/.dockercfg`.
