### PR TITLE
Fix CFN template for ECS Service to depend on policy and role.

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -534,7 +534,7 @@
     "Service": {
       "Type" : "AWS::ECS::Service",
       "Condition": "DemoMode",
-      "DependsOn": "Cluster",
+      "DependsOn": ["Cluster","ServiceRole","ServiceRolePolicies"],
       "Properties" : {
         "Cluster" : { "Ref": "Cluster" },
         "DesiredCount" : 1,


### PR DESCRIPTION
Not having the ECS::Service resource depend on Roles and Permissions required
would result in not being able to delete the stack as the Role gets deleted
before the Service and you end up with the error "Service did not stabilize".