### PR TITLE
Honeybadger reporter.

### DIFF
--- a/empire/cmd/empire/server.go
+++ b/empire/cmd/empire/server.go
@@ -11,23 +11,23 @@ import (
 
 func runServer(c *cli.Context) {
 	port := c.String("port")
-	opts, err := empireOptions(c)
+
+	e, err := newEmpire(c)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	e, err := empire.New(opts)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	sopts := server.Options{}
-	sopts.GitHub.ClientID = c.String("github.client.id")
-	sopts.GitHub.ClientSecret = c.String("github.client.secret")
-	sopts.GitHub.Organization = c.String("github.organization")
-	sopts.GitHub.Secret = c.String("github.secret")
-	s := server.New(e, sopts)
-
+	s := newServer(c, e)
 	log.Printf("Starting on port %s", port)
 	log.Fatal(http.ListenAndServe(":"+port, s))
+}
+
+func newServer(c *cli.Context, e *empire.Empire) http.Handler {
+	opts := server.Options{}
+	opts.GitHub.ClientID = c.String("github.client.id")
+	opts.GitHub.ClientSecret = c.String("github.client.secret")
+	opts.GitHub.Organization = c.String("github.organization")
+	opts.GitHub.Secret = c.String("github.secret")
+
+	return server.New(e, opts)
 }

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -22,8 +22,8 @@ var (
 	// intializing a new Empire.
 	DefaultOptions = Options{}
 
-	// defaultReporter is the default reporter.Reporter to use.
-	defaultReporter = reporter.NewLogReporter()
+	// DefaultReporter is the default reporter.Reporter to use.
+	DefaultReporter = reporter.NewLogReporter()
 )
 
 // DockerOptions is a set of options to configure a docker api client.
@@ -153,7 +153,6 @@ func New(options Options) (*Empire, error) {
 	}
 
 	return &Empire{
-		Reporter:     defaultReporter,
 		store:        store,
 		accessTokens: accessTokens,
 		apps:         apps,

--- a/empire/pkg/reporter/async.go
+++ b/empire/pkg/reporter/async.go
@@ -8,6 +8,12 @@ type AsyncReporter struct {
 	reporter Reporter
 }
 
+func Async(reporter Reporter) *AsyncReporter {
+	return &AsyncReporter{
+		reporter: reporter,
+	}
+}
+
 // TODO Creating a new go routine for every Report call may not be the best
 // thing, but should be ok for now.
 func (r *AsyncReporter) Report(ctx context.Context, err error) error {

--- a/empire/pkg/reporter/fallback.go
+++ b/empire/pkg/reporter/fallback.go
@@ -1,0 +1,21 @@
+package reporter
+
+import "golang.org/x/net/context"
+
+type FallbackReporter struct {
+	// The first reporter to call.
+	Reporter Reporter
+
+	// This reporter will be used to report an error if the first Reporter
+	// fails for some reason.
+	Fallback Reporter
+}
+
+func (r *FallbackReporter) Report(ctx context.Context, err error) error {
+	if err2 := r.Reporter.Report(ctx, err); err2 != nil {
+		r.Fallback.Report(ctx, err2)
+		return err2
+	}
+
+	return nil
+}

--- a/empire/pkg/reporter/fallback_test.go
+++ b/empire/pkg/reporter/fallback_test.go
@@ -1,0 +1,35 @@
+package reporter
+
+import (
+	"errors"
+	"testing"
+
+	"golang.org/x/net/context"
+)
+
+func TestFallback(t *testing.T) {
+	var called bool
+
+	errTimeout := errors.New("net: timeout")
+
+	r := &FallbackReporter{
+		Reporter: ReporterFunc(func(ctx context.Context, err error) error {
+			return errTimeout
+		}),
+		Fallback: ReporterFunc(func(ctx context.Context, err error) error {
+			called = true
+
+			if got, want := err, errTimeout; got != want {
+				t.Fatalf("err => %v; want %v", got, want)
+			}
+
+			return nil
+		}),
+	}
+
+	r.Report(context.Background(), ErrFake)
+
+	if !called {
+		t.Fatal("fallback not called")
+	}
+}

--- a/empire/pkg/reporter/honeybadger.go
+++ b/empire/pkg/reporter/honeybadger.go
@@ -1,10 +1,28 @@
 package reporter
 
-import "github.com/jcoene/honeybadger"
+import (
+	"errors"
 
-// HoneybadgerHandler is a Handler implementation backed for Honeybadger.
-type HoneybadgerHandler struct{}
+	"github.com/jcoene/honeybadger"
+	"golang.org/x/net/context"
+)
 
-func (h *HoneybadgerHandler) Report(err error) error {
-	return honeybadger.Send(err)
+// HoneybadgerReporter is a Reporter implementation backed for Honeybadger.
+type HoneybadgerReporter struct{}
+
+func (h *HoneybadgerReporter) Report(ctx context.Context, err error) error {
+	if honeybadger.ApiKey == "" {
+		return errors.New("missing honeybadger.ApiKey")
+	}
+
+	report, err2 := honeybadger.NewReport(err)
+	if err2 != nil {
+		return err2
+	}
+
+	if err2 := report.Send(); err2 != nil {
+		return err2
+	}
+
+	return nil
 }

--- a/empire/pkg/reporter/multi.go
+++ b/empire/pkg/reporter/multi.go
@@ -9,6 +9,12 @@ type MultiReporter struct {
 	reporters []Reporter
 }
 
+func NewMultiReporter(reporters ...Reporter) *MultiReporter {
+	return &MultiReporter{
+		reporters: reporters,
+	}
+}
+
 func (r *MultiReporter) Report(ctx context.Context, err error) error {
 	var errors []error
 


### PR DESCRIPTION
This allows a reporter to be configured via the `-reporter` flag (or `EMPIRE_REPORTER` env var). It defaults to a Logger reporter, but can be changed to use honeybadger by doing this:

```
-reporter=hb://api.honeybadger.io?key=1234&environment=staging
```

The honeybadger client we're using seems to be dropping relevant lines from the call stack, but I'll look into that separately. 

Honeybadger for staging is at https://app.honeybadger.io/projects/43058/faults?resolved=f
