### PR TITLE
Make `make test` depend on build/emp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,19 @@ TYPE = patch
 cmd:
 	godep go build -o build/empire ./cmd/empire
 
-bootstrap: cmd
-	go get github.com/remind101/emp
-	go build -o build/emp github.com/remind101/emp # Vendor the emp command for tests
+bootstrap: cmd build/emp
 	createdb empire
 	./build/empire migrate
 
 build: Dockerfile
 	docker build -t ${REPO} .
 
-test:
+test: build/emp
 	godep go test ./... && godep go vet ./...
+
+build/emp:
+	go get github.com/remind101/emp
+	go build -o build/emp github.com/remind101/emp # Vendor the emp command for tests
 
 bump:
 	pip install --upgrade bumpversion


### PR DESCRIPTION
Otherwise, tests can fail in a non-obvious way.