### PR TITLE
Update AMI ID in CloudFormation config to latest ECS release

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -12,7 +12,7 @@
     "AmiId" : {
       "Type": "String",
       "Description": "AMI Id",
-      "Default": "ami-1e091d76"
+      "Default": "ami-bf4db8d4"
     },
     "KeyName": {
       "Type": "AWS::EC2::KeyPair::KeyName",


### PR DESCRIPTION
Update AMI ID in `cloudformation.json` to the latest ECS AMI released on 06/08. See https://aws.amazon.com/marketplace/ordering?productId=4ce33fd9-63ff-4f35-8d3a-939b641f1931&ref_=dtl_psb_continue&region=us-east-1.