### PR TITLE
Fix ugly error when access token is empty.

### DIFF
--- a/empire/access_tokens.go
+++ b/empire/access_tokens.go
@@ -31,12 +31,20 @@ func (s *accessTokensService) AccessTokensCreate(token *AccessToken) (*AccessTok
 
 func (s *accessTokensService) AccessTokensFind(token string) (*AccessToken, error) {
 	at, err := ParseToken(s.Secret, token)
+	if err != nil {
+		switch err.(type) {
+		case *jwt.ValidationError:
+			return nil, nil
+		default:
+			return at, err
+		}
+	}
 
 	if at != nil {
 		at.Token = token
 	}
 
-	return at, err
+	return at, nil
 }
 
 // SignToken jwt signs the token and adds the signature to the Token field.

--- a/empire/access_tokens_test.go
+++ b/empire/access_tokens_test.go
@@ -1,3 +1,22 @@
 package empire
 
+import (
+	"reflect"
+	"testing"
+)
+
 var testSecret = []byte("secret")
+
+func TestAccessTokensFind(t *testing.T) {
+	s := &accessTokensService{Secret: testSecret}
+
+	at, err := s.AccessTokensFind("")
+	if err != nil {
+		t.Logf("err: %v", reflect.TypeOf(err))
+		t.Fatal(err)
+	}
+
+	if at != nil {
+		t.Fatal("Expected access token to be nil")
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/246. If the token is an invalid jwt, just return nil to represent that it wasn't found.

```
empire $ emp apps
error: Request not authenticated, API token is missing, invalid or expired Log in with `hk login`.
```
