### PR TITLE
Add environment variables for -port, -db, and -secret flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ USAGE:
    command server [command options] [arguments...]
 
 OPTIONS:
-   --port '8080'                                        The port to run the server on
-   --github.client.id                                   The client id for the GitHub OAuth application [$GITHUB_CLIENT_ID]
-   --github.client.secret                               The client secret for the GitHub OAuth application [$GITHUB_CLIENT_SECRET]
-   --github.organization                                The organization to allow access to [$GITHUB_ORGANIZATION]
-   --docker.socket 'unix:///var/run/docker.sock'        The location of the docker api [$DOCKER_HOST]
-   --docker.cert                                        If using TLS, a path to a certificate to use [$DOCKER_CERT_PATH]
-   --docker.auth '/Users/$HOME/.dockercfg'              Path to a docker registry auth file (~/.dockercfg) [$DOCKER_AUTH_PATH]
-   --fleet.api                                          The location of the fleet api [$FLEET_URL]
-   --secret '<change this>'                             The secret used to sign access tokens
-   --db 'postgres://localhost/empire?sslmode=disable'   SQL connection string for the database
-
+   --port '8080'          The port to run the server on [$EMPIRE_PORT]
+   --github.client.id           The client id for the GitHub OAuth application [$EMPIRE_GITHUB_CLIENT_ID]
+   --github.client.secret         The client secret for the GitHub OAuth application [$EMPIRE_GITHUB_CLIENT_SECRET]
+   --github.organization        The organization to allow access to [$EMPIRE_GITHUB_ORGANIZATION]
+   --github.secret          The shared secret between GitHub and Empire. GitHub will use this secret to sign webhook requests. [$EMPIRE_GITHUB_SECRET]
+   --docker.organization        The fallback docker registry organization to use when an app is not linked to a docker repo. (e.g. quay.io/remind101) [$EMPIRE_DOCKER_ORGANIZATION]
+   --docker.socket 'unix:///var/run/docker.sock'  The location of the docker api [$DOCKER_HOST]
+   --docker.cert          If using TLS, a path to a certificate to use [$DOCKER_CERT_PATH]
+   --docker.auth '/Users/ejholmes/.dockercfg'   Path to a docker registry auth file (~/.dockercfg) [$DOCKER_AUTH_PATH]
+   --fleet.api            The location of the fleet api [$FLEET_URL]
+   --secret '<change this>'       The secret used to sign access tokens [$EMPIRE_TOKEN_SECRET]
+   --db 'postgres://localhost/empire?sslmode=disable' SQL connection string for the database [$EMPIRE_DATABASE_URL]
+   
 ```
 
 ## Heroku API compatibility

--- a/cluster/user-data.template
+++ b/cluster/user-data.template
@@ -114,8 +114,8 @@ coreos:
         TimeoutStartSec=30m
         EnvironmentFile=/etc/environment
         Environment=DOCKER_AUTH_PATH=/tmp/.dockercfg
-        Environment=GITHUB_SECRET=secret
         Environment=DOCKER_ORGANIZATION=remind101
+        Environment=EMPIRE_GITHUB_SECRET=secret
         User=core
         Restart=on-failure
 
@@ -123,7 +123,7 @@ coreos:
         ExecStartPre=-/bin/bash -c "/usr/bin/docker rm empire &> /dev/null; exit 0"
         ExecStartPre=/usr/bin/docker run remind101/empire migrate -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
 
-        ExecStart=/usr/bin/docker run --name empire --rm -h %H -p 8080:8080 -e DOCKER_AUTH_PATH=${DOCKER_AUTH_PATH} -e GITHUB_SECRET=${GITHUB_SECRET} -e DOCKER_ORGANIZATION=${DOCKER_ORGANIZATION} -v /var/run/docker.sock:/tmp/docker.sock -v /home/core/.dockercfg:${DOCKER_AUTH_PATH} remind101/empire server -docker.socket=unix:///tmp/docker.sock -fleet.api=http://${COREOS_PRIVATE_IPV4}:49153 -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
+        ExecStart=/usr/bin/docker run --name empire --rm -h %H -p 8080:8080 -e DOCKER_AUTH_PATH=${DOCKER_AUTH_PATH} -e EMPIRE_GITHUB_SECRET=${EMPIRE_GITHUB_SECRET} -e DOCKER_ORGANIZATION=${DOCKER_ORGANIZATION} -v /var/run/docker.sock:/tmp/docker.sock -v /home/core/.dockercfg:${DOCKER_AUTH_PATH} remind101/empire server -docker.socket=unix:///tmp/docker.sock -fleet.api=http://${COREOS_PRIVATE_IPV4}:49153 -db postgres://postgres:postgres@${COREOS_PRIVATE_IPV4}:5432/postgres?sslmode=disable
 
         ExecStop=/usr/bin/docker stop empire
 

--- a/empire/cmd/empire/main.go
+++ b/empire/cmd/empire/main.go
@@ -20,31 +20,31 @@ var Commands = []cli.Command{
 				Name:   "port",
 				Value:  "8080",
 				Usage:  "The port to run the server on",
-				EnvVar: "PORT",
+				EnvVar: "EMPIRE_PORT",
 			},
 			cli.StringFlag{
 				Name:   "github.client.id",
 				Value:  "",
 				Usage:  "The client id for the GitHub OAuth application",
-				EnvVar: "GITHUB_CLIENT_ID",
+				EnvVar: "EMPIRE_GITHUB_CLIENT_ID",
 			},
 			cli.StringFlag{
 				Name:   "github.client.secret",
 				Value:  "",
 				Usage:  "The client secret for the GitHub OAuth application",
-				EnvVar: "GITHUB_CLIENT_SECRET",
+				EnvVar: "EMPIRE_GITHUB_CLIENT_SECRET",
 			},
 			cli.StringFlag{
 				Name:   "github.organization",
 				Value:  "",
 				Usage:  "The organization to allow access to",
-				EnvVar: "GITHUB_ORGANIZATION",
+				EnvVar: "EMPIRE_GITHUB_ORGANIZATION",
 			},
 			cli.StringFlag{
 				Name:   "github.secret",
 				Value:  "",
 				Usage:  "The shared secret between GitHub and Empire. GitHub will use this secret to sign webhook requests.",
-				EnvVar: "GITHUB_SECRET",
+				EnvVar: "EMPIRE_GITHUB_SECRET",
 			},
 		}, append(EmpireFlags, DBFlags...)...),
 		Action: runServer,
@@ -68,7 +68,7 @@ var DBFlags = []cli.Flag{
 		Name:   "db",
 		Value:  "postgres://localhost/empire?sslmode=disable",
 		Usage:  "SQL connection string for the database",
-		EnvVar: "DATABASE_URL",
+		EnvVar: "EMPIRE_DATABASE_URL",
 	},
 }
 
@@ -101,13 +101,13 @@ var EmpireFlags = []cli.Flag{
 		Name:   "fleet.api",
 		Value:  "",
 		Usage:  "The location of the fleet api",
-		EnvVar: "FLEET_URL",
+		EnvVar: "EMPIRE_FLEET_URL",
 	},
 	cli.StringFlag{
 		Name:   "secret",
 		Value:  "<change this>",
 		Usage:  "The secret used to sign access tokens",
-		EnvVar: "TOKEN_SECRET",
+		EnvVar: "EMPIRE_TOKEN_SECRET",
 	},
 }
 


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/226

I've also considered prefixing all of our environment variables with `EMPIRE_` so we don't inadvertently use an environment variable that might be set for something else. Thoughts?
