### PR TITLE
Re-release app when adding a domain.

### DIFF
--- a/empire/empire.go
+++ b/empire/empire.go
@@ -169,6 +169,7 @@ func New(options Options) (*Empire, error) {
 	runner := newRunner(options.Runner, store)
 
 	releaser := &releaser{
+		store:   store,
 		manager: manager,
 	}
 
@@ -183,7 +184,8 @@ func New(options Options) (*Empire, error) {
 	}
 
 	domains := &domainsService{
-		store: store,
+		store:    store,
+		releaser: releaser,
 	}
 
 	slugs := &slugsService{
@@ -299,13 +301,13 @@ func (e *Empire) DomainsFindByHostname(hostname string) (*Domain, error) {
 }
 
 // DomainsCreate adds a new Domain for an App.
-func (e *Empire) DomainsCreate(domain *Domain) (*Domain, error) {
-	return e.domains.DomainsCreate(domain)
+func (e *Empire) DomainsCreate(ctx context.Context, domain *Domain) (*Domain, error) {
+	return e.domains.DomainsCreate(ctx, domain)
 }
 
 // DomainsDestroy removes a Domain for an App.
-func (e *Empire) DomainsDestroy(domain *Domain) error {
-	return e.domains.DomainsDestroy(domain)
+func (e *Empire) DomainsDestroy(ctx context.Context, domain *Domain) error {
+	return e.domains.DomainsDestroy(ctx, domain)
 }
 
 // JobStatesByApp returns the JobStates for the given app.

--- a/empire/server/heroku/domains.go
+++ b/empire/server/heroku/domains.go
@@ -60,10 +60,10 @@ func (h *PostDomains) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 	}
 
 	domain := &empire.Domain{
-		AppID:    a.ID,
+		App:      a,
 		Hostname: form.Hostname,
 	}
-	d, err := h.DomainsCreate(domain)
+	d, err := h.DomainsCreate(ctx, domain)
 	if err != nil {
 		if err == empire.ErrDomainInUse {
 			return fmt.Errorf("%s is currently in use by another app.", domain.Hostname)
@@ -103,7 +103,7 @@ func (h *DeleteDomain) ServeHTTPContext(ctx context.Context, w http.ResponseWrit
 		}
 	}
 
-	if err = h.DomainsDestroy(d); err != nil {
+	if err = h.DomainsDestroy(ctx, d); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When adding a domain, the domainsService will use the releaser to fetch the last release for the app, then re-release it to the service manager.

This doesn't quite work as expected right now because when fetching a release, the process ports aren't eager loaded as well.

Closes https://github.com/remind101/empire/issues/376
