### PR TITLE
Quick spike into ECS backend.

### DIFF
--- a/empire/Godeps/Godeps.json
+++ b/empire/Godeps/Godeps.json
@@ -25,6 +25,30 @@
 			"Rev": "467d9d55c2d2c17248441a8fc661561161f40d5e"
 		},
 		{
+			"ImportPath": "github.com/awslabs/aws-sdk-go/aws",
+			"Rev": "ead96e61abfd0e731d94928e925abff3df6ebf02"
+		},
+		{
+			"ImportPath": "github.com/awslabs/aws-sdk-go/internal/endpoints",
+			"Rev": "ead96e61abfd0e731d94928e925abff3df6ebf02"
+		},
+		{
+			"ImportPath": "github.com/awslabs/aws-sdk-go/internal/protocol/json/jsonutil",
+			"Rev": "ead96e61abfd0e731d94928e925abff3df6ebf02"
+		},
+		{
+			"ImportPath": "github.com/awslabs/aws-sdk-go/internal/protocol/jsonrpc",
+			"Rev": "ead96e61abfd0e731d94928e925abff3df6ebf02"
+		},
+		{
+			"ImportPath": "github.com/awslabs/aws-sdk-go/internal/signer/v4",
+			"Rev": "ead96e61abfd0e731d94928e925abff3df6ebf02"
+		},
+		{
+			"ImportPath": "github.com/awslabs/aws-sdk-go/service/ecs",
+			"Rev": "ead96e61abfd0e731d94928e925abff3df6ebf02"
+		},
+		{
 			"ImportPath": "github.com/bgentry/heroku-go",
 			"Rev": "b891b4c66c7a330c5da052a0789f66c4e83c1bed"
 		},
@@ -301,6 +325,10 @@
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",
 			"Rev": "e4ec8152c15fc46bd5056ce65997a07c7d415325"
+		},
+		{
+			"ImportPath": "github.com/vaughan0/go-ini",
+			"Rev": "a98ad7ee00ec53921f08832bc06ecf7fd600e6a1"
 		},
 		{
 			"ImportPath": "golang.org/x/crypto/ssh",

--- a/empire/apps.go
+++ b/empire/apps.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/remind101/empire/empire/pkg/pod"
 	"github.com/remind101/pkg/timex"
 	"golang.org/x/net/context"
 	"gopkg.in/gorp.v1"
@@ -122,8 +123,10 @@ func (s *appsService) AppsDestroy(ctx context.Context, app *App) error {
 		return err
 	}
 
-	if err := s.manager.Destroy(templates...); err != nil {
-		return err
+	if m, ok := s.manager.Manager.(pod.Destroyable); ok {
+		if err := m.Destroy(templates...); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -344,6 +344,10 @@ func newScheduler(fleetURL string) (container.Scheduler, error) {
 }
 
 func newManager(options Options) (*manager, error) {
+	return &manager{
+		pod.NewECSManager(),
+	}, nil
+
 	scheduler, err := newScheduler(options.Fleet.API)
 	if err != nil {
 		return nil, err

--- a/empire/pkg/pod/ecs.go
+++ b/empire/pkg/pod/ecs.go
@@ -1,0 +1,167 @@
+package pod
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/awslabs/aws-sdk-go/service/ecs"
+)
+
+// ECSManager is an implementation of the Manager interface that can use ECS to
+// create and schedule Templates.
+type ECSManager struct {
+	client *ecs.ECS
+
+	mu sync.Mutex
+	// Maps a templateID to a task definition.
+	definitions map[string]*ecs.TaskDefinition
+}
+
+func NewECSManager() *ECSManager {
+	return &ECSManager{
+		client:      ecs.New(aws.DefaultConfig),
+		definitions: make(map[string]*ecs.TaskDefinition),
+	}
+}
+
+func (m *ECSManager) Submit(templates ...*Template) error {
+	for _, t := range templates {
+		if err := m.submit(t); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *ECSManager) submit(t *Template) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, err := m.createTaskDefinition(t)
+	if err != nil {
+		return err
+	}
+
+	m.definitions[t.ID] = td
+
+	if err := m.Scale(t.ID, t.Instances); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ECSManager) createTaskDefinition(t *Template) (*ecs.TaskDefinition, error) {
+	family := ecsFamily(t.ID)
+
+	var command []*string
+	for _, s := range strings.Split(t.Command, " ") {
+		command = append(command, &s)
+	}
+
+	var environment []*ecs.KeyValuePair
+	for k, v := range t.Env {
+		environment = append(environment, &ecs.KeyValuePair{
+			Name:  aws.String(k),
+			Value: aws.String(v),
+		})
+	}
+
+	resp, err := m.client.RegisterTaskDefinition(&ecs.RegisterTaskDefinitionInput{
+		Family: &family,
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			&ecs.ContainerDefinition{
+				Name:        aws.String(ecsContainerName(t.ID)), // TODO
+				CPU:         aws.Long(1024),
+				Command:     command,
+				Image:       aws.String(t.Image.Repo + ":" + t.Image.ID),
+				Essential:   aws.Boolean(true),
+				Memory:      aws.Long(128), // TODO Use MemoryLimit
+				Environment: environment,
+			},
+		},
+	})
+	if err != nil {
+		fmt.Println(resp)
+		fmt.Println(err)
+		return nil, err
+	}
+
+	return resp.TaskDefinition, nil
+}
+
+func (m *ECSManager) Scale(templateID string, instances uint) error {
+	if td, ok := m.definitions[templateID]; ok {
+		resp, err := m.client.UpdateService(&ecs.UpdateServiceInput{
+			Cluster:        aws.String("default"), // TODO
+			DesiredCount:   aws.Long(int64(instances)),
+			Service:        aws.String(ecsService(templateID)), // TODO
+			TaskDefinition: aws.String(fmt.Sprintf("%s:%d", *td.Family, *td.Revision)),
+		})
+		if err != nil {
+			if err, ok := err.(aws.APIError); ok {
+				if err.Message == "Service was not ACTIVE." {
+					resp, err := m.client.CreateService(&ecs.CreateServiceInput{
+						Cluster:        aws.String("default"), // TODO
+						DesiredCount:   aws.Long(int64(instances)),
+						ServiceName:    aws.String(ecsService(templateID)), // TODO
+						TaskDefinition: aws.String(fmt.Sprintf("%s:%d", *td.Family, *td.Revision)),
+					})
+					if err != nil {
+						fmt.Println(resp)
+						fmt.Println(err)
+						return err
+					}
+				}
+			} else {
+				fmt.Println(resp)
+				fmt.Println(err)
+			}
+			return err
+		}
+	} else {
+		return fmt.Errorf("no task definition found for %s", templateID)
+	}
+
+	return nil
+}
+
+func (m *ECSManager) Templates(tags map[string]string) ([]*Template, error) {
+	return nil, nil
+}
+
+func (m *ECSManager) Template(templateID string) (*Template, error) {
+	return nil, nil
+}
+
+func (m *ECSManager) Instances(templateID string) ([]*Instance, error) {
+	return nil, nil
+}
+
+func (m *ECSManager) InstanceStates(templateID string) ([]*InstanceState, error) {
+	return nil, nil
+}
+
+func (m *ECSManager) Restart(*Instance) error {
+	return nil
+}
+
+// acme-inc.1.web.1 => acme-inc-web
+func ecsFamily(templateID string) string {
+	parts := strings.Split(templateID, ".")
+	return fmt.Sprintf("%s-%s", parts[0], parts[2])
+}
+
+// acme-inc.1.web.1 => web
+func ecsContainerName(templateID string) string {
+	parts := strings.Split(templateID, ".")
+	return parts[2]
+}
+
+// acme-inc.1.web.1 => acme-inc-web
+func ecsService(templateID string) string {
+	return ecsFamily(templateID)
+}

--- a/empire/pkg/pod/manager.go
+++ b/empire/pkg/pod/manager.go
@@ -12,14 +12,16 @@ var (
 	ErrNoTemplate = errors.New("template does not exist")
 )
 
+type Destroyable interface {
+	// Destroy destroys a Template.
+	Destroy(...*Template) error
+}
+
 // Manager is an interface for interacting with Templates and
 // Instances.
 type Manager interface {
 	// Submit submits Templates.
 	Submit(...*Template) error
-
-	// Destroy destroys a Template.
-	Destroy(...*Template) error
 
 	// Scale scales a Template.
 	Scale(templateID string, instances uint) error

--- a/empire/releases.go
+++ b/empire/releases.go
@@ -263,7 +263,11 @@ func (r *releaser) Release(ctx context.Context, release *Release, config *Config
 		return err
 	}
 
-	return r.manager.Destroy(old...)
+	if m, ok := r.manager.Manager.(pod.Destroyable); ok {
+		return m.Destroy(old...)
+	}
+
+	return nil
 }
 
 func newTemplates(release *Release, config *Config, slug *Slug, formation Formation) []*pod.Template {


### PR DESCRIPTION
This allows you to deploy and scale with ECS. Listing Dynos is unimplemented, mainly because the Go client for ECS doesn't support ECS Services yet. This isn't really shipable, just a POC.

ECS doesn't quite fit with pod.Manager (notice the `strings.Split(templateID, ".")` and the mapping of templateID's to a task definition) because ECS is basically a layer above pkg pod with concepts like revisions and services. If we want to continue supporting other scheduling backends like fleet, it would be pretty easy by adding an abstraction layer above pkg/pod.

But, as long as you have an ECS cluster configured, this actually works pretty well. You can deploy any container, scale it and ECS will manage it. 
