### PR TITLE
Change data type of `memory` column to bigint.

### DIFF
--- a/migrations/0010_memory_bigint.down.sql
+++ b/migrations/0010_memory_bigint.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE processes ALTER COLUMN memory TYPE integer;

--- a/migrations/0010_memory_bigint.up.sql
+++ b/migrations/0010_memory_bigint.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE processes ALTER COLUMN memory TYPE bigint;

--- a/tests/cli/scale_test.go
+++ b/tests/cli/scale_test.go
@@ -31,3 +31,21 @@ v1.web.2  1X  running   5d  "./bin/web"`,
 		},
 	})
 }
+
+func TestScale_Constraints(t *testing.T) {
+	run(t, []Command{
+		DeployCommand("latest", "v1"),
+		{
+			"scale web=2:256:1GB -a acme-inc",
+			"Scaled acme-inc to web=2:256:1.00gb.",
+		},
+		{
+			"scale web=2:256:6GB -a acme-inc",
+			"Scaled acme-inc to web=2:256:6.00gb.",
+		},
+		{
+			"scale web=2:256:600GB -a acme-inc",
+			"Scaled acme-inc to web=2:256:600.00gb.",
+		},
+	})
+}


### PR DESCRIPTION
Turns out we can't scale past 1GB! I guess we could store in mb since we don't need that much resolution, but this should do.