### PR TITLE
Pass docker.AuthConfigurations to empire.Options.

### DIFF
--- a/empire/cmd/empire/server.go
+++ b/empire/cmd/empire/server.go
@@ -11,7 +11,10 @@ import (
 
 func runServer(c *cli.Context) {
 	port := c.String("port")
-	opts := empireOptions(c)
+	opts, err := empireOptions(c)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	e, err := empire.New(opts)
 	if err != nil {

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -3,6 +3,7 @@ package empire // import "github.com/remind101/empire/empire"
 import (
 	"time"
 
+	"github.com/fsouza/go-dockerclient"
 	"github.com/mattes/migrate/migrate"
 	"github.com/remind101/empire/empire/scheduler"
 )
@@ -25,8 +26,8 @@ type DockerOptions struct {
 	// Path to a certificate to use for TLS connections.
 	CertPath string
 
-	// Path to a docker registry auth file. Typically ~/.dockercfg
-	AuthPath string
+	// A set of docker registry credentials.
+	Auth *docker.AuthConfigurations
 }
 
 // FleetOptions is a set of options to configure a fleet api client.
@@ -74,7 +75,7 @@ func New(options Options) (*Empire, error) {
 	extractor, err := NewExtractor(
 		options.Docker.Socket,
 		options.Docker.CertPath,
-		options.Docker.AuthPath,
+		options.Docker.Auth,
 	)
 	if err != nil {
 		return nil, err

--- a/empire/extractor.go
+++ b/empire/extractor.go
@@ -27,23 +27,12 @@ type Extractor interface {
 }
 
 // NewExtractor returns a new Extractor instance.
-func NewExtractor(socket, certPath string, authPath string) (Extractor, error) {
+func NewExtractor(socket, certPath string, auth *docker.AuthConfigurations) (Extractor, error) {
 	if socket == "" {
 		return newExtractor(), nil
 	}
 
 	c, err := newDockerClient(socket, certPath)
-	if err != nil {
-		return nil, err
-	}
-
-	f, err := os.Open(authPath)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	auth, err := docker.NewAuthConfigurations(f)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I want to be able to re-use the `docker.auth` flag in https://github.com/remind101/empire/pull/150. The `docker.AuthConfigrations` is now parsed in the main package and provided to empire via `empire.Options`.
