### PR TITLE
Add pre-defined environment variables to task definition.

### DIFF
--- a/empire/releases.go
+++ b/empire/releases.go
@@ -252,7 +252,7 @@ func newServiceProcess(release *Release, p *Process) *service.Process {
 	env["EMPIRE_APPNAME"] = release.App.Name
 	env["EMPIRE_PROCESS"] = string(p.Type)
 	env["EMPIRE_RELEASE"] = fmt.Sprintf("%d", release.Version)
-	env["SOURCE"] = fmt.Sprintf("%s.%s", release.App.Name, p.Type)
+	env["SOURCE"] = fmt.Sprintf("%s.%s.%d", release.App.Name, p.Type, release.Version)
 
 	if len(ports) > 0 {
 		env["PORT"] = fmt.Sprintf("%d", *ports[0].Container)


### PR DESCRIPTION
This would be a temporary workaround for the lack of support for labels in ECS. If we merge this, then we can change the [`SYSLOG_STRUCTURED_DATA`](https://github.com/remind101/docker-heka/pull/8/files#diff-4e5e90c6228fd48698d074241c2ba760R22) environment variable in logspout to extract these specific variables into the structured-data fields in log messages. EZPZ log filtering for app name, version and process type.

[Soon](https://github.com/aws/amazon-ecs-agent/pull/88) the ecs agent will add the task arn, container-name, family and version as well. Once ECS supports adding labels to task definitions, then we can move these to labels like `com.remind.empire.appname`, `com.remind.empire.process`, `com.remind.empire.release`.

Related to https://github.com/remind101/empire/issues/445
