### PR TITLE
Dynamic host for nginx config

### DIFF
--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -5,13 +5,9 @@ RUN apt-get update && apt-get install -y nginx curl \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN cd /usr/local/bin && curl -L https://github.com/kelseyhightower/confd/releases/download/v0.7.1/confd-0.7.1-linux-amd64 -o confd \
- && chmod +x /usr/local/bin/confd
+RUN curl -LSs https://github.com/kelseyhightower/confd/releases/download/v0.7.1/confd-0.7.1-linux-amd64 > /usr/local/bin/confd \
+  && chmod +x /usr/local/bin/confd
 
-RUN mkdir -p /etc/confd/conf.d /etc/confd/templates
-ADD ./files/etc/confd/conf.d/nginx.toml /etc/confd/conf.d/nginx.toml
-ADD ./files/etc/confd/templates/nginx.conf.tmpl /etc/confd/templates/nginx.conf.tmpl
+ADD ./files /
 
-ADD ./files/usr/local/bin/confd-watch /usr/local/bin/confd-watch
-RUN chmod +x /usr/local/bin/confd-watch
 CMD /usr/local/bin/confd-watch

--- a/router/files/etc/confd/conf.d/nginx.toml
+++ b/router/files/etc/confd/conf.d/nginx.toml
@@ -17,5 +17,5 @@ mode = "0644"
 
 # These are the commands that will be used to check whether the rendered config is
 # valid and to reload the actual service once the new config is in place
-check_cmd = "/usr/sbin/nginx -t"
+check_cmd = "/usr/sbin/service nginx configtest"
 reload_cmd = "/usr/sbin/service nginx reload"

--- a/router/files/etc/confd/templates/nginx.conf.tmpl
+++ b/router/files/etc/confd/templates/nginx.conf.tmpl
@@ -17,26 +17,23 @@ http {
     server {{.Value}};
     {{end}}
   }
+  {{end}}
 
   server {
-    listen 80;
-    server_name {{base $dir}}.n.classchirp.com;
+    listen 80 default_server;
+    server_name ~^(?<app_name>[^\.]+)\.(.+)$;
+
+    # Respond with a 200 for Amazon ELB's health check
+    if ($http_user_agent ~* ELB-HealthChecker) {
+      return 200;
+    }
+
     location / {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Client-IP $remote_addr;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_pass http://{{base $dir}};
-    }
-  }
-  {{end}}
-
-  # healthcheck
-  server {
-    listen 80 default_server;
-    location /healthcheck {
-      add_header Content-Type text/plain;
-      return 200 'I am alive';
+        proxy_pass http://$app_name;
     }
   }
 }

--- a/router/files/usr/local/bin/confd-watch
+++ b/router/files/usr/local/bin/confd-watch
@@ -4,21 +4,25 @@
 # Return value of the last command to fail or run
 set -eo pipefail
 
-echo "$(date --utc +%FT%TZ) [nginx] booting container. ETCD: $ETCD"
+log_msg() {
+  echo "$(date --utc +%FT%TZ) $HOSTNAME confd-watch[$$] $1"
+}
+
+log_msg "booting container. ETCD: $ETCD"
 
 # Try to make initial configuration every 5 seconds until successful
 until confd -onetime -node $ETCD -config-file /etc/confd/conf.d/nginx.toml; do
-    echo "$(date --utc +%FT%TZ) [nginx] waiting for confd to create initial nginx configuration"
+    log_msg "waiting for confd to create initial nginx configuration"
     sleep 5
 done
 
 # Put a continual polling `confd` process into the background to watch
 # for changes every second
 confd -interval 1 -node $ETCD -config-file /etc/confd/conf.d/nginx.toml &
-echo "$(date --utc +%FT%TZ) [nginx] confd is now monitoring etcd for changes..."
+log_msg "confd is now monitoring etcd for changes..."
 
 # Start the Nginx service using the generated config
-echo "$(date --utc +%FT%TZ) [nginx] starting nginx service..."
+log_msg "starting nginx service..."
 service nginx start
 
 # Follow the logs to allow the script to continue running


### PR DESCRIPTION
This should allow us to not worry about configuring a host. `appname.anything.tld` will proxy pass to an upstream named `appname`.

This will only support our subdomain to app domains. Once we need real domains, we'll have to add additional server blocks in here. I figure we can store these in our empire db, but also push them to etcd so confd can use them.
