### PR TITLE
Document Procfile constraints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ Any tagged Docker image can be deployed to Empire as an app. Empire doesn't enfo
 
 When you deploy a Docker image to Empire, it will extract a `Procfile` from the WORKDIR. Like Heroku, you can specify different process types that compose your service (e.g. `web` and `worker`), and scale them individually. Each process type in the Procfile maps directly to an ECS Service.
 
+**Caveats**
+
+Because `docker run` does not exec commands within a shell, commands specified within the Procfile will also not be exec'd within a shell. This means that you cannot specify environment variables in the Procfile. The following is not valid:
+
+```
+web: acme-inc server -port=$PORT
+```
+
+If you need to specify environment variables as part of the command, we recommend splitting out your Procfile commands into small bash shims instead:
+
+```
+web: ./bin/web
+```
+
+```bash
+#!/bin/bash
+
+set -e
+
+exec acme-inc server -port=$PORT
+```
+
 ## Development
 
 To get started, run:


### PR DESCRIPTION
ECS doesn't support specifying environment variables as part of the command within task definitions, which means that commands inside Procfile's won't be exec'd within a shell. This just adds some documentation about this constraint, and best practices to work around it.
