### PR TITLE
Limit DescribeLoadBalancers to 20 at a time.

### DIFF
--- a/empire/pkg/lb/elb.go
+++ b/empire/pkg/lb/elb.go
@@ -115,7 +115,8 @@ func (m *ELBManager) LoadBalancers(ctx context.Context, tags map[string]string) 
 
 	for {
 		out, err := m.elb.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
-			Marker: nextMarker,
+			Marker:   nextMarker,
+			PageSize: aws.Long(20), // Set this to 20, because DescribeTags has a limit of 20 on the LoadBalancerNames attribute.
 		})
 		if err != nil {
 			return nil, err

--- a/empire/pkg/lb/elb_test.go
+++ b/empire/pkg/lb/elb_test.go
@@ -91,7 +91,7 @@ func TestELB_LoadBalancers(t *testing.T) {
 		{
 			Request: awsutil.Request{
 				RequestURI: "/",
-				Body:       `Action=DescribeLoadBalancers&Version=2012-06-01`,
+				Body:       `Action=DescribeLoadBalancers&PageSize=20&Version=2012-06-01`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
@@ -163,7 +163,7 @@ func TestELB_LoadBalancers(t *testing.T) {
 		{
 			Request: awsutil.Request{
 				RequestURI: "/",
-				Body:       `Action=DescribeLoadBalancers&Marker=%0A%09++++++abcd%0A%09++++&Version=2012-06-01`,
+				Body:       `Action=DescribeLoadBalancers&Marker=%0A%09++++++abcd%0A%09++++&PageSize=20&Version=2012-06-01`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,


### PR DESCRIPTION
This should fix the following error:

```
{"error":"ValidationError: 1 validation error detected: Value '[classchir-NginxPro-IXS2HATW8STD, remind-co-NginxPro-1N2NSTNXR7ZSG, stage-cla-EmpireCo-E4YBSY64ZR2X, bf0d58a7fc8840edbf5eb3175c9a4f92, d5d311fc692547ceaeac555bbf3c2cbc, 9aeaeb6f5bdb41519b6cf219b160a7ce, 5a9c01f8e4484bc88fb3e1e7333ef55f, a851ea50d0b54c24b91fb96a1016fd9a, 4d885cff6ee04d9c81b9e78ca3019de7, 14181775fb0b464c9c85aaf3831e72f7, 3ee5a88c4dcb4364b3899f0b7af065a2, 4b7a5d0260204fca8c803267d24a8b7b, 3539ccc083a04aa09a620f3b6e2a78b2, prod-remi-EmpireCo-117TEQUA7WODX, 02a52c13d9af4af09973ee505af3d3a0, 03ecd145fdb146f19fb8eb93662295b6, cab45ee4837a43a9b99192089abd8ad8, 46431678a587461796d40932916b75bf, 2d0aaf5782874ecfa152201690a9e330, 5f08aabf40f2484f893b5d2ffeadd85a, 32f340530f6149cf85131db4a27f528d]' at 'loadBalancerNames' failed to satisfy constraint: Member must have length less than or equal to 20\n\tstatus code: 400, request id: [04d62a00-0bad-11e5-8547-6505e868cb59]"}
```

Which is caused because we try to pass more than 20 load balancers to `DescribeTags`.
