### PR TITLE
User docker-1.6 to build image in CI.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,5 @@
 machine:
   timezone: America/Los_Angeles
-  services:
-    - docker
-
 
 checkout:
   post:
@@ -12,6 +9,7 @@ checkout:
 
 dependencies:
   pre:
+    - sudo service docker stop; sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.0-circleci'; sudo chmod 0755 /usr/bin/docker; sudo service docker start; true
     - go install -a -race std
     - go get github.com/tools/godep
     - go version


### PR DESCRIPTION
I want to lock down our pulls in production to a given sha256, but first, we need to be pushing with the registry 2.0 protocol so that the sha gets generated.
