### PR TITLE
move references to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you want to contribute to Empire, you may end up wanting to run a local insta
    $ $(boot2docker shellinit)
    ```
 
-   You should ensure that you've configured boot2docker to disable TLS. Refer to the [troubleshooting](./docs/troubleshooting.md) doc.
+   You should ensure that you've configured boot2docker to disable TLS. Refer to the [disabling boot2docker tls](http://empire.readthedocs.org/en/latest/troubleshooting/#x509-certificate-signed-by-unknown-authority-with-docker-compose).
 
 4. Run the bootstrap script, which will create a cloudformation stack, ecs cluster and populate a .env file:
 
@@ -142,5 +142,5 @@ We have a google group, [empire-dev][empire-dev], where you can ask questions an
 [heroku-go]: https://github.com/bgentry/heroku-go
 [hk]: https://github.com/heroku/hk
 [emp]: https://github.com/remind101/emp
-[guide]: ./docs
+[guide]: http://empire.readthedocs.org/en/latest/
 [empire-dev]: https://groups.google.com/forum/#!forum/empire-dev

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you want to contribute to Empire, you may end up wanting to run a local insta
    $ $(boot2docker shellinit)
    ```
 
-   You should ensure that you've configured boot2docker to disable TLS. Refer to the [disabling boot2docker tls](http://empire.readthedocs.org/en/latest/troubleshooting/#x509-certificate-signed-by-unknown-authority-with-docker-compose).
+   You should ensure that you've configured boot2docker to disable TLS. Refer to the [disabling boot2docker tls](http://empire.readthedocs.org/en/latest/troubleshooting/#x509-certificate-signed-by-unknown-authority-with-docker-compose) docs in the troubleshooting guide.
 
 4. Run the bootstrap script, which will create a cloudformation stack, ecs cluster and populate a .env file:
 

--- a/docs/administering.md
+++ b/docs/administering.md
@@ -1,9 +1,2 @@
 # Empire :: Administering
 
-1. [Overview](./index.md)
-2. [Installing](./installing.md)
-3. [Using](./using.md)
-4. [Administering](./administering.md) **TODO**
-5. [Troubleshooting](./troubleshooting.md)
-6. [Roadmap](./roadmap.md) **TODO**
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,5 @@
 # Empire :: Overview
 
-1. [Overview](./index.md)
-2. [Installing](./installing.md)
-3. [Using](./using.md)
-4. [Administering](./administering.md) **TODO**
-5. [Troubleshooting](./troubleshooting.md)
-6. [Roadmap](./roadmap.md) **TODO**
-
 Empire is an open source, self-hosted PaaS that makes deployment and management
 of [dockerized][dockerized] [12-factor apps][12factor] easy. Empire's goals are
 described below.

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,12 +1,5 @@
 # Empire :: Installing
 
-1. [Overview](./index.md)
-2. [Installing](./installing.md)
-3. [Using](./using.md)
-4. [Administering](./administering.md) **TODO**
-5. [Troubleshooting](./troubleshooting.md)
-6. [Roadmap](./roadmap.md) **TODO**
-
 **IMPORTANT:** Use the following document as a quick way to try empire. This
 method is not suggested for a production environment, and should not be
 considered secure. There will be further docs describing best practices for

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,9 +1,2 @@
 # Empire :: Roadmap
 
-1. [Overview](./index.md)
-2. [Installing](./installing.md)
-3. [Using](./using.md)
-4. [Administering](./administering.md) **TODO**
-5. [Troubleshooting](./troubleshooting.md)
-6. [Roadmap](./roadmap.md) **TODO**
-

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,25 +6,27 @@ If you are encountering this error with using docker-compose and boot2docker,
 you need to disable TLS on boot2docker. Here is how to do so:
 
 1. Set DOCKER_TLS in boot2docker VM
-  ```console
-  # ssh to boot2docker from host machine (OSX)
-  boot2docker up
-  boot2docker ssh
 
-  # add DOCKER_TLS=no
-  sudo vi /var/lib/boot2docker/profile # should only contain DOCKER_TLS=no
+```console
+# ssh to boot2docker from host machine (OSX)
+boot2docker up
+boot2docker ssh
 
-  # exit from boot2docker vm
-  exit
+# add DOCKER_TLS=no
+sudo vi /var/lib/boot2docker/profile # should only contain DOCKER_TLS=no
 
-  # restart the boot2docker vm
-  boot2docker restart
-  ```
+# exit from boot2docker vm
+exit
+
+# restart the boot2docker vm
+boot2docker restart
+```
 
 2. Set the docker environment variables on the host machine
-  ```console
-  eval "$(boot2docker shellinit)"
-  ```
+
+```console
+eval "$(boot2docker shellinit)"
+```
 
 ## Deleting an Empire CloudFormation stack
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,13 +1,6 @@
 # Empire :: Troubleshooting
 
-1. [Overview](./index.md)
-2. [Installing](./installing.md)
-3. [Using](./using.md)
-4. [Administering](./administering.md) **TODO**
-5. [Troubleshooting](./troubleshooting.md)
-6. [Roadmap](./roadmap.md) **TODO**
-
-### x509: certificate signed by unknown authority with docker-compose
+## x509: certificate signed by unknown authority with docker-compose
 
 If you are encountering this error with using docker-compose and boot2docker,
 you need to disable TLS on boot2docker. Here is how to do so:
@@ -33,7 +26,7 @@ you need to disable TLS on boot2docker. Here is how to do so:
   eval "$(boot2docker shellinit)"
   ```
 
-### Deleting an Empire CloudFormation stack
+## Deleting an Empire CloudFormation stack
 
 If you've created an Empire CloudFormation stack and deployed an app to it, you have created an ECS Service with an attached ELB inside the VPC of your Empire stack. Before you can delete the stack, you must no longer have any services or ELBs running inside of it. You can do this by running `emp destroy <app>` for each app in your Empire cluster.
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -1,12 +1,5 @@
 # Empire :: Using
 
-1. [Overview](./index.md)
-2. [Installing](./installing.md)
-3. [Using](./using.md)
-4. [Administering](./administering.md) **TODO**
-5. [Troubleshooting](./troubleshooting.md)
-6. [Roadmap](./roadmap.md) **TODO**
-
 Going forward from the [installing](./installing.md) guide, the first thing we'll need to do is tell the empire client where it can find the empire API. The *bootstrap* command should have printed that out for you, so make sure you've set it in your environment like so:
 
 ```


### PR DESCRIPTION
Also remove ToC on each page, since readthedocs handles that in a much
better way.