### PR TITLE
Fix confusing error when no tasks present

### DIFF
--- a/empire/pkg/service/ecs.go
+++ b/empire/pkg/service/ecs.go
@@ -201,6 +201,10 @@ func (m *ECSManager) describeAppTasks(ctx context.Context, appID string) ([]*ecs
 		return nil, err
 	}
 
+	if len(resp.TaskARNs) == 0 {
+		return []*ecs.Task{}, nil
+	}
+
 	tasks, err := m.ecs.DescribeTasks(ctx, &ecs.DescribeTasksInput{
 		Cluster: aws.String(m.cluster),
 		Tasks:   resp.TaskARNs,


### PR DESCRIPTION
Fixes #472

When a service doesn't yet exist for a new app, we would return a nasty
error message before. This removes that error message.

That said, this only returns a blank response now.  Not sure if there'd
be something better here.

When an app doesn't exist at all in Empire, we still get an appropriate
error:

```
error: Request failed, the specified resource does not exist
```
