### PR TITLE
Fix emp cli for quoted args.

### DIFF
--- a/emp
+++ b/emp
@@ -1,3 +1,3 @@
 #!/bin/bash
 EMPIRE_URL=${EMPIRE_URL:-"http://0.0.0.0:8080"}
-HEROKU_API_URL=${EMPIRE_URL} hk $@
+HEROKU_API_URL=${EMPIRE_URL} hk "$@"


### PR DESCRIPTION
Apparently $@ and "$@" have a different behavior for quoted args. See http://stackoverflow.com/a/4824637
