### PR TITLE
No need to disable TLS in boot2docker anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,6 @@ If you want to contribute to Empire, you may end up wanting to run a local insta
    $ boot2docker start
    $ $(boot2docker shellinit)
    ```
-
-   You should ensure that you've configured boot2docker to disable TLS. Refer to the [disabling boot2docker tls](http://empire.readthedocs.org/en/latest/troubleshooting/#x509-certificate-signed-by-unknown-authority-with-docker-compose) docs in the troubleshooting guide.
-
 4. Run the bootstrap script, which will create a cloudformation stack, ecs cluster and populate a .env file:
 
    ```console

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ server:
     - "8080:8080"
   volumes:
     - ~/.dockercfg:/root/.dockercfg
-    - /var/lib/boot2docker/tls:/root/certs
+    - "$DOCKER_CERT_PATH:/root/certs:ro"
   env_file: .env
   user: root
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,13 @@ server:
     - "8080:8080"
   volumes:
     - ~/.dockercfg:/root/.dockercfg
+    - /var/lib/boot2docker/tls:/root/certs
   env_file: .env
   user: root
   environment:
     EMPIRE_DATABASE_URL: postgres://postgres:postgres@postgres/postgres?sslmode=disable
     DOCKER_HOST:
+    DOCKER_CERT_PATH: /root/certs
 postgres:
   image: postgres
   ports:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,33 +1,5 @@
 # Empire :: Troubleshooting
 
-## x509: certificate signed by unknown authority with docker-compose
-
-If you are encountering this error with using docker-compose and boot2docker,
-you need to disable TLS on boot2docker. Here is how to do so:
-
-1. Set DOCKER_TLS in boot2docker VM
-
-```console
-# ssh to boot2docker from host machine (OSX)
-boot2docker up
-boot2docker ssh
-
-# add DOCKER_TLS=no
-sudo vi /var/lib/boot2docker/profile # should only contain DOCKER_TLS=no
-
-# exit from boot2docker vm
-exit
-
-# restart the boot2docker vm
-boot2docker restart
-```
-
-2. Set the docker environment variables on the host machine
-
-```console
-eval "$(boot2docker shellinit)"
-```
-
 ## Deleting an Empire CloudFormation stack
 
 If you've created an Empire CloudFormation stack and deployed an app to it, you have created an ECS Service with an attached ELB inside the VPC of your Empire stack. Before you can delete the stack, you must no longer have any services or ELBs running inside of it. You can do this by running `emp destroy <app>` for each app in your Empire cluster.

--- a/empire/docker.go
+++ b/empire/docker.go
@@ -7,7 +7,7 @@ func newDockerClient(socket, certPath string) (*docker.Client, error) {
 	if certPath != "" {
 		cert := certPath + "/cert.pem"
 		key := certPath + "/key.pem"
-		ca := ""
+		ca := certPath + "/ca.pem"
 		return docker.NewTLSClient(socket, cert, key, ca)
 	}
 


### PR DESCRIPTION
This fixes #505 . Before this, we would use the docker.NewClient, instead of docker.NewTLSClient,
since no certPath was provided. Also we now provides the path to the `ca.pem`.