### PR TITLE
Use remind101/acme-inc.

### DIFF
--- a/empire/pkg/container/fleet_test.go
+++ b/empire/pkg/container/fleet_test.go
@@ -18,8 +18,8 @@ var testContainer = Container{
 	},
 	Command: "acme-inc",
 	Image: Image{
-		Repo: "quay.io/ejholmes/acme-inc",
-		ID:   "ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+		Repo: "remind101/acme-inc",
+		ID:   "9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 	},
 }
 
@@ -49,9 +49,9 @@ ExecStartPre=/bin/sh -c "echo GOENV=production >> /tmp/acme-inc.v1.web.1.env"
 ExecStartPre=/bin/sh -c "echo PORT=8080 >> /tmp/acme-inc.v1.web.1.env"
 
 
-ExecStartPre=-/usr/bin/docker pull quay.io/ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02
+ExecStartPre=-/usr/bin/docker pull remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2
 ExecStartPre=-/usr/bin/docker rm acme-inc.v1.web.1
-ExecStart=/usr/bin/docker run --name acme-inc.v1.web.1 --env-file /tmp/acme-inc.v1.web.1.env -e PORT=80 -h %H -p 80 quay.io/ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02 sh -c 'acme-inc'
+ExecStart=/usr/bin/docker run --name acme-inc.v1.web.1 --env-file /tmp/acme-inc.v1.web.1.env -e PORT=80 -h %H -p 80 remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2 sh -c 'acme-inc'
 ExecStop=/usr/bin/docker stop acme-inc.v1.web.1
 
 [X-Fleet]

--- a/empire/pkg/registry/registry_test.go
+++ b/empire/pkg/registry/registry_test.go
@@ -11,8 +11,8 @@ func TestSplitRepo(t *testing.T) {
 
 		err error
 	}{
-		{"ejholmes/acme-inc", "", "ejholmes/acme-inc", nil},
-		{"quay.io/ejholmes/acme-inc", "quay.io", "ejholmes/acme-inc", nil},
+		{"remind101/acme-inc", "", "remind101/acme-inc", nil},
+		{"quay.io/remind101/acme-inc", "quay.io", "remind101/acme-inc", nil},
 		{"ejholmes", "", "", ErrInvalidRepo},
 	}
 

--- a/empire/tests/api/api_test.go
+++ b/empire/tests/api/api_test.go
@@ -13,8 +13,8 @@ var (
 
 	// An test docker image that can be deployed.
 	DefaultImage = empire.Image{
-		Repo: "quay.io/ejholmes/acme-inc",
-		ID:   "ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+		Repo: "remind101/acme-inc",
+		ID:   "9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 	}
 )
 

--- a/empire/tests/hk/hk_test.go
+++ b/empire/tests/hk/hk_test.go
@@ -137,8 +137,8 @@ func TestUpdateConfigNewReleaseSameFormation(t *testing.T) {
 
 	run(t, []Command{
 		{
-			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
-			"Deployed ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
 			"dynos -a acme-inc",
@@ -198,20 +198,20 @@ func TestDomains(t *testing.T) {
 func TestDeploy(t *testing.T) {
 	run(t, []Command{
 		{
-			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
-			"Deployed ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
 			"releases -a acme-inc",
-			"v1    Dec 31 17:01  Deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"v1    Dec 31 17:01  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
-			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
-			"Deployed ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
 			"releases -a acme-inc",
-			"v1    Dec 31 17:01  Deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02\nv2    Dec 31 17:01  Deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"v1    Dec 31 17:01  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2\nv2    Dec 31 17:01  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 	})
 }
@@ -222,8 +222,8 @@ func TestScale(t *testing.T) {
 
 	run(t, []Command{
 		{
-			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
-			"Deployed ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
 			"scale web=2 -a acme-inc",
@@ -249,12 +249,12 @@ acme-inc.1.web.2    unknown   5d  "./bin/web"`,
 func TestRollback(t *testing.T) {
 	run(t, []Command{
 		{
-			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
-			"Deployed ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
-			"deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
-			"Deployed ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02",
+			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
 			"rollback v1 -a acme-inc",
@@ -262,8 +262,8 @@ func TestRollback(t *testing.T) {
 		},
 		{
 			"releases -a acme-inc",
-			`v1    Dec 31 17:01  Deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02
-v2    Dec 31 17:01  Deploy ejholmes/acme-inc:ec238137726b58285f8951802aed0184f915323668487b4919aff2671c0f9a02
+			`v1    Dec 31 17:01  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2
+v2    Dec 31 17:01  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2
 v3    Dec 31 17:01  Rollback to v1`,
 		},
 	})


### PR DESCRIPTION
Just changes any references to ejholmes/acme-inc to point to remind101/acme-inc. Deploying this image to a fresh empire instance takes ~20 seconds:

``` console
$ time emp deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2
Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2

real    0m16.062s
user    0m0.025s
sys     0m0.033s
```
