### PR TITLE
Raise an error if the currently assigned load balancer is not suitable for the exposure settings.

### DIFF
--- a/empire/server/heroku/deployments.go
+++ b/empire/server/heroku/deployments.go
@@ -45,13 +45,13 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 		select {
 		case evt := <-ch:
 			if err := Stream(w, evt); err != nil {
-				Stream(w, jsonmessage.JSONMessage{ErrorMessage: err.Error()})
+				Stream(w, newJSONMessageError(err))
 				return nil
 			}
 			continue
 		case err := <-errCh:
 			if err != nil {
-				Stream(w, jsonmessage.JSONMessage{ErrorMessage: err.Error()})
+				Stream(w, newJSONMessageError(err))
 				return nil
 			}
 		}
@@ -64,4 +64,13 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 	})
 
 	return nil
+}
+
+func newJSONMessageError(err error) jsonmessage.JSONMessage {
+	return jsonmessage.JSONMessage{
+		ErrorMessage: err.Error(),
+		Error: &jsonmessage.JSONError{
+			Message: err.Error(),
+		},
+	}
 }


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/452

Instead of deleting the ECS service, which will cause the app to incur downtime, we raise an error so the operator can perform the steps manually. This is probably more desirable than deleting and ELB and bringing the web process down.
