### PR TITLE
Updated to latest remind101/pkg.

### DIFF
--- a/empire/Godeps/Godeps.json
+++ b/empire/Godeps/Godeps.json
@@ -214,23 +214,23 @@
 		},
 		{
 			"ImportPath": "github.com/remind101/pkg/httpx",
-			"Rev": "39d92f6ff6a9c82f93b48a26874d681d0015c9c5"
+			"Rev": "835283e5cf4be4a19295819879cc5259718ec075"
 		},
 		{
 			"ImportPath": "github.com/remind101/pkg/logger",
-			"Rev": "39d92f6ff6a9c82f93b48a26874d681d0015c9c5"
+			"Rev": "835283e5cf4be4a19295819879cc5259718ec075"
 		},
 		{
 			"ImportPath": "github.com/remind101/pkg/reporter",
-			"Rev": "39d92f6ff6a9c82f93b48a26874d681d0015c9c5"
+			"Rev": "835283e5cf4be4a19295819879cc5259718ec075"
 		},
 		{
 			"ImportPath": "github.com/remind101/pkg/timex",
-			"Rev": "39d92f6ff6a9c82f93b48a26874d681d0015c9c5"
+			"Rev": "835283e5cf4be4a19295819879cc5259718ec075"
 		},
 		{
 			"ImportPath": "github.com/remind101/pkg/trace",
-			"Rev": "39d92f6ff6a9c82f93b48a26874d681d0015c9c5"
+			"Rev": "835283e5cf4be4a19295819879cc5259718ec075"
 		},
 		{
 			"ImportPath": "github.com/vaughan0/go-ini",

--- a/empire/Godeps/_workspace/src/github.com/remind101/pkg/reporter/reporter.go
+++ b/empire/Godeps/_workspace/src/github.com/remind101/pkg/reporter/reporter.go
@@ -57,23 +57,29 @@ func AddRequest(ctx context.Context, req *http.Request) {
 
 // newError returns a new Error instance. If err is already an Error instance,
 // it will be returned, otherwise err will be wrapped with NewErrorWithContext.
-func newError(ctx context.Context, err error) *Error {
+func newError(ctx context.Context, err error, skip int) *Error {
 	if e, ok := err.(*Error); ok {
 		return e
 	} else {
-		return NewErrorWithContext(ctx, err, 2)
+		return NewErrorWithContext(ctx, err, skip+1)
 	}
 }
 
-// Report wraps the err as an Error and reports it the the Reporter embedded
+// Report reports the error with the backtrace starting at the calling function.
+func Report(ctx context.Context, err error) error {
+	return ReportWithSkip(ctx, err, 1)
+}
+
+// ReportWithSkip wraps the err as an Error and reports it the the Reporter embedded
 // within the context.Context. If err is nil, Report will return early, so this
 // function is safe to call without performing a nill check on the error first.
-func Report(ctx context.Context, err error) error {
+// A skip value of 0 refers to the calling function.
+func ReportWithSkip(ctx context.Context, err error, skip int) error {
 	if err == nil {
 		return nil
 	}
 
-	e := newError(ctx, err)
+	e := newError(ctx, err, skip+1)
 
 	if r, ok := FromContext(ctx); ok {
 		return r.Report(ctx, e)

--- a/empire/Godeps/_workspace/src/github.com/remind101/pkg/trace/trace.go
+++ b/empire/Godeps/_workspace/src/github.com/remind101/pkg/trace/trace.go
@@ -28,13 +28,13 @@ func Trace(ctx context.Context) (context.Context, func(error, string, ...interfa
 	}
 
 	return ctx, func(err error, msg string, pairs ...interface{}) {
-		l, ok := logger.WithValues(ctx, "trace.id", "trace.func", "trace.file", "trace.line", "trace.duration")
+		l, ok := logger.WithValues(ctx, "trace.id", "trace.parent", "trace.func", "trace.file", "trace.line", "trace.duration")
 		if ok {
 			l.Info(msg, pairs...)
 		}
 
 		// Report the error to the reporter.
-		reporter.Report(ctx, err)
+		reporter.ReportWithSkip(ctx, err, 1)
 	}
 }
 
@@ -55,7 +55,7 @@ func (ctx *tracedContext) Value(v interface{}) interface{} {
 		switch key {
 		case "trace.id":
 			return ctx.id
-		case "trace.parent.id":
+		case "trace.parent":
 			return ctx.parent
 		case "trace.func":
 			return ctx.fnname

--- a/empire/Godeps/_workspace/src/github.com/remind101/pkg/trace/trace_test.go
+++ b/empire/Godeps/_workspace/src/github.com/remind101/pkg/trace/trace_test.go
@@ -8,10 +8,14 @@ import (
 )
 
 func TestTracedContext(t *testing.T) {
-	ctx := &tracedContext{Context: context.Background(), id: "1234", file: "pkg/main.go", line: 10, fnname: "pkg/main.main"}
+	ctx := &tracedContext{Context: context.Background(), id: "1234", file: "pkg/main.go", line: 10, fnname: "pkg/main.main", parent: "4321"}
 
 	if id, ok := ctx.Value("trace.id").(string); !ok || id != "1234" {
 		t.Fatalf("Expected id; got %v", id)
+	}
+
+	if id, ok := ctx.Value("trace.parent").(string); !ok || id != "4321" {
+		t.Fatalf("Expected parent; got %v", id)
 	}
 
 	if fnname, ok := ctx.Value("trace.func").(string); !ok || fnname != "pkg/main.main" {

--- a/empire/pkg/ecsutil/ecs.go
+++ b/empire/pkg/ecsutil/ecs.go
@@ -68,7 +68,6 @@ func (c *ecsClient) UpdateService(ctx context.Context, input *ecs.UpdateServiceI
 }
 
 func (c *ecsClient) RegisterTaskDefinition(ctx context.Context, input *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
-	fmt.Println("Here")
 	if c.tdThrottle == nil {
 		// Only allow 1 task definition per second.
 		c.tdThrottle = time.NewTicker(time.Second)


### PR DESCRIPTION
Added a [commit](https://github.com/remind101/pkg/commit/835283e5cf4be4a19295819879cc5259718ec075) to the `trace` branch that omits the `Trace` call from the backtrace when reporting the error:

![](https://s3.amazonaws.com/ejholmes.github.com/Ofulj.png)
