### PR TITLE
Use created serviceRole rather than default

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -479,6 +479,11 @@
                 "Value": { "Fn::Join": [ ",", [{ "Ref": "PubSubnetAz1" }, { "Ref": "PubSubnetAz2" }] ] }
               },
               {
+                "Name": "EMPIRE_ECS_SERVICE_ROLE",
+                "Value": { "Ref": "ServiceRole" }
+              },
+
+              {
                 "Name": "EMPIRE_EC2_SUBNETS_PUBLIC",
                 "Value": { "Fn::Join": [ ",", [{ "Ref": "PubSubnetAz1" }, { "Ref": "PubSubnetAz2" }] ] }
               }


### PR DESCRIPTION
Fixes GH-534

This was being caused when someone launched the Empire cloudformation in
their account with never having used ECS before.  Since we were using
the default ServiceRole (ecsServiceRole) it would fail on those
accounts.

Now we use the ServiceRole that is created with the CF template.

Verified by deleting my account default ecsServiceRole and InstanceRole,
launched a Empire cluster, then made sure I could do things like create
load balancers, etc.