### PR TITLE
Create an empty ~/.dockercfg if one isn't present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ If you want to contribute to Empire, you may end up wanting to run a local insta
    ```console
    $ docker-compose up
    ```
+
+   **NOTE**: You might need to run this twice the first time you start it up, to give the postgres container time to initialize.
 6. Install the emp CLI.
 
    ```console

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -98,6 +98,10 @@ then
   echo "$ export EMPIRE_API_URL=http://$(output ELBDNSName)/"
   echo "$ emp login"
 else
+  if [ ! -e ~/.dockercfg ]; then
+    echo '{}' > ~/.dockercfg
+  fi
+
   echo "==> Dumping stack info into .env for devmode."
   echo "AWS_REGION=$AWS_DEFAULT_REGION" > .env
   echo "AWS_ACCESS_KEY_ID=$(output AccessKeyId)" >> .env

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -99,6 +99,7 @@ then
   echo "$ emp login"
 else
   if [ ! -e ~/.dockercfg ]; then
+    echo "==> ~/.dockercfg not found. Creating."
     echo '{}' > ~/.dockercfg
   fi
 


### PR DESCRIPTION
I originally wanted to change `bin/bootstrap` to be more like [this](https://github.com/remind101/empire/compare/docker-auth) and just use ~/.dockercfg if provided, but the AWS CLI [doesn't really like JSON](https://github.com/aws/aws-cli/issues/1400). Maybe I'm doing something blatantly wrong.

Closes https://github.com/remind101/empire/issues/537