### PR TITLE
Default to port 80.

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -16,7 +16,7 @@
     },
     "KeyName": {
       "Type": "AWS::EC2::KeyPair::KeyName",
-      "Description": "The name of the key pair to use to allow SSH access."
+      "Description": "The name of the key pair to use to allow SSH access. If you have not already created a key pair, you can find more information at http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html."
     },
     "DockerRegistry": {
       "Type": "String",

--- a/empire.go
+++ b/empire.go
@@ -28,7 +28,7 @@ var (
 
 const (
 	// WebPort is the default PORT to set on web processes.
-	WebPort = 8080
+	WebPort = 80
 
 	// WebProcessType is the process type we assume are web server processes.
 	WebProcessType = "web"


### PR DESCRIPTION
So, the reason I'm thinking this would be a good idea is that it makes deploying containers that don't respect $PORT easier. This would mostly be an optimization for new comers.

For example, deploying the official `nginx` container would be possible after this change, which would be a pretty slick experience imo:

```
$ emp deploy nginx
$ open http://nginx-elb # default "nginx is installed page"
```

If we did merge this, we'd have to check a couple of our own applications. I know we have a few that currently make the assumption to bind to 8080.