### PR TITLE
GitHub Enterprise support.

### DIFF
--- a/empire/cmd/empire/main.go
+++ b/empire/cmd/empire/main.go
@@ -21,6 +21,7 @@ const (
 	FlagGithubClient = "github.client.id"
 	FlagGithubSecret = "github.client.secret"
 	FlagGithubOrg    = "github.organization"
+	FlagGithubApiURL = "github.api.url"
 
 	FlagDBPath = "path"
 	FlagDB     = "db"
@@ -80,6 +81,12 @@ var Commands = []cli.Command{
 				Value:  "",
 				Usage:  "The organization to allow access to",
 				EnvVar: "EMPIRE_GITHUB_ORGANIZATION",
+			},
+			cli.StringFlag{
+				Name:   FlagGithubApiURL,
+				Value:  "",
+				Usage:  "The URL to use when talking to GitHub.",
+				EnvVar: "EMPIRE_GITHUB_API_URL",
 			},
 		}, append(EmpireFlags, DBFlags...)...),
 		Action: runServer,

--- a/empire/cmd/empire/server.go
+++ b/empire/cmd/empire/server.go
@@ -31,6 +31,7 @@ func newServer(c *cli.Context, e *empire.Empire) http.Handler {
 	opts.GitHub.ClientID = c.String(FlagGithubClient)
 	opts.GitHub.ClientSecret = c.String(FlagGithubSecret)
 	opts.GitHub.Organization = c.String(FlagGithubOrg)
+	opts.GitHub.ApiURL = c.String(FlagGithubApiURL)
 
 	return server.New(e, opts)
 }

--- a/empire/server/authorization/github/github.go
+++ b/empire/server/authorization/github/github.go
@@ -22,6 +22,9 @@ type Authorizer struct {
 	// organization.
 	Organization string
 
+	// The oauth application URL.
+	ApiURL string
+
 	client interface {
 		CreateAuthorization(CreateAuthorizationOpts) (*Authorization, error)
 		GetUser(token string) (*User, error)
@@ -32,7 +35,9 @@ type Authorizer struct {
 func (a *Authorizer) Authorize(username, password, twofactor string) (*empire.User, error) {
 	c := a.client
 	if c == nil {
-		c = &Client{}
+		c = &Client{
+			URL: a.ApiURL,
+		}
 	}
 
 	auth, err := c.CreateAuthorization(CreateAuthorizationOpts{

--- a/empire/server/server.go
+++ b/empire/server/server.go
@@ -28,6 +28,7 @@ type Options struct {
 		ClientID     string
 		ClientSecret string
 		Organization string
+		ApiURL       string
 	}
 }
 
@@ -38,6 +39,7 @@ func New(e *empire.Empire, options Options) http.Handler {
 		options.GitHub.ClientID,
 		options.GitHub.ClientSecret,
 		options.GitHub.Organization,
+		options.GitHub.ApiURL,
 	)
 
 	// Mount the heroku api
@@ -82,7 +84,7 @@ func (h *HealthHandler) ServeHTTPContext(_ context.Context, w http.ResponseWrite
 // NewAuthorizer returns a new Authorizer. If the client id is present, it will
 // return a real Authorizer that talks to GitHub. If an empty string is
 // provided, then it will just return a fake authorizer.
-func NewAuthorizer(clientID, clientSecret, organization string) authorization.Authorizer {
+func NewAuthorizer(clientID, clientSecret, organization string, apiURL string) authorization.Authorizer {
 	if clientID == "" {
 		return &authorization.Fake{}
 	}
@@ -92,5 +94,6 @@ func NewAuthorizer(clientID, clientSecret, organization string) authorization.Au
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Organization: organization,
+		ApiURL:       apiURL,
 	}
 }


### PR DESCRIPTION
Closes #547.

Adds EMPIRE_GITHUB_API_URL option. Should be set to something like

https://your-github-enterprise.com/api/v3