### PR TITLE
Implement Run for ECS.

### DIFF
--- a/pkg/ecsutil/ecs.go
+++ b/pkg/ecsutil/ecs.go
@@ -27,6 +27,7 @@ type ECS interface {
 	ListTasks(context.Context, *ecs.ListTasksInput) (*ecs.ListTasksOutput, error)
 	StopTask(context.Context, *ecs.StopTaskInput) (*ecs.StopTaskOutput, error)
 	DescribeTasks(context.Context, *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
+	RunTask(context.Context, *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
 }
 
 // newECSClient builds a new ECS client with autopagination and tracing.
@@ -120,6 +121,13 @@ func (c *ecsClient) StopTask(ctx context.Context, input *ecs.StopTaskInput) (*ec
 	ctx, done := trace.Trace(ctx)
 	resp, err := c.ECS.StopTask(input)
 	done(err, "StopTask", "task", stringField(input.Task))
+	return resp, err
+}
+
+func (c *ecsClient) RunTask(ctx context.Context, input *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
+	ctx, done := trace.Trace(ctx)
+	resp, err := c.ECS.RunTask(input)
+	done(err, "RunTask", "task-definition", stringField(input.TaskDefinition))
 	return resp, err
 }
 

--- a/pkg/service/ecs.go
+++ b/pkg/service/ecs.go
@@ -288,17 +288,22 @@ func (m *ecsProcessManager) CreateProcess(ctx context.Context, app *App, p *Proc
 	return err
 }
 
-func (m *ecsProcessManager) Run(ctx context.Context, app *App, process *Process, in io.Reader, out io.Writer) error {
-	attachment := "detached"
+func (m *ecsProcessManager) Run(ctx context.Context, app *App, p *Process, in io.Reader, out io.Writer) error {
 	if out != nil {
-		attachment = "attached"
+		return fmt.Errorf("running an attached process is not implemented by the ECS manager.")
 	}
-	// TODO(ejholmes): Actually implement this. We could have the ECS
-	// manager handle the lifecycle of "detached" processes which don't have
-	// their stdin, stdout and stderr attached. It would be nice if we can
-	// eventually remove the "runner" package and have both attached and
-	// detached processes run via ECS.
-	return fmt.Errorf("running a %s process is not implemented by the ECS manager.", attachment)
+
+	td, err := m.createTaskDefinition(ctx, app, p)
+	if err != nil {
+		return err
+	}
+
+	_, err = m.ecs.RunTask(ctx, &ecs.RunTaskInput{
+		Cluster:        aws.String(m.cluster),
+		Count:          aws.Long(1),
+		TaskDefinition: aws.String(fmt.Sprintf("%s:%d", *td.Family, *td.Revision)),
+	})
+	return err
 }
 
 // createTaskDefinition creates a Task Definition in ECS for the service.


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/570

This implements detached runs using the ECS `RunTask` api. I probably won't merge this until we have a solution for showing one off tasks like this within `emp ps`.