### PR TITLE
Don't wait for container to stop if the client disconnects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * Implemented support for attached one-off commands #568
 
+**Bugs**
+
+* Fixes a bug that caused containers launched by one-off tasks to stay around if the client disconnected. #589
+
 ## 0.9.0 (2015-06-16)
 
 Initial public release


### PR DESCRIPTION
This fixes https://github.com/remind101/empire/issues/587. Turns out, a lot of what I was doing previously is unnecessary. `AttachToContainer` will block while the `Read`'ing from the connection doesn't return io.EOF, so there's no need to `WaitContainer`. At that point in time, the container is already stopped because it exited, so there's no need to stop the container and we can just remove it.

If the user `killall emp`'s then the container will still be removed because the connection closes and returns io.EOF.
