### PR TITLE
Update tests to reflect changes in emp.

### DIFF
--- a/empire/tests/cli/login_test.go
+++ b/empire/tests/cli/login_test.go
@@ -42,7 +42,7 @@ func TestLoginUnauthorized(t *testing.T) {
 		t.Fatal("Expected an error")
 	}
 
-	if got, want := string(out), "Enter email: error: Request not authenticated, API token is missing, invalid or expired Log in with `hk login`.\n"; got != want {
+	if got, want := string(out), "Enter email: error: Request not authenticated, API token is missing, invalid or expired Log in with `emp login`.\n"; got != want {
 		t.Fatalf("%q", got)
 	}
 }

--- a/empire/tests/cli/ssl_test.go
+++ b/empire/tests/cli/ssl_test.go
@@ -27,7 +27,7 @@ Status: Created new release v1 for acme-inc`,
 		},
 		{
 			fmt.Sprintf("ssl-cert-add -a acme-inc %s %s", crt.Name(), key.Name()),
-			`Added cert for acme-inc at .`,
+			`Added cert for acme-inc.`,
 		},
 		{
 			`set FOO=bar -a acme-inc`, // Trigger a release


### PR DESCRIPTION
Couple of recent changes in remind101/emp to remove `hk` terminology broke tests here. This fixes those.
