### PR TITLE
Remove link to video demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ Empire is a control layer on top of [Amazon Elastic Container Service (ECS)][ecs
 
 Empire is targeted at small to medium sized startups that are running a large number of microservices and need more flexibility than what Heroku provides.
 
-[![](https://s3.amazonaws.com/ejholmes.github.com/eyiq4.png)](https://www.youtube.com/watch?v=myGiBYTfn08&feature=youtu.be&VQ=HD720)
-
 ## Quickstart
 
 To use Empire, you'll need to have an ECS cluster running. See the [quickstart guide][guide] for more information.


### PR DESCRIPTION
The demo is horribly outdated. We should do something nicer with https://asciinema.org/ before open sourcing.
