### PR TITLE
Speed up docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
 server:
   build: ./empire
   command: server -automigrate=true
+  entrypoint: ./bin/empire
   links:
     - postgres:postgres
   ports:
     - "8080:8080"
   volumes:
-    - ~/.dockercfg:/root/.dockercfg
+    - ".:/go/src/github.com/remind101/empire"
+    - "~/.dockercfg:/root/.dockercfg"
   env_file: .env
   user: root
   environment:

--- a/empire/bin/empire
+++ b/empire/bin/empire
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This is an entrypoint that can be used by docker-compose to compile then run empire
+
+set -e
+
+godep go install ./cmd/empire
+
+exec /go/bin/empire $@


### PR DESCRIPTION
This will mount the source directory and `godep install` when running `docker-compose up` making `docker-compose build --no-cache` unnecessary for normal use.

This _should_ work, but I'm running into strange problems with godep when mounting the empire volume.

This works:

```console
$ docker-compose build --no-cache
$ docker run -it --entrypoint /bin/bash empire_server
$ godep go install ./...
```

But this does not work:

```console
$ docker-compose build --no-cache
$ docker run -it --entrypoint /bin/bash -v "$PWD:/go/src/github.com/remind101/empire" empire_server
$ godep go install ./...
# github.com/remind101/pkg/trace
Godeps/_workspace/src/github.com/remind101/pkg/trace/trace.go:31: undefined: logger.WithValues
Godeps/_workspace/src/github.com/remind101/pkg/trace/trace.go:37: undefined: reporter.ReportWithSkip
# github.com/remind101/pkg/httpx/middleware
Godeps/_workspace/src/github.com/remind101/pkg/httpx/middleware/background.go:38: undefined: httpx.WithRequest
Godeps/_workspace/src/github.com/remind101/pkg/httpx/middleware/newrelic_tracer.go:41: route.GetPathTemplate undefined (type *httpx.Route has no field or method GetPathTemplate)
godep: go exit status 2
```

wat?