### PR TITLE
Add a ReleasesRollback method to empire.

### DIFF
--- a/empire/empire.go
+++ b/empire/empire.go
@@ -221,6 +221,12 @@ func (e *Empire) ReleasesLast(app *App) (*Release, error) {
 	return e.store.ReleasesLast(app)
 }
 
+// ReleasesRollback rolls an app back to a specific release version. Returns a
+// new release.
+func (e *Empire) ReleasesRollback(app *App, version int) (*Release, error) {
+	return e.releases.ReleasesRollback(app, version)
+}
+
 // ScaleRelease scales the processes in a release.
 func (e *Empire) ScaleRelease(release *Release, config *Config, slug *Slug, formation Formation, qm ProcessQuantityMap) error {
 	return e.manager.ScaleRelease(release, config, slug, formation, qm)

--- a/empire/server/heroku/releases.go
+++ b/empire/server/heroku/releases.go
@@ -1,7 +1,6 @@
 package heroku
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -106,39 +105,7 @@ func (h *PostReleases) ServeHTTPContext(ctx context.Context, w http.ResponseWrit
 		return err
 	}
 
-	// Find previous release
-	rel, err := h.ReleasesFindByAppAndVersion(app, version)
-	if err != nil {
-		return err
-	}
-
-	if rel == nil {
-		return ErrNotFound
-	}
-
-	// Find config
-	config, err := h.ConfigsFind(rel.ConfigID)
-	if err != nil {
-		return err
-	}
-
-	if config == nil {
-		return ErrNotFound
-	}
-
-	// Find slug
-	slug, err := h.SlugsFind(rel.SlugID)
-	if err != nil {
-		return err
-	}
-
-	if slug == nil {
-		return ErrNotFound
-	}
-
-	// Create new release
-	desc := fmt.Sprintf("Rollback to v%d", version)
-	release, err := h.ReleasesCreate(app, config, slug, desc)
+	release, err := h.ReleasesRollback(app, version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This cleans up the `POST /apps/:app/releases` endpoint to utilize a `ReleasesRollback` method.
