### PR TITLE
Use ELB defaults in example CloudFormation stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Updated demo to support private registries other than the official registry #528.
 * General updates to documentation.
+* Changed ELB health check thresholds to follow AWS defaults.
 
 ## 0.9.0 (2015-06-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Updated demo to support private registries other than the official registry #528.
 * General updates to documentation.
-* Changed ELB health check thresholds to follow AWS defaults.
+* Changed ELB health check thresholds in example CloudFormation stack to follow AWS defaults.
 
 ## 0.9.0 (2015-06-16)
 

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -244,8 +244,8 @@
         ],
         "HealthCheck": {
           "Target": "HTTP:8080/health",
-          "HealthyThreshold": "2",
-          "UnhealthyThreshold": "10",
+          "HealthyThreshold": "10",
+          "UnhealthyThreshold": "2",
           "Interval": "30",
           "Timeout": "5"
         }


### PR DESCRIPTION
We've just discovered (courtesy of @tmichel) that the example CloudFormation stack that pulls up an Empire cluster in AWS has the ELB healthy and unhealthy thresholds swapped compared to the ELB defaults.

While a super minor issue, the consequence is that the ELBs that Empire creates and its own ELB are not consistent in their health check behavior. We're big fans of consistency and also think that the EC2 defaults, while quite pessimistic, make a lot of sense:

 * You want to get rid of unhealthy instances as quickly as possible
 * You want to think twice (or in this case, ten times) before you reintroduce an instance as healthy

So here's our first admittedly small contribution to Empire. We actually have quite a few ideas and things in the pipeline so we plan to send more PRs your way.

Thanks for open sourcing Empire.

The @sspinc team

PS Do you guys hang out on Slack/IRC/HipChat somewhere?