### PR TITLE
Fix haproxy reload for runit

### DIFF
--- a/router/files/etc/confd/conf.d/haproxy.toml
+++ b/router/files/etc/confd/conf.d/haproxy.toml
@@ -18,4 +18,4 @@ mode = "0644"
 # These are the commands that will be used to check whether the rendered config is
 # valid and to reload the actual service once the new config is in place
 check_cmd = "/usr/sbin/haproxy -c -f {{.src}}"
-reload_cmd = "/usr/sbin/haproxy -f {{.src}} -p /run/haproxy.pid -st /run/haproxy.pid"
+reload_cmd = "/usr/bin/sv reload haproxy"

--- a/router/files/etc/service/haproxy/run
+++ b/router/files/etc/service/haproxy/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 exec 2>&1
-exec /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+exec /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid


### PR DESCRIPTION
Had to use systemd-wrapper-haproxy in order to get this to work because
of disagreements in process management between haproxy and certain init
replacements (systemd,supervisord, runit, etc)
