### PR TITLE
Faster docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM golang:1.4.2
 MAINTAINER Eric Holmes <eric@remind101.com>
 
+LABEL version 0.9.0
+
+RUN go get github.com/tools/godep
 ADD . /go/src/github.com/remind101/empire
 WORKDIR /go/src/github.com/remind101/empire
-RUN go get github.com/tools/godep && godep go install ./cmd/empire
-
-LABEL version 0.9.0
+RUN godep go install ./cmd/empire
 
 ENTRYPOINT ["/go/bin/empire"]
 CMD ["server"]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ bootstrap: cmd
 	./build/empire migrate
 
 build: Dockerfile
-	docker build --no-cache -t ${REPO} .
+	docker build -t ${REPO} .
 
 test:
 	godep go test ./... && godep go vet ./...


### PR DESCRIPTION
Installing godep is the most time consuming part of building. Moving it up makes it cacheable and makes `docker-compose build` without the `--no-cache` flag work as expected.