### PR TITLE
Resolve images to the canonical image id.

### DIFF
--- a/empire/empire.go
+++ b/empire/empire.go
@@ -103,6 +103,14 @@ func New(options Options) (*Empire, error) {
 	extractor, err := NewExtractor(
 		options.Docker.Socket,
 		options.Docker.CertPath,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	resolver, err := newResolver(
+		options.Docker.Socket,
+		options.Docker.CertPath,
 		options.Docker.Auth,
 	)
 	if err != nil {
@@ -151,6 +159,7 @@ func New(options Options) (*Empire, error) {
 	slugs := &slugsService{
 		store:     store,
 		extractor: extractor,
+		resolver:  resolver,
 	}
 
 	deployer := &deployer{

--- a/empire/slugs.go
+++ b/empire/slugs.go
@@ -59,17 +59,23 @@ func slugsFindBy(db *db, field string, value interface{}) (*Slug, error) {
 type slugsService struct {
 	store     *store
 	extractor Extractor
+	resolver  Resolver
 }
 
 // SlugsCreateByImage creates a Slug for the given image.
 func (s *slugsService) SlugsCreateByImage(image Image) (*Slug, error) {
-	return slugsCreateByImage(s.store, s.extractor, image)
+	return slugsCreateByImage(s.store, s.extractor, s.resolver, image)
 }
 
 // SlugsCreateByImage first attempts to find a matching slug for the image. If
 // it's not found, it will fallback to extracting the process types using the
 // provided extractor, then create a slug.
-func slugsCreateByImage(store *store, e Extractor, image Image) (*Slug, error) {
+func slugsCreateByImage(store *store, e Extractor, r Resolver, image Image) (*Slug, error) {
+	image, err := r.Resolve(image)
+	if err != nil {
+		return nil, err
+	}
+
 	slug, err := store.SlugsFindByImage(image)
 	if err != nil {
 		return slug, err


### PR DESCRIPTION
This should fix https://github.com/remind101/empire/issues/275. This will resolve an image like:

``` go
remind101/r101-shorty:99212f7416b7242b4526da7961507d57a28e03a5
```

to it's canonical image using the docker image id:

``` go
remind101/r101-shorty:a4eb601e0cd2bb8e1ac3c35f29337d878f67d7339495a9c808f23bcb1ce4142f
```

before creating a slug. This means you should be able to use `emp deploy` with any valid tag and it should just work.

Should really have some tests for this. Thinking I'll move `ejholmes/acme-inc` to `remind101/acme-inc` and base it on alpine so it can be docker pulled in integration tests.
