### PR TITLE
Image.ID => Image.Tag.

### DIFF
--- a/empire/deploys.go
+++ b/empire/deploys.go
@@ -118,7 +118,7 @@ func (s *commitDeployer) DeployCommitToApp(app *App, commit Commit) (*Deploy, er
 
 	return s.DeployImageToApp(app, Image{
 		Repo: docker,
-		ID:   commit.Sha,
+		Tag:  commit.Sha,
 	})
 }
 

--- a/empire/deploys_test.go
+++ b/empire/deploys_test.go
@@ -25,7 +25,7 @@ func TestDeploysServiceDeployToApp(t *testing.T) {
 	app := &App{}
 	image := Image{
 		Repo: "remind101/r101-api",
-		ID:   "1234",
+		Tag:  "1234",
 	}
 
 	if _, err := d.DeployImageToApp(app, image); err != nil {

--- a/empire/extractor.go
+++ b/empire/extractor.go
@@ -143,7 +143,7 @@ func (e *ProcfileExtractor) pullImage(i Image) error {
 
 	return e.Client.PullImage(docker.PullImageOptions{
 		Repository:   string(i.Repo),
-		Tag:          i.ID,
+		Tag:          i.Tag,
 		OutputStream: os.Stdout,
 	}, a)
 }

--- a/empire/images.go
+++ b/empire/images.go
@@ -8,7 +8,7 @@ import (
 
 // Image represents a container image, which is tied to a repository.
 type Image struct {
-	ID   string `json:"id"`
+	Tag  string `json:"id"`
 	Repo Repo   `json:"repo"`
 }
 
@@ -31,13 +31,13 @@ func (i Image) Value() (driver.Value, error) {
 }
 
 func encodeImage(i Image) string {
-	return fmt.Sprintf("%s:%s", i.Repo, i.ID)
+	return fmt.Sprintf("%s:%s", i.Repo, i.Tag)
 }
 
 func decodeImage(s string) Image {
 	c := strings.Split(s, ":")
 	return Image{
 		Repo: Repo(c[0]),
-		ID:   c[1],
+		Tag:  c[1],
 	}
 }

--- a/empire/images_test.go
+++ b/empire/images_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestEncodeImage(t *testing.T) {
 	i := Image{
 		Repo: "remind101/r101-api",
-		ID:   "1234",
+		Tag:  "1234",
 	}
 
 	if got, want := encodeImage(i), "remind101/r101-api:1234"; got != want {
@@ -17,7 +17,7 @@ func TestDecodeImage(t *testing.T) {
 	s := "remind101/r101-api:1234"
 	expected := Image{
 		Repo: "remind101/r101-api",
-		ID:   "1234",
+		Tag:  "1234",
 	}
 
 	if got, want := decodeImage(s), expected; got != want {

--- a/empire/jobs.go
+++ b/empire/jobs.go
@@ -146,7 +146,7 @@ func Schedule(db Inserter, s container.Scheduler, j *Job) (*Job, error) {
 		Command: string(j.Command),
 		Image: container.Image{
 			Repo: string(j.Image.Repo),
-			ID:   j.Image.ID,
+			Tag:  j.Image.Tag,
 		},
 	}
 

--- a/empire/manager_test.go
+++ b/empire/manager_test.go
@@ -18,7 +18,7 @@ func TestNewContainerName(t *testing.T) {
 func TestBuildJobs(t *testing.T) {
 	image := Image{
 		Repo: "remind101/r101-api",
-		ID:   "1234",
+		Tag:  "1234",
 	}
 
 	vars := Vars{"RAILS_ENV": "production"}

--- a/empire/pkg/container/container.go
+++ b/empire/pkg/container/container.go
@@ -8,12 +8,12 @@ import "fmt"
 // rocket image, etc.
 type Image struct {
 	Repo string
-	ID   string
+	Tag  string
 }
 
 // String implements the fmt.Stringer interface.
 func (i Image) String() string {
-	return fmt.Sprintf("%s:%s", i.Repo, i.ID)
+	return fmt.Sprintf("%s:%s", i.Repo, i.Tag)
 }
 
 // Container represents a container.

--- a/empire/pkg/container/fleet_test.go
+++ b/empire/pkg/container/fleet_test.go
@@ -19,7 +19,7 @@ var testContainer = Container{
 	Command: "acme-inc",
 	Image: Image{
 		Repo: "quay.io/ejholmes/acme-inc",
-		ID:   "ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+		Tag:  "ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
 	},
 }
 

--- a/empire/server/heroku/deploys.go
+++ b/empire/server/heroku/deploys.go
@@ -15,7 +15,7 @@ type PostDeploys struct {
 // PostDeployForm is the form object that represents the POST body.
 type PostDeployForm struct {
 	Image struct {
-		ID   string `json:"id"`
+		Tag  string `json:"tag"`
 		Repo string `json:"repo"`
 	} `json:"image"`
 }
@@ -30,7 +30,7 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 
 	d, err := h.DeployImage(empire.Image{
 		Repo: empire.Repo(form.Image.Repo),
-		ID:   form.Image.ID,
+		Tag:  form.Image.Tag,
 	})
 	if err != nil {
 		return err

--- a/empire/tests/api/api_test.go
+++ b/empire/tests/api/api_test.go
@@ -14,7 +14,7 @@ var (
 	// An test docker image that can be deployed.
 	DefaultImage = empire.Image{
 		Repo: "quay.io/ejholmes/acme-inc",
-		ID:   "ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+		Tag:  "ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
 	}
 )
 

--- a/empire/tests/api/deploys_test.go
+++ b/empire/tests/api/deploys_test.go
@@ -10,7 +10,7 @@ import (
 type DeployForm struct {
 	Image struct {
 		Repo string `json:"repo"`
-		ID   string `json:"id"`
+		Tag  string `json:"tag"`
 	} `json:"image"`
 }
 
@@ -44,7 +44,7 @@ func mustDeploy(t testing.TB, c *heroku.Client, image empire.Image) Deploy {
 	)
 
 	f.Image.Repo = string(image.Repo)
-	f.Image.ID = string(image.ID)
+	f.Image.Tag = string(image.Tag)
 
 	if err := c.Post(&d, "/deploys", &f); err != nil {
 		t.Fatal(err)

--- a/hk-plugins/deploy
+++ b/hk-plugins/deploy
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 repo=$(echo $1 | cut -d : -f 1)
-id=$(echo $1 | cut -d : -f 2)
+tag=$(echo $1 | cut -d : -f 2)
 
 function deploy() {
-  curl --user "${HKUSER}:${HKPASS}" -X POST "${HEROKU_API_URL}/deploys" -d "{\"image\":{\"repo\":\"${repo}\",\"id\":\"${id}\"}}" -H "Accept: application/vnd.heroku+json; version=3" > /dev/null 2>&1
+  curl --user "${HKUSER}:${HKPASS}" -X POST "${HEROKU_API_URL}/deploys" -d "{\"image\":{\"repo\":\"${repo}\",\"tag\":\"${tag}\"}}" -H "Accept: application/vnd.heroku+json; version=3" > /dev/null 2>&1
 }
 
 if deploy; then


### PR DESCRIPTION
I think this might just be the simplest thing to do until docker actually supports immutable identifiers. Since we fundamentally have to use tags, we might as well make it explicit, which also means we can just deploy git commits without the need to resolve it to an image id. 
