### PR TITLE
RFC: Scopes

### DIFF
--- a/empire/apps.go
+++ b/empire/apps.go
@@ -205,7 +205,7 @@ type scaler struct {
 }
 
 func (s *scaler) Scale(ctx context.Context, app *App, t ProcessType, quantity int) error {
-	release, err := s.store.ReleasesLast(app)
+	release, err := s.store.ReleasesFirst(ReleasesQuery{App: app})
 	if err != nil {
 		return err
 	}

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -342,17 +342,17 @@ func (e *Empire) ProcessesRun(ctx context.Context, app *App, command string, opt
 
 // ReleasesFindByApp returns all Releases for a given App.
 func (e *Empire) ReleasesFindByApp(app *App) ([]*Release, error) {
-	return e.store.ReleasesFindByApp(app)
+	return e.store.Releases(ReleasesQuery{App: app})
 }
 
 // ReleasesFindByAppAndVersion finds a specific Release for a given App.
 func (e *Empire) ReleasesFindByAppAndVersion(app *App, version int) (*Release, error) {
-	return e.store.ReleasesFindByAppAndVersion(app, version)
+	return e.store.ReleasesFirst(ReleasesQuery{App: app, Version: &version})
 }
 
 // ReleasesLast returns the last release for an App.
 func (e *Empire) ReleasesLast(app *App) (*Release, error) {
-	return e.store.ReleasesLast(app)
+	return e.store.ReleasesFirst(ReleasesQuery{App: app})
 }
 
 // ReleasesRollback rolls an app back to a specific release version. Returns a

--- a/empire/runner.go
+++ b/empire/runner.go
@@ -96,7 +96,7 @@ func (r *runner) Run(ctx context.Context, app *App, command string, opts Process
 }
 
 func (r *runner) newContainerForm(ctx context.Context, app *App, command string, opts ProcessesRunOpts) (*postContainersForm, error) {
-	release, err := r.store.ReleasesLast(app)
+	release, err := r.store.ReleasesFirst(ReleasesQuery{App: app})
 	if err != nil {
 		return nil, err
 	}

--- a/empire/server/heroku/errors.go
+++ b/empire/server/heroku/errors.go
@@ -3,6 +3,7 @@ package heroku
 import (
 	"net/http"
 
+	"github.com/jinzhu/gorm"
 	"github.com/remind101/empire/empire"
 )
 
@@ -45,6 +46,10 @@ type ErrorResource struct {
 }
 
 func newError(err error) *ErrorResource {
+	if err == gorm.RecordNotFound {
+		return ErrNotFound
+	}
+
 	switch err := err.(type) {
 	case *ErrorResource:
 		return err

--- a/empire/store.go
+++ b/empire/store.go
@@ -1,10 +1,86 @@
 package empire
 
-import "github.com/jinzhu/gorm"
+import (
+	"fmt"
+
+	"github.com/jinzhu/gorm"
+)
+
+// Scope is an interface that scopes a gorm.DB. Scopes are used in
+// ThingsFirst and ThingsAll methods on the store for filtering/querying.
+type Scope interface {
+	Scope(*gorm.DB) *gorm.DB
+}
+
+// ScopeFunc implements the Scope interface for functions.
+type ScopeFunc func(*gorm.DB) *gorm.DB
+
+// Scope implements the Scope interface.
+func (f ScopeFunc) Scope(db *gorm.DB) *gorm.DB {
+	return f(db)
+}
+
+// ComposedScope is an implementation of the Scope interface that chains the
+// scopes together.
+type ComposedScope []Scope
+
+// Scope implements the Scope interface.
+func (s ComposedScope) Scope(db *gorm.DB) *gorm.DB {
+	for _, s := range s {
+		db = s.Scope(db)
+	}
+
+	return db
+}
+
+// FieldEquals returns a Scope that filters on a field.
+func FieldEquals(field string, v interface{}) Scope {
+	return ScopeFunc(func(db *gorm.DB) *gorm.DB {
+		return db.Where(fmt.Sprintf("%s = ?", field), v)
+	})
+}
+
+// Preload returns a Scope that preloads the associations.
+func Preload(associations ...string) Scope {
+	var scope ComposedScope
+
+	for _, a := range associations {
+		aa := a
+		scope = append(scope, ScopeFunc(func(db *gorm.DB) *gorm.DB {
+			return db.Preload(aa)
+		}))
+	}
+
+	return scope
+}
+
+// Order returns a Scope that orders the results.
+func Order(order string) Scope {
+	return ScopeFunc(func(db *gorm.DB) *gorm.DB {
+		return db.Order(order)
+	})
+}
 
 // store provides methods for CRUD'ing things.
 type store struct {
 	db *gorm.DB
+}
+
+// Scope applies the scope to the gorm.DB.
+func (s *store) Scope(scope Scope) *gorm.DB {
+	return scope.Scope(s.db)
+}
+
+// First applies the scope to the gorm.DB and finds the first record, populating
+// v.
+func (s *store) First(scope Scope, v interface{}) error {
+	return s.Scope(scope).First(v).Error
+}
+
+// Find applies the scope to the gorm.DB and finds the matching records,
+// populating v.
+func (s *store) Find(scope Scope, v interface{}) error {
+	return s.Scope(scope).Find(v).Error
 }
 
 func (s *store) Reset() error {

--- a/empire/store_test.go
+++ b/empire/store_test.go
@@ -1,0 +1,42 @@
+package empire
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jinzhu/gorm"
+)
+
+func TestComposedScope(t *testing.T) {
+	var scope ComposedScope
+
+	a, b := make(chan struct{}), make(chan struct{})
+
+	scope = append(scope, MockScope(a))
+	scope = append(scope, MockScope(b))
+
+	db := &gorm.DB{}
+
+	go scope.Scope(db)
+
+	select {
+	case <-a:
+	case <-time.After(time.Second):
+		t.Fatal("Expected a to be called")
+	}
+
+	select {
+	case <-b:
+	default:
+		t.Fatal("Expected b to be called")
+	}
+}
+
+// MockScope is a Scope implementation that closes the channel when it is
+// called.
+func MockScope(called chan struct{}) Scope {
+	return ScopeFunc(func(db *gorm.DB) *gorm.DB {
+		close(called)
+		return db
+	})
+}


### PR DESCRIPTION
Here's what I basically have in mind for scope/query objects. Basically, every method on the store would have the same 3/4 basic functions:

``` go
Things(scope Scope) ([]*Things, error) // Returns all things, scoped.
ThingsFirst(scope Scope) (*Thing, error) // Returns the first thing, scoped.
ThingsCreate(*Thing) error // Creates the thing
ThingsUpdate(*Thing) error // Updates the thing
```

Scope is just an interface that is defined as:

``` go
Scope(*gorm.DB) *gorm.DB
```

I think this would be pretty flexible and easy to scale. We can build query objects as structs that implement the Scope interface, like I did here with the ReleasesQuery struct, but anything that implements the Scope interface can be provided.

Since the Things<Something> methods are so simple, and they won't grow, it also makes it easier to wrap the implementation with middleware, which could be used to do more complicated eager loading that can't be done with gorm.
