### PR TITLE
Fix crash caused by panic.

### DIFF
--- a/empire/pkg/service/ecs.go
+++ b/empire/pkg/service/ecs.go
@@ -162,25 +162,17 @@ func (m *ECSManager) listAppTasks(app string) ([]*ecs.Task, error) {
 		return tasks, err
 	}
 
-	l := len(resp.ServiceARNs)
-	serviceTasks := make(chan []*ecs.Task, l)
-
 	for _, s := range resp.ServiceARNs {
 		id, err := arn.ResourceID(*s)
 		if err != nil {
 			return tasks, err
 		}
 
-		go func(id string) {
-			// TODO handle error
-			t, _ := m.serviceTasks(id)
+		t, err := m.serviceTasks(id)
+		if err != nil {
+			return tasks, err
+		}
 
-			serviceTasks <- t
-		}(id)
-	}
-
-	for i := 0; i < l; i++ {
-		t := <-serviceTasks
 		tasks = append(tasks, t...)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/386

I could add a `defer func() { recover() }`, but then errors would just be silenced. Figure it's best to just remove the parallelization and do a pass at making the aws service calls more performant later on.
