### PR TITLE
Get config from latest release

### DIFF
--- a/empire/configs.go
+++ b/empire/configs.go
@@ -145,10 +145,26 @@ func (s *configsService) ConfigsApply(ctx context.Context, app *App, vars Vars) 
 	return c, nil
 }
 
+// Returns configs for latest release or the latest configs if there are no releases.
 func (s *configsService) ConfigsCurrent(app *App) (*Config, error) {
-	c, err := s.store.ConfigsFindByApp(app)
+	r, err := s.store.ReleasesLast(app)
 	if err != nil {
 		return nil, err
+	}
+
+	var c *Config
+
+	if r != nil {
+		c, err = s.store.ConfigsFind(r.ConfigID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// It's possible to have config without releases, this handles that.
+		c, err = s.store.ConfigsFindByApp(app)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if c != nil {

--- a/empire/tests/hk/hk_test.go
+++ b/empire/tests/hk/hk_test.go
@@ -291,14 +291,23 @@ func TestRollback(t *testing.T) {
 			"Deployed remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
 		},
 		{
+			"set FOO=bar -a acme-inc",
+			"Set env vars and restarted acme-inc.",
+		},
+		{
 			"rollback v1 -a acme-inc",
-			"Rolled back acme-inc to v1 as v3.",
+			"Rolled back acme-inc to v1 as v4.",
 		},
 		{
 			"releases -a acme-inc",
 			`v1    Dec 31 17:01  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2
 v2    Dec 31 17:01  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2
-v3    Dec 31 17:01  Rollback to v1`,
+v3    Dec 31 17:01  Set FOO config vars
+v4    Dec 31 17:01  Rollback to v1`,
+		},
+		{
+			"env -a acme-inc",
+			"",
 		},
 	})
 }


### PR DESCRIPTION
If there are releases for a given app, when getting the current config
make sure to get the config from the latest release.

If there are no releases, then just return the last config in the store.

Fixes GH-309
