### PR TITLE
Add a button to create an empire stack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Empire
 
+[![Install](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#cstack=sn%7Eempire%7Cturl%7Ehttps://s3.amazonaws.com/empirepaas/cloudformation.json)
+
 [![readthedocs badge](https://readthedocs.org/projects/pip/badge/?version=latest)](http://empire.readthedocs.org/en/latest/) [![Circle CI](https://circleci.com/gh/remind101/empire.svg?style=svg)](https://circleci.com/gh/remind101/empire)
 
 Empire is a control layer on top of [Amazon EC2 Container Service (ECS)][ecs] that provides a Heroku like workflow. It conforms to a subset of the [Heroku Platform API][heroku-api], which means you can use the same tools and processes that you use with Heroku, but with all the power of EC2 and [Docker][docker].


### PR DESCRIPTION
Adds a clouformation stack installation button to the readme.

We should followup with a script to automatically upload the cloudformation.json to the s3 bucket for the master branch. The parameters could probably also use some better descriptions for this mode to be more friendly.