### PR TITLE
Prefix version with "v".

### DIFF
--- a/empire/releases.go
+++ b/empire/releases.go
@@ -252,7 +252,7 @@ func newServiceProcess(release *Release, p *Process) *service.Process {
 	env["EMPIRE_APPNAME"] = release.App.Name
 	env["EMPIRE_PROCESS"] = string(p.Type)
 	env["EMPIRE_RELEASE"] = fmt.Sprintf("v%d", release.Version)
-	env["SOURCE"] = fmt.Sprintf("%s.%s.v%d", release.App.Name, p.Type, release.Version)
+	env["SOURCE"] = fmt.Sprintf("%s.v%d.%s", release.App.Name, release.Version, p.Type)
 
 	if len(ports) > 0 {
 		env["PORT"] = fmt.Sprintf("%d", *ports[0].Container)


### PR DESCRIPTION
Prefixes the version in the SOURCE and EMPIRE_RELEASE environment variables with "v". e.g:

```
app.web.v1
```

Not doing this could probably cause confusion about what that part of the source is.
