### PR TITLE
Simplify POST /deploys.

### DIFF
--- a/empire/images.go
+++ b/empire/images.go
@@ -2,6 +2,7 @@ package empire
 
 import (
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -28,6 +29,15 @@ func (i *Image) Scan(src interface{}) error {
 // Value implements the driver.Value interface.
 func (i Image) Value() (driver.Value, error) {
 	return driver.Value(i.String()), nil
+}
+
+func (i *Image) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	*i = decodeImage(s)
+	return nil
 }
 
 func encodeImage(i Image) string {

--- a/empire/server/heroku/deployments.go
+++ b/empire/server/heroku/deployments.go
@@ -25,10 +25,7 @@ type PostDeploys struct {
 
 // PostDeployForm is the form object that represents the POST body.
 type PostDeployForm struct {
-	Image struct {
-		ID   string `json:"id"`
-		Repo string `json:"repo"`
-	} `json:"image"`
+	Image empire.Image
 }
 
 // jsonMessage represents a streamed status message from the docker remote api.
@@ -50,11 +47,6 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
-	image := empire.Image{
-		Repo: empire.Repo(form.Image.Repo),
-		ID:   form.Image.ID,
-	}
-
 	w.Header().Set("Content-Type", "application/json; boundary=NL")
 
 	var (
@@ -65,7 +57,7 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 	ch := make(chan empire.Event)
 	errCh := make(chan error)
 	go func() {
-		d, err = h.DeployImage(ctx, image, ch)
+		d, err = h.DeployImage(ctx, form.Image, ch)
 		errCh <- err
 	}()
 

--- a/empire/tests/api/api_test.go
+++ b/empire/tests/api/api_test.go
@@ -12,10 +12,7 @@ import (
 var (
 
 	// An test docker image that can be deployed.
-	DefaultImage = empire.Image{
-		Repo: "remind101/acme-inc",
-		ID:   "9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
-	}
+	DefaultImage = "remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2"
 )
 
 // Run the tests with empiretest.Run, which will lock access to the database

--- a/empire/tests/api/deploys_test.go
+++ b/empire/tests/api/deploys_test.go
@@ -4,14 +4,10 @@ import (
 	"testing"
 
 	"github.com/bgentry/heroku-go"
-	"github.com/remind101/empire/empire"
 )
 
 type DeployForm struct {
-	Image struct {
-		Repo string `json:"repo"`
-		ID   string `json:"id"`
-	} `json:"image"`
+	Image string
 }
 
 type Deploy struct {
@@ -27,14 +23,13 @@ func TestDeploy(t *testing.T) {
 	mustDeploy(t, c, DefaultImage)
 }
 
-func mustDeploy(t testing.TB, c *heroku.Client, image empire.Image) Deploy {
+func mustDeploy(t testing.TB, c *heroku.Client, image string) Deploy {
 	var (
 		f DeployForm
 		d Deploy
 	)
 
-	f.Image.Repo = string(image.Repo)
-	f.Image.ID = string(image.ID)
+	f.Image = image
 
 	if err := c.Post(&d, "/deploys", &f); err != nil {
 		t.Fatal(err)

--- a/hk-plugins/deploy
+++ b/hk-plugins/deploy
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-repo=$(echo $1 | cut -d : -f 1)
-id=$(echo $1 | cut -d : -f 2)
+image=$1
+
 TMPFILE=$(mktemp /tmp/.hk_deploy.XXXXXXX)
 echo "== DEBUG: REPO:${repo} ID:${id} USER:${HKUSER} API:${HEROKU_API_URL}" > $TMPFILE
 
 function deploy() {
-    curl -sS --fail -D - --user "${HKUSER}:${HKPASS}" -X POST "${HEROKU_API_URL}/deploys" -d "{\"image\":{\"repo\":\"${repo}\",\"id\":\"${id}\"}}" -H "Accept: application/vnd.heroku+json; version=3" >> $TMPFILE 2>&1
+    curl -sS --fail -D - --user "${HKUSER}:${HKPASS}" -X POST "${HEROKU_API_URL}/deploys" -d "{\"image\":\"$image\"}" -H "Accept: application/vnd.heroku+json; version=3" >> $TMPFILE 2>&1
 }
 
 if deploy; then
-  echo "Deployed $1"
+  echo "Deployed $image"
   rm $TMPFILE
 else
-  echo "Failed to deploy $1"
+  echo "Failed to deploy $image"
   cat $TMPFILE
   rm $TMPFILE
   exit 1


### PR DESCRIPTION
This changes the `image` input in POST /deploys from an object to a string. It's a little simpler, and gives us a better layer of abstraction to support tags and eventually immutable identifiers. Now, deploying an image is just:

```
POST /deploys
```

``` json
 {"image":"remind101/acme-inc:latest"}
```
