### PR TITLE
Configurable service role.

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -42,9 +42,10 @@ output() {
 }
 
 echo "AWS_REGION=us-east-1" > .env
-echo "AWS_ACCESS_KEY_ID=$(output AccessKey)" >> .env
+echo "AWS_ACCESS_KEY_ID=$(output AccessKeyId)" >> .env
 echo "AWS_SECRET_ACCESS_KEY=$(output SecretAccessKey)" >> .env
 echo "EMPIRE_ELB_VPC_ID=$(output VPC)" >> .env
-echo "EMPIRE_ELB_INTERNAL_SG=$(output InternalELBSG)" >> .env
-echo "EMPIRE_ELB_EXTERNAL_SG=$(output ExternalELBSG)" >> .env
+echo "EMPIRE_ELB_SG_PRIVATE=$(output InternalELBSG)" >> .env
+echo "EMPIRE_ELB_SG_PUBLIC=$(output ExternalELBSG)" >> .env
 echo "EMPIRE_ECS_CLUSTER=$STACK" >> .env
+echo "EMPIRE_ECS_SERVICE_ROLE=$(output ServiceRole)" >> .env

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -62,15 +62,11 @@ Then create the task definition:
 $ aws ecs register-task-definition --family empire --cli-input-json file://$PWD/docs/guide/empire.ecs.json
 ```
 
-**Create the ECS Service Role**
-
-Refer to the ECS documentation to create the `ecsServiceRole` role: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAM_policies.html#service_IAM_role
-
 **Create the Service**
 
 ```console
 $ aws ecs create-service --cluster default --service-name empire --task-definition empire \
-  --desired-count 1 --role ecsServiceRole \
+  --desired-count 1 --role $(stack-output $STACK ServiceRole) \
   --load-balancers loadBalancerName=$(stack-output $STACK ELBName),containerName=empire,containerPort=8080
 ```
 

--- a/docs/guide/cloudformation.json
+++ b/docs/guide/cloudformation.json
@@ -284,6 +284,53 @@
       }
     },
 
+    "ServiceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Path": "/",
+        "AssumeRolePolicyDocument": {
+          "Version": "2008-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [ "ecs.amazonaws.com" ]
+              },
+              "Action": [ "sts:AssumeRole" ]
+            }
+          ]
+        }
+      }
+    },
+
+    "ServiceRolePolicies": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "ecsServiceRole",
+        "Roles": [ { "Ref": "ServiceRole" } ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ec2:Describe*",
+                "elasticloadbalancing:*",
+                "ecs:*",
+                "iam:ListInstanceProfiles",
+                "iam:ListRoles",
+                "iam:PassRole",
+                "route53:*"
+              ],
+              "Resource": [
+                "*"
+              ]
+            }
+          ]
+        }
+      }
+    },
+
     "InstanceProfile": {
       "Type": "AWS::IAM::InstanceProfile",
       "Properties": {
@@ -351,7 +398,11 @@
       "Description": "The name of the ELB for the Empire controller",
       "Value": { "Ref": "LoadBalancer" }
     },
-    "AccessKey": {
+    "ServiceRole": {
+      "Description": "Role to assume when creating an ECS service with an ELB attached",
+      "Value": { "Ref": "ServiceRole" }
+    },
+    "AccessKeyId": {
       "Description": "Access key that can be used for a development instance of Empire",
       "Value": { "Ref": "AccessKey" }
     },

--- a/empire/cmd/empire/main.go
+++ b/empire/cmd/empire/main.go
@@ -30,7 +30,8 @@ const (
 	FlagDockerCert   = "docker.cert"
 	FlagDockerAuth   = "docker.auth"
 
-	FlagECSCluster = "ecs.cluster"
+	FlagECSCluster     = "ecs.cluster"
+	FlagECSServiceRole = "ecs.service.role"
 
 	FlagELBSGPrivate = "elb.sg.private"
 	FlagELBSGPublic  = "elb.sg.public"
@@ -135,6 +136,12 @@ var EmpireFlags = []cli.Flag{
 		EnvVar: "EMPIRE_ECS_CLUSTER",
 	},
 	cli.StringFlag{
+		Name:   FlagECSServiceRole,
+		Value:  "default",
+		Usage:  "The ECS cluster to create services within",
+		EnvVar: "EMPIRE_ECS_SERVICE_ROLE",
+	},
+	cli.StringFlag{
 		Name:   FlagELBSGPrivate,
 		Value:  "",
 		Usage:  "The ELB security group to assign private load balancers",
@@ -195,6 +202,7 @@ func newEmpire(c *cli.Context) (*empire.Empire, error) {
 	opts.Runner.API = c.String(FlagRunner)
 	opts.AWSConfig = aws.DefaultConfig
 	opts.ECS.Cluster = c.String(FlagECSCluster)
+	opts.ECS.ServiceRole = c.String(FlagECSServiceRole)
 	opts.ELB.InternalSecurityGroupID = c.String(FlagELBSGPrivate)
 	opts.ELB.ExternalSecurityGroupID = c.String(FlagELBSGPublic)
 	opts.ELB.InternalSubnetIDs = c.StringSlice(FlagEC2SubnetsPrivate)

--- a/empire/empire.go
+++ b/empire/empire.go
@@ -52,7 +52,8 @@ type DockerOptions struct {
 
 // ECSOptions is a set of options to configure ECS.
 type ECSOptions struct {
-	Cluster string
+	Cluster     string
+	ServiceRole string
 }
 
 // ELBOptions is a set of options to configure ELB.
@@ -408,6 +409,7 @@ func newManager(ecsOpts ECSOptions, elbOpts ELBOptions, config *aws.Config) serv
 
 	m := service.NewECSManager(service.ECSConfig{
 		Cluster:                 ecsOpts.Cluster,
+		ServiceRole:             ecsOpts.ServiceRole,
 		InternalSecurityGroupID: elbOpts.InternalSecurityGroupID,
 		ExternalSecurityGroupID: elbOpts.ExternalSecurityGroupID,
 		InternalSubnetIDs:       elbOpts.InternalSubnetIDs,


### PR DESCRIPTION
Looks like the original bug me and ben ran into with the name of the iam role has been fixed, so we can now create a service role in cloudformation, which now needs to be set with the `EMPIRE_ECS_SERVICE_ROLE` environment variable.

Note to self: need to add the EMPIRE_EC2_SUBNETS_PRIVATE and EMPIRE_EC2_SUBNETS_PUBLIC environment variables in `bin/bootstrap` and remove the VPC one.
