### PR TITLE
Authenticate requests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ go:
 
 before_install:
   - mkdir -p $HOME/gopath/bin
-  - L=$HOME/gopath/bin/hk && curl -sL -A "`uname -sp`" https://hk.heroku.com/hk.gz | zcat >$L && chmod +x $L
-  - hk version
   - go install -a -race std
   - go get github.com/tools/godep
   - export PATH=$HOME/gopath/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ USAGE:
 
 OPTIONS:
    --port '8080'                                        The port to run the server on
+   --github.client.id                                   The client id for the GitHub OAuth application [$GITHUB_CLIENT_ID]
+   --github.client.secret                               The client secret for the GitHub OAuth application [$GITHUB_CLIENT_SECRET]
+   --github.organization                                The organization to allow access to [$GITHUB_ORGANIZATION]
    --docker.socket 'unix:///var/run/docker.sock'        The location of the docker api [$DOCKER_HOST]
-   --docker.registry                                    The docker registry to pull container images from [$DOCKER_REGISTRY]
    --docker.cert                                        If using TLS, a path to a certificate to use [$DOCKER_CERT_PATH]
+   --docker.auth '/Users/$HOME/.dockercfg'              Path to a docker registry auth file (~/.dockercfg) [$DOCKER_AUTH_PATH]
    --fleet.api                                          The location of the fleet api [$FLEET_URL]
+   --secret '<change this>'                             The secret used to sign access tokens
    --db 'postgres://localhost/empire?sslmode=disable'   SQL connection string for the database
 
 ```
@@ -100,6 +104,16 @@ To run the tests:
 ```console
 $ godep go test ./...
 ```
+
+**Caveats**
+
+1. `emp login` won't work by default if you're running on a non-standard port.
+   Once you emp login, you'll need to change the appropriate `machine` entry in
+   your `~/.netrc` to include to port.
+
+   ```
+   machine 0.0.0.0:8080
+   ```
 
 ## Tests
 

--- a/empire/Makefile
+++ b/empire/Makefile
@@ -4,6 +4,8 @@ cmd:
 	godep go build -o build/empire ./cmd/empire
 
 bootstrap: cmd
+	go get github.com/heroku/hk
+	go build -o build/hk github.com/heroku/hk # The current stable release doesn't have a bugfix we need for plugins.
 	createdb empire
 	./build/empire migrate
 

--- a/empire/access_tokens.go
+++ b/empire/access_tokens.go
@@ -1,15 +1,28 @@
 package empire
 
-import "github.com/dgrijalva/jwt-go"
+import (
+	"errors"
+
+	"github.com/dgrijalva/jwt-go"
+)
 
 // AccessToken represents a token that allow access to the api.
 type AccessToken struct {
-	Token       string `json:"token"`
-	GitHubToken string `json:"-"`
+	Token string `json:"token"`
+	User  *User  `json:"-"`
+}
+
+type AccessTokensCreator interface {
+	AccessTokensCreate(*AccessToken) (*AccessToken, error)
+}
+
+type AccessTokensFinder interface {
+	AccessTokensFind(string) (*AccessToken, error)
 }
 
 type AccessTokensService interface {
-	AccessTokensCreate(*AccessToken) (*AccessToken, error)
+	AccessTokensCreator
+	AccessTokensFinder
 }
 
 // an implementation of the accessTokensService backed by JWT signed tokens.
@@ -17,21 +30,94 @@ type accessTokensService struct {
 	Secret []byte // Secret used to sign jwt tokens.
 }
 
+// AccessTokensCreate "creates" the token by jwt signing it and setting the
+// Token value.
 func (s *accessTokensService) AccessTokensCreate(token *AccessToken) (*AccessToken, error) {
-	return token, signToken(s.Secret, token)
-}
-
-// signToken jwt signs the token and adds the signature to the Token field.
-func signToken(secret []byte, token *AccessToken) error {
-	t := jwt.New(jwt.SigningMethodHS256)
-	t.Claims["github_token"] = token.GitHubToken
-
-	signed, err := t.SignedString(secret)
+	signed, err := SignToken(s.Secret, token)
 	if err != nil {
-		return err
+		return token, err
 	}
 
 	token.Token = signed
 
-	return err
+	return token, nil
+}
+
+func (s *accessTokensService) AccessTokensFind(token string) (*AccessToken, error) {
+	at, err := ParseToken(s.Secret, token)
+
+	if at != nil {
+		at.Token = token
+	}
+
+	return at, err
+}
+
+// SignToken jwt signs the token and adds the signature to the Token field.
+func SignToken(secret []byte, token *AccessToken) (string, error) {
+	t := accessTokenToJwt(token)
+	return t.SignedString(secret)
+}
+
+// ParseToken parses a string token, verifies it, and returns an AccessToken
+// instance.
+func ParseToken(secret []byte, token string) (*AccessToken, error) {
+	t, err := jwtParse(secret, token)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !t.Valid {
+		return nil, nil
+	}
+
+	return jwtToAccessToken(t)
+}
+
+func accessTokenToJwt(token *AccessToken) *jwt.Token {
+	t := jwt.New(jwt.SigningMethodHS256)
+	t.Claims["User"] = struct {
+		Name        string
+		GitHubToken string
+	}{
+		Name:        token.User.Name,
+		GitHubToken: token.User.GitHubToken,
+	}
+
+	return t
+}
+
+// jwtToAccessTokens maps a jwt.Token to an AccessToken.
+func jwtToAccessToken(t *jwt.Token) (*AccessToken, error) {
+	var token AccessToken
+
+	// TODO Should probably return an error here if a user isn't present.
+	if u, ok := t.Claims["User"].(map[string]interface{}); ok {
+		var user User
+
+		if n, ok := u["Name"].(string); ok {
+			user.Name = n
+		} else {
+			return &token, errors.New("missing name")
+		}
+
+		if gt, ok := u["GitHubToken"].(string); ok {
+			user.GitHubToken = gt
+		} else {
+			return &token, errors.New("missing github token")
+		}
+
+		token.User = &user
+	} else {
+		return &token, errors.New("missing user")
+	}
+
+	return &token, nil
+}
+
+func jwtParse(secret []byte, token string) (*jwt.Token, error) {
+	return jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+		return secret, nil
+	})
 }

--- a/empire/access_tokens_test.go
+++ b/empire/access_tokens_test.go
@@ -1,0 +1,3 @@
+package empire
+
+var testSecret = []byte("secret")

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -168,3 +168,10 @@ type ValidationError struct {
 func (e *ValidationError) Error() string {
 	return e.Err.Error()
 }
+
+// key used to store context values from within this package.
+type key int
+
+const (
+	UserKey key = 0
+)

--- a/empire/server/apps.go
+++ b/empire/server/apps.go
@@ -5,13 +5,14 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
 )
 
 type GetApps struct {
 	Empire
 }
 
-func (h *GetApps) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *GetApps) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	apps, err := h.AppsAll()
 	if err != nil {
 		return err
@@ -25,7 +26,7 @@ type DeleteApp struct {
 	Empire
 }
 
-func (h *DeleteApp) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *DeleteApp) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	a, err := findApp(r, h)
 	if err != nil {
 		return err
@@ -50,7 +51,7 @@ type PostApps struct {
 	Empire
 }
 
-func (h *PostApps) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *PostApps) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	var form PostAppsForm
 
 	if err := Decode(r, &form); err != nil {

--- a/empire/server/authentication.go
+++ b/empire/server/authentication.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
+)
+
+// Middleware for handling authentication.
+type Authentication struct {
+	finder  empire.AccessTokensFinder
+	handler Handler
+}
+
+// Authenticat wraps a Handler in the Authentication middleware to authenticate
+// the request.
+func Authenticate(f empire.AccessTokensFinder, h Handler) Handler {
+	return &Authentication{
+		finder:  f,
+		handler: h,
+	}
+}
+
+// ServeHTTPContext implements the Handler interface. It will ensure that
+// there is a Bearer token present and that it is valid.
+func (h *Authentication) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	token, ok := extractToken(r)
+	if !ok {
+		return ErrUnauthorized
+	}
+
+	at, err := h.finder.AccessTokensFind(token)
+	if err != nil {
+		return err
+	}
+
+	// Token is invalid or not found.
+	if at == nil {
+		return ErrUnauthorized
+	}
+
+	// Embed the associated user into the context.
+	ctx = empire.WithUser(ctx, at.User)
+
+	return h.handler.ServeHTTPContext(ctx, w, r)
+}
+
+// extractToken extracts an AccessToken Token from a request.
+func extractToken(r *http.Request) (string, bool) {
+	_, pass, ok := r.BasicAuth()
+	if !ok {
+		return "", false
+	}
+
+	return pass, true
+}

--- a/empire/server/authentication_test.go
+++ b/empire/server/authentication_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
+)
+
+func TestAuthentication(t *testing.T) {
+	m := &Authentication{
+		finder: &mockEmpire{
+			AccessTokensFindFunc: func(token string) (*empire.AccessToken, error) {
+				return &empire.AccessToken{
+					User: &empire.User{
+						Name: "ehjolmes",
+					},
+				}, nil
+			},
+		},
+		handler: HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			_, ok := empire.UserFromContext(ctx)
+			if !ok {
+				t.Fatal("Expected a user to be present in the context")
+			}
+
+			return nil
+		}),
+	}
+
+	ctx := context.Background()
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/apps", nil)
+	req.SetBasicAuth("", "token")
+
+	if err := m.ServeHTTPContext(ctx, resp, req); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/empire/server/configs.go
+++ b/empire/server/configs.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 
 	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
 )
 
 type GetConfigs struct {
 	Empire
 }
 
-func (h *GetConfigs) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *GetConfigs) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	a, err := findApp(r, h)
 	if err != nil {
 		return err
@@ -31,7 +32,7 @@ type PatchConfigs struct {
 	Empire
 }
 
-func (h *PatchConfigs) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *PatchConfigs) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	var configVars empire.Vars
 
 	if err := Decode(r, &configVars); err != nil {

--- a/empire/server/deploys.go
+++ b/empire/server/deploys.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
 )
 
 // PostDeploys is a Handler for the POST /v1/deploys endpoint.
@@ -20,7 +21,7 @@ type PostDeployForm struct {
 }
 
 // Serve implements the Handler interface.
-func (h *PostDeploys) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	var form PostDeployForm
 
 	if err := Decode(r, &form); err != nil {

--- a/empire/server/empire_test.go
+++ b/empire/server/empire_test.go
@@ -1,0 +1,11 @@
+package server
+
+import "github.com/remind101/empire/empire"
+
+type mockEmpire struct {
+	AccessTokensFindFunc func(string) (*empire.AccessToken, error)
+}
+
+func (e *mockEmpire) AccessTokensFind(token string) (*empire.AccessToken, error) {
+	return e.AccessTokensFindFunc(token)
+}

--- a/empire/server/formations.go
+++ b/empire/server/formations.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
 )
 
 // formation is a heroku compatible response struct to the hk scale command.
@@ -30,7 +31,7 @@ type PatchFormationForm struct {
 	} `json:"updates"`
 }
 
-func (h *PatchFormation) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *PatchFormation) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	var form PatchFormationForm
 
 	if err := Decode(r, &form); err != nil {

--- a/empire/server/oauth.go
+++ b/empire/server/oauth.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -31,19 +32,19 @@ type PostAuthorizations struct {
 	Authorizer
 }
 
-func (h *PostAuthorizations) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *PostAuthorizations) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	user, pass, ok := r.BasicAuth()
 	if !ok {
 		return ErrBadRequest
 	}
 
-	token, err := h.Authorize(user, pass, r.Header.Get(HeaderTwoFactor))
+	u, err := h.Authorize(user, pass, r.Header.Get(HeaderTwoFactor))
 	if err != nil {
 		return err
 	}
 
 	at, err := h.Empire.AccessTokensCreate(&empire.AccessToken{
-		GitHubToken: token,
+		User: u,
 	})
 	if err != nil {
 		return err
@@ -56,7 +57,7 @@ func (h *PostAuthorizations) ServeHTTP(w http.ResponseWriter, r *http.Request) e
 
 // Authorizer is an interface for obtaining an authorization.
 type Authorizer interface {
-	Authorize(username, password, twofactor string) (token string, err error)
+	Authorize(username, password, twofactor string) (*empire.User, error)
 }
 
 // NewAuthorizer returns a new Authorizer. If the client id is present, it will
@@ -95,7 +96,7 @@ type GitHubAuthorizer struct {
 	url string
 }
 
-func (a *GitHubAuthorizer) Authorize(username, password, twofactor string) (string, error) {
+func (a *GitHubAuthorizer) Authorize(username, password, twofactor string) (*empire.User, error) {
 	f := struct {
 		Scopes       []string `json:"scopes"`
 		ClientSecret string   `json:"client_secret"`
@@ -106,7 +107,7 @@ func (a *GitHubAuthorizer) Authorize(username, password, twofactor string) (stri
 
 	raw, err := json.Marshal(f)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if a.url == "" {
@@ -125,43 +126,68 @@ func (a *GitHubAuthorizer) Authorize(username, password, twofactor string) (stri
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if resp.StatusCode/100 != 2 {
-		return "", ErrTwoFactor
+		return nil, ErrTwoFactor
 	}
 
 	// When the `X-GitHub-OTP` header is present in the response, it means
 	// a two factor auth code needs to be provided.
 	if resp.Header.Get(HeaderGitHubTwoFactor) != "" {
-		return "", ErrTwoFactor
+		return nil, ErrTwoFactor
 	}
 
 	var ga struct {
 		Token string `json:"token"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&ga); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	token := ga.Token
 
+	req, err = http.NewRequest("GET", a.url+"/user", nil)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.SetBasicAuth(token, "x-oauth-basic")
+
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode/100 != 2 {
+		return nil, ErrUnauthorized
+	}
+
+	var gu struct {
+		Login string `json:"login"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&gu); err != nil {
+		return nil, err
+	}
+
+	user := &empire.User{
+		Name:        gu.Login,
+		GitHubToken: token,
+	}
+
 	if a.Organization != "" {
 		req, err = http.NewRequest("HEAD", a.url+"/user/memberships/orgs/"+a.Organization, nil)
 		if err != nil {
-			return token, err
+			return user, err
 		}
 		req.Header.Set("Accept", "application/vnd.github.v3+json")
 		req.SetBasicAuth(token, "x-oauth-basic")
 
 		resp, err = http.DefaultClient.Do(req)
 		if err != nil {
-			return token, err
+			return user, err
 		}
 
 		if resp.StatusCode/100 != 2 {
-			return token, &ErrorResource{
+			return user, &ErrorResource{
 				Status:  http.StatusForbidden,
 				ID:      "forbidden",
 				Message: fmt.Sprintf("You are not a member of %s", a.Organization),
@@ -169,7 +195,7 @@ func (a *GitHubAuthorizer) Authorize(username, password, twofactor string) (stri
 		}
 	}
 
-	return token, nil
+	return user, nil
 }
 
 // authorizer is a fake implementation of the Authorizer interface that let's
@@ -177,6 +203,6 @@ func (a *GitHubAuthorizer) Authorize(username, password, twofactor string) (stri
 type authorizer struct{}
 
 // Authorizer implements Authorizer Authorize.
-func (a *authorizer) Authorize(username, password, twofactor string) (string, error) {
-	return "token", nil
+func (a *authorizer) Authorize(username, password, twofactor string) (*empire.User, error) {
+	return &empire.User{Name: "fake", GitHubToken: "token"}, nil
 }

--- a/empire/server/processes.go
+++ b/empire/server/processes.go
@@ -3,6 +3,8 @@ package server
 import (
 	"net/http"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // dyno is a heroku compatible response struct to the hk dynos command.
@@ -17,7 +19,7 @@ type GetProcesses struct {
 	Empire
 }
 
-func (h *GetProcesses) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *GetProcesses) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	a, err := findApp(r, h)
 	if err != nil {
 		return err

--- a/empire/server/releases.go
+++ b/empire/server/releases.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bgentry/heroku-go"
 	"github.com/gorilla/mux"
 	"github.com/remind101/empire/empire"
+	"golang.org/x/net/context"
 )
 
 type Release heroku.Release
@@ -31,7 +32,7 @@ type GetRelease struct {
 	Empire
 }
 
-func (h *GetRelease) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *GetRelease) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	a, err := findApp(r, h)
 	if err != nil {
 		return err
@@ -57,7 +58,7 @@ type GetReleases struct {
 	Empire
 }
 
-func (h *GetReleases) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *GetReleases) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	a, err := findApp(r, h)
 	if err != nil {
 		return err
@@ -90,7 +91,7 @@ func (p *PostReleasesForm) ReleaseVersion() (empire.ReleaseVersion, error) {
 	return empire.ReleaseVersion(i), nil
 }
 
-func (h *PostReleases) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (h *PostReleases) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	var form PostReleasesForm
 
 	if err := Decode(r, &form); err != nil {

--- a/empire/tests/api/api_test.go
+++ b/empire/tests/api/api_test.go
@@ -27,8 +27,20 @@ func TestMain(m *testing.M) {
 // NewTestClient will return a new heroku.Client that's configured to interact
 // with a instance of the empire HTTP server.
 func NewTestClient(t testing.TB) (*heroku.Client, *httptest.Server) {
-	s := empiretest.NewServer(t)
-	c := &heroku.Client{}
+	e := empiretest.NewEmpire(t)
+	s := empiretest.NewServer(t, e)
+
+	token, err := e.AccessTokensCreate(&empire.AccessToken{
+		User: &empire.User{Name: "fake", GitHubToken: "token"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := &heroku.Client{
+		Username: "",
+		Password: token.Token,
+	}
 	c.URL = s.URL
 
 	return c, s

--- a/empire/users.go
+++ b/empire/users.go
@@ -1,0 +1,51 @@
+package empire
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// User represents a user of Empire.
+type User struct {
+	Name        string `json:"name"`
+	GitHubToken string `json:"-"`
+}
+
+// GitHubClient returns an http.Client that will automatically add the
+// GitHubToken to all requests.
+func (u *User) GitHubClient() *http.Client {
+	return &http.Client{
+		Transport: &githubTransport{
+			Token: u.GitHubToken,
+		},
+	}
+}
+
+// WithUser adds a user to the context.Context.
+func WithUser(ctx context.Context, u *User) context.Context {
+	return context.WithValue(ctx, UserKey, u)
+}
+
+// UserFromContext returns a user from a context.Context if one is present.
+func UserFromContext(ctx context.Context) (*User, bool) {
+	u, ok := ctx.Value(UserKey).(*User)
+	return u, ok
+}
+
+// githubTransport is an http.RoundTripper that will automatically set an oauth
+// token as the basic auth credentials before dispatching a request.
+type githubTransport struct {
+	Token     string
+	Transport http.RoundTripper
+}
+
+func (t *githubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Transport == nil {
+		t.Transport = http.DefaultTransport
+	}
+
+	req.SetBasicAuth(t.Token, "x-oauth-basic")
+
+	return t.Transport.RoundTrip(req)
+}

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -35,8 +35,11 @@ func NewEmpire(t testing.TB) *empire.Empire {
 
 // NewServer builds a new empire.Empire instance and returns an httptest.Server
 // running the empire API.
-func NewServer(t testing.TB) *httptest.Server {
-	e := NewEmpire(t)
+func NewServer(t testing.TB, e *empire.Empire) *httptest.Server {
+	if e == nil {
+		e = NewEmpire(t)
+	}
+
 	return httptest.NewServer(server.New(e, server.DefaultOptions))
 }
 

--- a/hk-plugins/deploy
+++ b/hk-plugins/deploy
@@ -4,7 +4,7 @@ repo=$(echo $1 | cut -d : -f 1)
 id=$(echo $1 | cut -d : -f 2)
 
 function deploy() {
-  curl -X POST "${HEROKU_API_URL}/deploys" -d "{\"image\":{\"repo\":\"${repo}\",\"id\":\"${id}\"}}" > /dev/null 2>&1
+  curl --user "${HKUSER}:${HKPASS}" -X POST "${HEROKU_API_URL}/deploys" -d "{\"image\":{\"repo\":\"${repo}\",\"id\":\"${id}\"}}" > /dev/null 2>&1
 }
 
 if deploy; then


### PR DESCRIPTION
WIP But pretty much there.

Some caveats:
1. In development, after an `emp login`, you need to add the port to the `machine 0.0.0.0` entry in your `~/.netrc`. It should read `machine 0.0.0.0:8080`. I'll add something to the readme about this before merging.

Closes #145
