### PR TITLE
Specify a default command for etcd_peers.

### DIFF
--- a/etcd_peers/Dockerfile
+++ b/etcd_peers/Dockerfile
@@ -2,3 +2,5 @@ FROM remind101/go:1.4
 MAINTAINER Michael Barrett <mike@remind101.com>
 
 WORKDIR /go/bin
+
+CMD ["/go/bin/etcd_peers"]


### PR DESCRIPTION
[This unit](https://github.com/remind101/private_stacks/blob/master/private_stacks/userdata/empire_router_userdata.py#L13-L29) fails to start right now, with a message saying:

```
etcd_peers $ docker run remind101/etcd_peers
option requires an argument -- c
BusyBox v1.22.1 (2014-11-22 09:00:22 GMT) multi-call binary.

Usage: su [OPTIONS] [-] [USER]

Run shell under USER (by default, root)

        -,-l    Clear environment, run shell as login shell
        -p,-m   Do not set new $HOME, $SHELL, $USER, $LOGNAME
        -c CMD  Command to pass to 'sh -c'
        -s SH   Shell to use instead of user's default

```

This fixes the issue locally, but not sure if it'll fix the issue in that unit, since it's already specifying a command to run.
