### PR TITLE
Remove slug image id resolving and caching.

### DIFF
--- a/empire/migrations/0006_remove_unique_constraint_on_image.down.sql
+++ b/empire/migrations/0006_remove_unique_constraint_on_image.down.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX index_slugs_on_image ON images USING btree (image);

--- a/empire/migrations/0006_remove_unique_constraint_on_image.up.sql
+++ b/empire/migrations/0006_remove_unique_constraint_on_image.up.sql
@@ -1,0 +1,1 @@
+DROP INDEX index_slugs_on_image;

--- a/empire/slugs.go
+++ b/empire/slugs.go
@@ -71,21 +71,12 @@ func (s *slugsService) SlugsCreateByImage(image Image, out chan Event) (*Slug, e
 // it's not found, it will fallback to extracting the process types using the
 // provided extractor, then create a slug.
 func slugsCreateByImage(store *store, e Extractor, r Resolver, image Image, out chan Event) (*Slug, error) {
-	image, err := r.Resolve(image, out)
+	_, err := r.Resolve(image, out)
 	if err != nil {
 		return nil, err
 	}
 
-	slug, err := store.SlugsFindByImage(image)
-	if err != nil {
-		return slug, err
-	}
-
-	if slug != nil {
-		return slug, nil
-	}
-
-	slug, err = slugsExtract(e, image)
+	slug, err := slugsExtract(e, image)
 	if err != nil {
 		return slug, err
 	}


### PR DESCRIPTION
This is related to https://github.com/remind101/empire/issues/247. Making this change has a couple consequences.
1. It removes the need to tag images with the image id, which means this will enable users to deploy _any_ docker image to empire.
2. Deploying the same image twice will now result in 2 slugs, instead of it re-using the first. This had very little advantage, so I think that's ok.
3. The tag is no longer resolved to the image id before creating the slug, which means the ECS task definition is created using the provided tag. If you `deploy <image>:latest` then the task definition will be created as `<image>:latest`. This is fine for us because we'll always deploy with a git sha as the tag.
