### PR TITLE
Store release creator.

### DIFF
--- a/deployments.go
+++ b/deployments.go
@@ -85,10 +85,16 @@ func (s *deployerService) Deploy(ctx context.Context, opts DeploymentsCreateOpts
 	// and Slug.
 	desc := fmt.Sprintf("Deploy %s", img.String())
 
+	var creator string
+	if opts.User != nil {
+		creator = opts.User.Name
+	}
+
 	r, err := s.ReleasesCreate(ctx, &Release{
 		App:         app,
 		Config:      config,
 		Slug:        slug,
+		Creator:     creator,
 		Description: desc,
 	})
 

--- a/migrations/0011_add_creator_column.down.sql
+++ b/migrations/0011_add_creator_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE releases DROP COLUMN creator;

--- a/migrations/0011_add_creator_column.up.sql
+++ b/migrations/0011_add_creator_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE releases ADD COLUMN creator text;

--- a/releases.go
+++ b/releases.go
@@ -27,6 +27,7 @@ type Release struct {
 
 	Processes []*Process
 
+	Creator     string
 	Description string
 	CreatedAt   *time.Time
 }

--- a/server/heroku/releases.go
+++ b/server/heroku/releases.go
@@ -21,6 +21,12 @@ func newRelease(r *empire.Release) *Release {
 		}{
 			Id: r.SlugID,
 		},
+		User: struct {
+			Id    string `json:"id"`
+			Email string `json:"email"`
+		}{
+			Email: r.Creator,
+		},
 		Description: r.Description,
 		CreatedAt:   *r.CreatedAt,
 	}


### PR DESCRIPTION
With this change, the user that created the release will be displayed in the CLI output for `emp releases`:


```console
$ emp releases -a nginx                                                                           v1        Jul 23 11:15  Deploy nginx:latest
v1  ejholmes  Jul 23 11:44  Deploy nginx:latest
```

This is kinda a shitty, mvp version. Really, we should have a `user_id` column on releases with a `users` table.


After https://github.com/remind101/tugboat/pull/38, I'll `godep update` and the deployer will be tracked in tugboat as well.

**TODO**

* [ ] Pass the use down when updating config.