### PR TITLE
Registrator needs the schema to start with etcd://

### DIFF
--- a/etcd_peers/cmd/etcd_peers/main.go
+++ b/etcd_peers/cmd/etcd_peers/main.go
@@ -27,6 +27,7 @@ func main() {
 	var outputFile = flag.String("output", "-", "The file to dump the variable to. Setting to - dumps to stdout.")
 	var onePeer = flag.Bool("1", false, "If set, only dump the peer with the longest TTL (the most recent).")
 	var sleep = flag.Duration("sleep", time.Duration(5)*time.Second, "Time to sleep between attempts to discover nodes.")
+	var schema = flag.String("schema", "", "Replace the schema of each peer with this string. Useful for things like registrator that use etcd instead of http to determine the schema.")
 	flag.Parse()
 
 	discoveryURL := flag.Arg(0)
@@ -61,7 +62,13 @@ func main() {
 			count = 1
 		}
 
-		livePeers, err := etcd_peers.FindLivePeers(urls, count)
+		livePeers, err := etcd_peers.FindLivePeers(urls, count, *schema)
+
+		if len(livePeers) < 1 {
+			log.Println("No live peers, continuing.")
+			time.Sleep(*sleep)
+			continue
+		}
 
 		fd, err := etcd_peers.GetOutput(*outputFile)
 		if err != nil {


### PR DESCRIPTION
This isn't ideal, but it gets us where we need to go.

```
core@ip-10-128-8-85 ~ $ ./etcd_peers -1 -schema etcd https://discovery.etcd.io/e45b93f757d8acb562a412ea903157d2
FLEET_ETCD_SERVERS="etcd://10.128.8.85:4001/"
```
