### PR TITLE
Send a periodic heartbeat to keep the connection alive.

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -58,7 +58,7 @@ func (r *Runner) Run(ctx context.Context, opts RunOpts) error {
 	defer r.remove(ctx, c.ID)
 
 	if err := r.start(ctx, c.ID); err != nil {
-		return fmt.Errorf("runner: start containeer: %v", err)
+		return fmt.Errorf("runner: start container: %v", err)
 	}
 	defer tryClose(opts.Output)
 

--- a/pkg/stream/http/http.go
+++ b/pkg/stream/http/http.go
@@ -3,8 +3,10 @@ package http
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
 
 // ResponseWriter provides an implementation of the http.ResponseWriter
@@ -59,4 +61,26 @@ func (fw *flushWriter) Write(p []byte) (n int, err error) {
 		fw.f.Flush()
 	}
 	return
+}
+
+// Heartbeat sends the null character periodically, to keep the connection alive.
+func Heartbeat(outStream io.Writer, interval time.Duration) chan struct{} {
+	stop := make(chan struct{})
+	t := time.NewTicker(interval)
+
+	go func() {
+		for {
+			select {
+			case <-t.C:
+				fmt.Fprintf(outStream, "\x00")
+				continue
+			case <-stop:
+				t.Stop()
+				return
+			}
+			break
+		}
+	}()
+
+	return stop
 }

--- a/pkg/stream/http/http.go
+++ b/pkg/stream/http/http.go
@@ -78,7 +78,6 @@ func Heartbeat(outStream io.Writer, interval time.Duration) chan struct{} {
 				t.Stop()
 				return
 			}
-			break
 		}
 	}()
 

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 
 	"github.com/bgentry/heroku-go"
 	"github.com/remind101/empire"
@@ -90,6 +91,13 @@ func (h *PostProcess) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 		defer closeStreams(inStream, outStream)
 
 		fmt.Fprintf(outStream, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.empire.raw-stream\r\n\r\n")
+
+		go func() {
+			for {
+				fmt.Fprintf(outStream, "\x00")
+				runtime.Gosched()
+			}
+		}()
 
 		opts.Input = inStream
 		opts.Output = outStream

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -92,6 +92,8 @@ func (h *PostProcess) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 
 		fmt.Fprintf(outStream, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.empire.raw-stream\r\n\r\n")
 
+		// We send the null character periodically, to keep the connection alive.
+		// Otherwise the connection would close after the ELB idle connection timeout.
 		go func() {
 			for {
 				fmt.Fprintf(outStream, "\x00")


### PR DESCRIPTION
 Fix for #599 

Maybe we want to reduce the frequency to something < 60s? We can do this:

```golang
ticker := time.NewTicker(30 * time.Second)
go func() {
	for {
		select {
		case <-ticker.C:
			fmt.Fprintf(outStream, "\x00")
			runtime.Gosched()
		}
	}
}()
```

Can also put that into its own function.