### PR TITLE
Export a `Scale(*App, ProcessType, int) error` method on Empire.

### DIFF
--- a/empire/manager.go
+++ b/empire/manager.go
@@ -35,21 +35,7 @@ func (m *manager) ScheduleRelease(release *Release, config *Config, slug *Slug, 
 	return nil
 }
 
-// ScaleRelease takes a release and process quantity map, and
-// schedules/unschedules jobs to make the formation match the quantity map
-func (m *manager) ScaleRelease(release *Release, config *Config, slug *Slug, formation Formation, qm ProcessQuantityMap) error {
-	for t, q := range qm {
-		if p, ok := formation[t]; ok {
-			if err := m.scaleProcess(release, config, slug, p, q); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (m *manager) scaleProcess(release *Release, config *Config, slug *Slug, p *Process, q int) error {
+func (m *manager) ScaleProcess(release *Release, config *Config, slug *Slug, p *Process, q int) error {
 	var scale func(*Release, *Config, *Slug, *Process, int) error
 
 	switch {

--- a/empire/server/heroku/formations.go
+++ b/empire/server/heroku/formations.go
@@ -16,9 +16,9 @@ type PatchFormation struct {
 
 type PatchFormationForm struct {
 	Updates []struct {
-		Process  string `json:"process"` // Refers to process type
-		Quantity int    `json:"quantity"`
-		Size     string `json:"size"`
+		Process  empire.ProcessType `json:"process"` // Refers to process type
+		Quantity int                `json:"quantity"`
+		Size     string             `json:"size"`
 	} `json:"updates"`
 }
 
@@ -29,50 +29,22 @@ func (h *PatchFormation) ServeHTTPContext(ctx context.Context, w http.ResponseWr
 		return err
 	}
 
-	a, err := findApp(r, h)
+	app, err := findApp(r, h)
 	if err != nil {
 		return err
 	}
 
-	qm := empire.ProcessQuantityMap{}
 	for _, up := range form.Updates {
-		qm[empire.ProcessType(up.Process)] = up.Quantity
-	}
-
-	release, err := h.ReleasesLast(a)
-	if err != nil {
-		return err
-	}
-
-	if release == nil {
-		return ErrNotFound
-	}
-
-	config, err := h.ConfigsFind(release.ConfigID)
-	if err != nil {
-		return err
-	}
-
-	slug, err := h.SlugsFind(release.SlugID)
-	if err != nil {
-		return err
-	}
-
-	f, err := h.ProcessesAll(release)
-	if err != nil {
-		return err
-	}
-
-	err = h.ScaleRelease(release, config, slug, f, qm)
-	if err != nil {
-		return err
+		if err := h.AppsScale(app, up.Process, up.Quantity); err != nil {
+			return err
+		}
 	}
 
 	// Create the response object
 	resp := make([]*Formation, len(form.Updates))
 	for i, up := range form.Updates {
 		resp[i] = &Formation{
-			Type:     up.Process,
+			Type:     string(up.Process),
 			Quantity: up.Quantity,
 			Size:     "1X",
 		}


### PR DESCRIPTION
This cleans up the PATCH /apps/:app/formation endpoint with a `Scale(*App, ProcessType, int) error` method on Empire.

Still a little messy internally, but hides the details from the consumer.
