### PR TITLE
Some app.ID's were being sent as app.Names

### DIFF
--- a/empire/apps.go
+++ b/empire/apps.go
@@ -253,7 +253,7 @@ type restarter struct {
 }
 
 func (s *restarter) Restart(ctx context.Context, app *App, t ProcessType, id string) error {
-	instances, err := s.manager.Instances(ctx, app.Name)
+	instances, err := s.manager.Instances(ctx, app.ID)
 	if err != nil {
 		return err
 	}

--- a/empire/pkg/ecsutil/client.go
+++ b/empire/pkg/ecsutil/client.go
@@ -62,10 +62,10 @@ func (c *Client) RegisterAppTaskDefinition(ctx context.Context, app string, inpu
 }
 
 // ListAppTasks lists all the tasks for the app.
-func (c *Client) ListAppTasks(ctx context.Context, app string, input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
+func (c *Client) ListAppTasks(ctx context.Context, appID string, input *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
 	var arns []*string
 
-	resp, err := c.ListAppServices(ctx, app, &ecs.ListServicesInput{
+	resp, err := c.ListAppServices(ctx, appID, &ecs.ListServicesInput{
 		Cluster: input.Cluster,
 	})
 	if err != nil {
@@ -99,7 +99,7 @@ func (c *Client) ListAppTasks(ctx context.Context, app string, input *ecs.ListTa
 }
 
 // ListAppServices lists all services for the app.
-func (c *Client) ListAppServices(ctx context.Context, app string, input *ecs.ListServicesInput) (*ecs.ListServicesOutput, error) {
+func (c *Client) ListAppServices(ctx context.Context, appID string, input *ecs.ListServicesInput) (*ecs.ListServicesOutput, error) {
 	resp, err := c.ListServices(ctx, input)
 	if err != nil {
 		return resp, err
@@ -118,7 +118,7 @@ func (c *Client) ListAppServices(ctx context.Context, app string, input *ecs.Lis
 
 		appName, _ := c.split(&id)
 
-		if appName == app {
+		if appName == appID {
 			arns = append(arns, a)
 		}
 	}

--- a/empire/pkg/ecsutil/client_test.go
+++ b/empire/pkg/ecsutil/client_test.go
@@ -23,14 +23,14 @@ func TestListAppServices(t *testing.T) {
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/acme-inc--web"]}`,
+				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/ae69bb4c-3903-4844-82fe-548ac5b74570--web"]}`,
 			},
 		},
 	})
 	m, s := newTestClient(h)
 	defer s.Close()
 
-	resp, err := m.ListAppServices(context.Background(), "acme-inc", &ecs.ListServicesInput{
+	resp, err := m.ListAppServices(context.Background(), "ae69bb4c-3903-4844-82fe-548ac5b74570", &ecs.ListServicesInput{
 		Cluster: aws.String("cluster"),
 	})
 	if err != nil {
@@ -52,7 +52,7 @@ func TestListAppServices_Pagination(t *testing.T) {
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/acme-inc--web"],"nextToken":"1234"}`,
+				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/ae69bb4c-3903-4844-82fe-548ac5b74570--web"],"nextToken":"1234"}`,
 			},
 		},
 
@@ -64,14 +64,14 @@ func TestListAppServices_Pagination(t *testing.T) {
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/acme-inc--web"]}`,
+				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/ae69bb4c-3903-4844-82fe-548ac5b74570--web"]}`,
 			},
 		},
 	})
 	m, s := newTestClient(h)
 	defer s.Close()
 
-	resp, err := m.ListAppServices(context.Background(), "acme-inc", &ecs.ListServicesInput{
+	resp, err := m.ListAppServices(context.Background(), "ae69bb4c-3903-4844-82fe-548ac5b74570", &ecs.ListServicesInput{
 		Cluster: aws.String("cluster"),
 	})
 	if err != nil {
@@ -93,7 +93,7 @@ func TestListAppTasks(t *testing.T) {
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/acme-inc--web"]}`,
+				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/ae69bb4c-3903-4844-82fe-548ac5b74570--web"]}`,
 			},
 		},
 
@@ -101,7 +101,7 @@ func TestListAppTasks(t *testing.T) {
 			Request: awsutil.Request{
 				RequestURI: "/",
 				Operation:  "AmazonEC2ContainerServiceV20141113.ListTasks",
-				Body:       `{"cluster":"cluster","serviceName":"acme-inc--web"}`,
+				Body:       `{"cluster":"cluster","serviceName":"ae69bb4c-3903-4844-82fe-548ac5b74570--web"}`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
@@ -112,7 +112,7 @@ func TestListAppTasks(t *testing.T) {
 	m, s := newTestClient(h)
 	defer s.Close()
 
-	resp, err := m.ListAppTasks(context.Background(), "acme-inc", &ecs.ListTasksInput{
+	resp, err := m.ListAppTasks(context.Background(), "ae69bb4c-3903-4844-82fe-548ac5b74570", &ecs.ListTasksInput{
 		Cluster: aws.String("cluster"),
 	})
 	if err != nil {
@@ -134,7 +134,7 @@ func TestListAppTasks_Paginate(t *testing.T) {
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/acme-inc--web"]}`,
+				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/ae69bb4c-3903-4844-82fe-548ac5b74570--web"]}`,
 			},
 		},
 
@@ -142,7 +142,7 @@ func TestListAppTasks_Paginate(t *testing.T) {
 			Request: awsutil.Request{
 				RequestURI: "/",
 				Operation:  "AmazonEC2ContainerServiceV20141113.ListTasks",
-				Body:       `{"cluster":"cluster","serviceName":"acme-inc--web"}`,
+				Body:       `{"cluster":"cluster","serviceName":"ae69bb4c-3903-4844-82fe-548ac5b74570--web"}`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
@@ -154,7 +154,7 @@ func TestListAppTasks_Paginate(t *testing.T) {
 			Request: awsutil.Request{
 				RequestURI: "/",
 				Operation:  "AmazonEC2ContainerServiceV20141113.ListTasks",
-				Body:       `{"cluster":"cluster","serviceName":"acme-inc--web","nextToken":"1234"}`,
+				Body:       `{"cluster":"cluster","serviceName":"ae69bb4c-3903-4844-82fe-548ac5b74570--web","nextToken":"1234"}`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
@@ -165,7 +165,7 @@ func TestListAppTasks_Paginate(t *testing.T) {
 	m, s := newTestClient(h)
 	defer s.Close()
 
-	resp, err := m.ListAppTasks(context.Background(), "acme-inc", &ecs.ListTasksInput{
+	resp, err := m.ListAppTasks(context.Background(), "ae69bb4c-3903-4844-82fe-548ac5b74570", &ecs.ListTasksInput{
 		Cluster: aws.String("cluster"),
 	})
 	if err != nil {

--- a/empire/pkg/ecsutil/ecs.go
+++ b/empire/pkg/ecsutil/ecs.go
@@ -91,7 +91,7 @@ func (c *ecsClient) DescribeTaskDefinition(ctx context.Context, input *ecs.Descr
 func (c *ecsClient) ListServices(ctx context.Context, input *ecs.ListServicesInput) (*ecs.ListServicesOutput, error) {
 	ctx, done := trace.Trace(ctx)
 	resp, err := c.ECS.ListServices(input)
-	done(err, "ListServices")
+	done(err, "ListServices", "services", len(resp.ServiceARNs))
 	return resp, err
 }
 

--- a/empire/pkg/service/ecs.go
+++ b/empire/pkg/service/ecs.go
@@ -139,14 +139,14 @@ func (m *ECSManager) Submit(ctx context.Context, app *App) error {
 }
 
 // Remove removes any ECS services that belong to this app.
-func (m *ECSManager) Remove(ctx context.Context, app string) error {
-	processes, err := m.Processes(ctx, app)
+func (m *ECSManager) Remove(ctx context.Context, appID string) error {
+	processes, err := m.Processes(ctx, appID)
 	if err != nil {
 		return err
 	}
 
 	for t, _ := range processTypes(processes) {
-		if err := m.RemoveProcess(ctx, app, t); err != nil {
+		if err := m.RemoveProcess(ctx, appID, t); err != nil {
 			return err
 		}
 	}
@@ -156,10 +156,10 @@ func (m *ECSManager) Remove(ctx context.Context, app string) error {
 
 // Instances returns all instances that are currently running, pending or
 // draining.
-func (m *ECSManager) Instances(ctx context.Context, app string) ([]*Instance, error) {
+func (m *ECSManager) Instances(ctx context.Context, appID string) ([]*Instance, error) {
 	var instances []*Instance
 
-	tasks, err := m.describeAppTasks(ctx, app)
+	tasks, err := m.describeAppTasks(ctx, appID)
 	if err != nil {
 		return instances, err
 	}
@@ -193,8 +193,8 @@ func (m *ECSManager) Instances(ctx context.Context, app string) ([]*Instance, er
 	return instances, nil
 }
 
-func (m *ECSManager) describeAppTasks(ctx context.Context, app string) ([]*ecs.Task, error) {
-	resp, err := m.ecs.ListAppTasks(ctx, app, &ecs.ListTasksInput{
+func (m *ECSManager) describeAppTasks(ctx context.Context, appID string) ([]*ecs.Task, error) {
+	resp, err := m.ecs.ListAppTasks(ctx, appID, &ecs.ListTasksInput{
 		Cluster: aws.String(m.cluster),
 	})
 	if err != nil {
@@ -300,10 +300,10 @@ func (m *ecsProcessManager) updateCreateService(ctx context.Context, app *App, p
 	return m.createService(ctx, app, p)
 }
 
-func (m *ecsProcessManager) Processes(ctx context.Context, app string) ([]*Process, error) {
+func (m *ecsProcessManager) Processes(ctx context.Context, appID string) ([]*Process, error) {
 	var processes []*Process
 
-	list, err := m.ecs.ListAppServices(ctx, app, &ecs.ListServicesInput{
+	list, err := m.ecs.ListAppServices(ctx, appID, &ecs.ListServicesInput{
 		Cluster: aws.String(m.cluster),
 	})
 	if err != nil {

--- a/empire/pkg/service/fake.go
+++ b/empire/pkg/service/fake.go
@@ -38,14 +38,14 @@ func (m *FakeManager) Scale(ctx context.Context, app string, ptype string, insta
 	return nil
 }
 
-func (m *FakeManager) Remove(ctx context.Context, app string) error {
-	delete(m.apps, app)
+func (m *FakeManager) Remove(ctx context.Context, appID string) error {
+	delete(m.apps, appID)
 	return nil
 }
 
-func (m *FakeManager) Instances(ctx context.Context, app string) ([]*Instance, error) {
+func (m *FakeManager) Instances(ctx context.Context, appID string) ([]*Instance, error) {
 	var instances []*Instance
-	if a, ok := m.apps[app]; ok {
+	if a, ok := m.apps[appID]; ok {
 		for _, p := range a.Processes {
 			for i := uint(1); i <= p.Instances; i++ {
 				instances = append(instances, &Instance{


### PR DESCRIPTION
Fixes GH-464

During a previous refactor, when we started using UUID's for names of
things in ECS, there were some methods that were missed.  We were
passing in the local name of the app ('acme-inc') when we needed the ECS
name of the app (ie: a UUID).
