### PR TITLE
More deployments cleanup.

### DIFF
--- a/empire/db.go
+++ b/empire/db.go
@@ -40,7 +40,6 @@ func newDB(uri string) (*db, error) {
 
 	db.AddTableWithName(App{}, "apps").SetKeys(false, "Name")
 	db.AddTableWithName(Config{}, "configs").SetKeys(true, "ID")
-	db.AddTableWithName(Deployment{}, "deployments").SetKeys(true, "ID")
 	db.AddTableWithName(Domain{}, "domains").SetKeys(true, "ID")
 	db.AddTableWithName(Port{}, "ports").SetKeys(true, "ID")
 	db.AddTableWithName(Process{}, "processes").SetKeys(true, "ID")

--- a/empire/deployments.go
+++ b/empire/deployments.go
@@ -2,11 +2,8 @@ package empire
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/remind101/pkg/timex"
 	"golang.org/x/net/context"
-	"gopkg.in/gorp.v1"
 )
 
 // Deployment statuses.
@@ -15,53 +12,6 @@ const (
 	StatusFailed  = "failed"
 	StatusSuccess = "success"
 )
-
-// Deployment represents a deployment to the platform.
-type Deployment struct {
-	ID         string    `db:"id"`
-	AppName    string    `db:"app_id"`
-	Status     string    `db:"status"`
-	Image      Image     `db:"image"`
-	Error      *string   `db:"error"`
-	ReleaseID  *string   `db:"release_id"`
-	CreatedAt  time.Time `db:"created_at"`
-	FinishedAt time.Time `db:"finished_at"`
-
-	// Used to store the old status when changing statuses.
-	prevStatus string `db:"-"`
-}
-
-// PreInsert implements a pre insert hook for the db interface
-func (d *Deployment) PreInsert(s gorp.SqlExecutor) error {
-	d.CreatedAt = timex.Now()
-	return nil
-}
-
-// Success marks the deployment as successful. The release provided will be
-// associated with this deployment.
-func (d *Deployment) Success(release *Release) *Deployment {
-	d.ReleaseID = &release.ID
-	d.finished(StatusSuccess)
-	return d
-}
-
-// Failed marks the deployment as failed. An error can be provided, which should
-// indicate what went wrong.
-func (d *Deployment) Failed(err error) *Deployment {
-	e := err.Error()
-	d.Error = &e
-	d.finished(StatusFailed)
-	return d
-}
-
-func (d *Deployment) finished(status string) {
-	d.FinishedAt = timex.Now()
-	d.changeStatus(status)
-}
-
-func (d *Deployment) changeStatus(status string) {
-	d.prevStatus, d.Status = d.Status, status
-}
 
 // DeploymentsCreateOpts represents options that can be passed when creating a
 // new Deployment.
@@ -76,22 +26,7 @@ type DeploymentsCreateOpts struct {
 	EventCh chan Event
 }
 
-func (s *store) DeploymentsCreate(opts DeploymentsCreateOpts) (*Deployment, error) {
-	d := &Deployment{
-		AppName: opts.App.Name,
-		Image:   opts.Image,
-		Status:  StatusPending,
-	}
-	return deploymentsCreate(s.db, d)
-}
-
-func (s *store) DeploymentsUpdate(d *Deployment) error {
-	return deploymentsUpdate(s.db, d)
-}
-
 type deployer struct {
-	store *store
-
 	*appsService
 	*configsService
 	*slugsService
@@ -99,63 +34,33 @@ type deployer struct {
 }
 
 // DeploymentsDo performs the Deployment.
-func (s *deployer) DeploymentsDo(ctx context.Context, opts DeploymentsCreateOpts) (d *Deployment, err error) {
+func (s *deployer) DeploymentsDo(ctx context.Context, opts DeploymentsCreateOpts) (*Release, error) {
 	app, image := opts.App, opts.Image
 
-	d, err = s.store.DeploymentsCreate(opts)
-	if err != nil {
-		return
-	}
-
-	var (
-		config  *Config
-		slug    *Slug
-		release *Release
-	)
-
-	defer func() {
-		if err == nil {
-			d.Success(release)
-		} else {
-			d.Failed(err)
-		}
-
-		if err2 := s.store.DeploymentsUpdate(d); err2 != nil {
-			err = err2
-		}
-
-		return
-	}()
-
 	// Grab the latest config.
-	config, err = s.ConfigsCurrent(app)
+	config, err := s.ConfigsCurrent(app)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// Create a new slug for the docker image.
-	slug, err = s.SlugsCreateByImage(image, opts.EventCh)
+	slug, err := s.SlugsCreateByImage(image, opts.EventCh)
 	if err != nil {
-		return
+		return nil, err
 	}
 
 	// Create a new release for the Config
 	// and Slug.
 	desc := fmt.Sprintf("Deploy %s", image.String())
-	release, err = s.ReleasesCreate(ctx, ReleasesCreateOpts{
+	return s.ReleasesCreate(ctx, ReleasesCreateOpts{
 		App:         app,
 		Config:      config,
 		Slug:        slug,
 		Description: desc,
 	})
-	if err != nil {
-		return
-	}
-
-	return
 }
 
-func (s *deployer) DeployImageToApp(ctx context.Context, app *App, image Image, out chan Event) (*Deployment, error) {
+func (s *deployer) DeployImageToApp(ctx context.Context, app *App, image Image, out chan Event) (*Release, error) {
 	if err := s.appsService.AppsEnsureRepo(app, image.Repo); err != nil {
 		return nil, err
 	}
@@ -168,20 +73,11 @@ func (s *deployer) DeployImageToApp(ctx context.Context, app *App, image Image, 
 }
 
 // Deploy deploys an Image to the cluster.
-func (s *deployer) DeployImage(ctx context.Context, image Image, out chan Event) (*Deployment, error) {
+func (s *deployer) DeployImage(ctx context.Context, image Image, out chan Event) (*Release, error) {
 	app, err := s.appsService.AppsFindOrCreateByRepo(image.Repo)
 	if err != nil {
 		return nil, err
 	}
 
 	return s.DeployImageToApp(ctx, app, image, out)
-}
-
-func deploymentsCreate(db *db, d *Deployment) (*Deployment, error) {
-	return d, db.Insert(d)
-}
-
-func deploymentsUpdate(db *db, d *Deployment) error {
-	_, err := db.Update(d)
-	return err
 }

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -178,7 +178,6 @@ func New(options Options) (*Empire, error) {
 	}
 
 	deployer := &deployer{
-		store:           store,
 		appsService:     apps,
 		configsService:  configs,
 		slugsService:    slugs,
@@ -313,7 +312,7 @@ func (e *Empire) ReleasesRollback(ctx context.Context, app *App, version int) (*
 }
 
 // DeployImage deploys an image to Empire.
-func (e *Empire) DeployImage(ctx context.Context, image Image, out chan Event) (*Deployment, error) {
+func (e *Empire) DeployImage(ctx context.Context, image Image, out chan Event) (*Release, error) {
 	return e.deployer.DeployImage(ctx, image, out)
 }
 

--- a/empire/events.go
+++ b/empire/events.go
@@ -6,14 +6,6 @@ type Event interface {
 	Event() string
 }
 
-type DeploymentEvent struct {
-	Deployment *Deployment
-}
-
-func (e *DeploymentEvent) Event() string {
-	return "deploy"
-}
-
 type dockerProgress struct {
 	Current int   `json:"current,omitempty"`
 	Total   int   `json:"total,omitempty"`

--- a/empire/migrations/0005_add_repo.down.sql
+++ b/empire/migrations/0005_add_repo.down.sql
@@ -1,3 +1,14 @@
 ALTER TABLE apps DROP COLUMN repo;
 ALTER TABLE apps ADD COLUMN docker_repo text;
 ALTER TABLE apps ADD COLUMN github_repo text;
+
+CREATE TABLE deployments (
+  id uuid NOT NULL DEFAULT uuid_generate_v4() primary key,
+  app_id text NOT NULL references apps(name) ON DELETE CASCADE,
+  release_id uuid references releases(id),
+  image text NOT NULL,
+  status text NOT NULL,
+  error text,
+  created_at timestamp without time zone default (now() at time zone 'utc'),
+  finished_at timestamp without time zone
+);

--- a/empire/migrations/0005_add_repo.up.sql
+++ b/empire/migrations/0005_add_repo.up.sql
@@ -1,3 +1,4 @@
 ALTER TABLE apps DROP COLUMN docker_repo;
 ALTER TABLE apps DROP COLUMN github_repo;
 ALTER TABLE apps ADD COLUMN repo text;
+DROP TABLE deployments;

--- a/empire/server/heroku/deployments.go
+++ b/empire/server/heroku/deployments.go
@@ -7,17 +7,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-type Deployment struct {
-	ID      string   `json:"id"`
-	Release *Release `json:"release"`
-}
-
-func newDeployment(d *empire.Deployment) *Deployment {
-	return &Deployment{
-		ID: d.ID,
-	}
-}
-
 // PostDeploys is a Handler for the POST /v1/deploys endpoint.
 type PostDeploys struct {
 	*empire.Empire
@@ -28,36 +17,25 @@ type PostDeployForm struct {
 	Image empire.Image
 }
 
-// jsonMessage represents a streamed status message from the docker remote api.
-// https://docs.docker.com/reference/api/docker_remote_api_v1.9/#create-an-image
-type jsonMessage struct {
-	Status         string      `json:"status,omitempty"`
-	Progress       string      `json:"progress,omitempty"`
-	ProgressDetail interface{} `json:"progressDetail,omitempty"`
-	Error          string      `json:"error,omitempty"`
-	Stream         string      `json:"stream,omitempty"`
-	Deployment     *Deployment `json:"deployment,omitempty"`
-}
-
 // Serve implements the Handler interface.
-func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
 	var form PostDeployForm
 
-	if err := Decode(r, &form); err != nil {
+	if err := Decode(req, &form); err != nil {
 		return err
 	}
 
 	w.Header().Set("Content-Type", "application/json; boundary=NL")
 
 	var (
-		d   *empire.Deployment
+		r   *empire.Release
 		err error
 	)
 
 	ch := make(chan empire.Event)
 	errCh := make(chan error)
 	go func() {
-		d, err = h.DeployImage(ctx, form.Image, ch)
+		r, err = h.DeployImage(ctx, form.Image, ch)
 		errCh <- err
 	}()
 
@@ -76,5 +54,5 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 		}
 	}
 
-	return Encode(w, newDeployment(d))
+	return Encode(w, newRelease(r))
 }


### PR DESCRIPTION
Since we're not performing the deployment in the background anywhere, there's not much need for the deployments table anymore.
