### PR TITLE
Bumpversion

### DIFF
--- a/empire/.bumpversion.cfg
+++ b/empire/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version=0.8.0
+current_version = 0.9.0
 commit = True
 tag = True
 
@@ -8,3 +8,4 @@ tag = True
 [bumpversion:file:Dockerfile]
 
 [bumpversion:file:Makefile]
+

--- a/empire/.bumpversion.cfg
+++ b/empire/.bumpversion.cfg
@@ -1,0 +1,10 @@
+[bumpversion]
+current_version=0.8.0
+commit = True
+tag = True
+
+[bumpversion:file:cmd/empire/version.go]
+
+[bumpversion:file:Dockerfile]
+
+[bumpversion:file:Makefile]

--- a/empire/Dockerfile
+++ b/empire/Dockerfile
@@ -5,7 +5,7 @@ ADD . /go/src/github.com/remind101/empire/empire
 WORKDIR /go/src/github.com/remind101/empire/empire
 RUN go get github.com/tools/godep && godep go install ./cmd/empire
 
-LABEL version 0.8.0
+LABEL version 0.9.0
 
 ENTRYPOINT ["/go/bin/empire"]
 CMD ["server"]

--- a/empire/Dockerfile
+++ b/empire/Dockerfile
@@ -5,6 +5,8 @@ ADD . /go/src/github.com/remind101/empire/empire
 WORKDIR /go/src/github.com/remind101/empire/empire
 RUN go get github.com/tools/godep && godep go install ./cmd/empire
 
+LABEL version 0.8.0
+
 ENTRYPOINT ["/go/bin/empire"]
 CMD ["server"]
 

--- a/empire/Makefile
+++ b/empire/Makefile
@@ -1,5 +1,7 @@
 .PHONY: cmd build test
 
+VERSION = "0.8.0"
+
 cmd:
 	godep go build -o build/empire ./cmd/empire
 
@@ -10,7 +12,7 @@ bootstrap: cmd
 	./build/empire migrate
 
 build: Dockerfile
-	docker build --no-cache -t remind101/empire .
+	docker build --no-cache -t remind101/empire:$(VERSION) .
 
 test:
 	godep go test ./... && godep go vet ./...

--- a/empire/Makefile
+++ b/empire/Makefile
@@ -1,7 +1,7 @@
 .PHONY: cmd build test
 
 TYPE = "patch"
-VERSION = "0.8.0"
+VERSION = "0.9.0"
 
 cmd:
 	godep go build -o build/empire ./cmd/empire

--- a/empire/Makefile
+++ b/empire/Makefile
@@ -1,7 +1,8 @@
 .PHONY: cmd build test
 
-TYPE = "patch"
-VERSION = "0.9.0"
+REPO = remind101/empire
+TYPE = patch
+VERSION = 0.9.0
 
 cmd:
 	godep go build -o build/empire ./cmd/empire
@@ -13,11 +14,13 @@ bootstrap: cmd
 	./build/empire migrate
 
 build: Dockerfile
-	docker build --no-cache -t remind101/empire:$(VERSION) .
+	docker build --no-cache -t ${REPO} .
 
 test:
 	godep go test ./... && godep go vet ./...
 
-release:
+release: test build
 	pip install --upgrade bumpversion
 	bumpversion ${TYPE}
+	docker tag ${REPO} ${REPO}:${VERSION}
+	docker push ${REPO}:${VERSION}

--- a/empire/Makefile
+++ b/empire/Makefile
@@ -1,5 +1,6 @@
 .PHONY: cmd build test
 
+TYPE = "patch"
 VERSION = "0.8.0"
 
 cmd:
@@ -16,3 +17,7 @@ build: Dockerfile
 
 test:
 	godep go test ./... && godep go vet ./...
+
+release:
+	pip install --upgrade bumpversion
+	bumpversion ${TYPE}

--- a/empire/cmd/empire/main.go
+++ b/empire/cmd/empire/main.go
@@ -196,6 +196,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "empire"
 	app.Usage = "Platform as a Binary"
+	app.Version = Version
 	app.Commands = Commands
 
 	app.Run(os.Args)

--- a/empire/cmd/empire/version.go
+++ b/empire/cmd/empire/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.8.0"
+const Version = "0.9.0"

--- a/empire/cmd/empire/version.go
+++ b/empire/cmd/empire/version.go
@@ -1,0 +1,3 @@
+package main
+
+const Version = "0.8.0"


### PR DESCRIPTION
This sets the version in the CLI `empire --version`, our logs (version label), tags our docker image and push it to the registry.

It uses [bumpversion](https://github.com/peritus/bumpversion) to increment the versions in `cmd/empire/version.go`, the Makefile and the Dockerfile, as well as tag and commit the changes. The default is `patch`, but you can specify it via the `TYPE` variable:

```console
make release TYPE=patch # Results in 0.8.0 -> 0.8.1
make release TYPE=minor # Results in 0.8.0 -> 0.9.0
make release TYPE=major # Results in 0.8.0 -> 1.0.0
```

