### PR TITLE
Fix scope of ReleasesQuery when the Range header is not present.

### DIFF
--- a/pkg/headerutil/headerutil.go
+++ b/pkg/headerutil/headerutil.go
@@ -46,3 +46,27 @@ func ParseRange(header string) (*Range, error) {
 
 	return &rangeHeader, nil
 }
+
+// WithDefaults returns a new Range instance with the defaults taken from d.
+func (r *Range) WithDefaults(d Range) Range {
+	if r == nil {
+		return d
+	}
+
+	// Make a copy.
+	c := *r
+
+	if c.Max == nil {
+		c.Max = d.Max
+	}
+
+	if c.Sort == nil {
+		c.Sort = d.Sort
+	}
+
+	if c.Order == nil {
+		c.Order = d.Order
+	}
+
+	return c
+}

--- a/releases.go
+++ b/releases.go
@@ -74,6 +74,8 @@ func (q ReleasesQuery) Scope(db *gorm.DB) *gorm.DB {
 
 	if r := q.Range; r != nil {
 		scope = append(scope, Range(r))
+	} else {
+		scope = append(scope, Order("version desc"))
 	}
 
 	// Preload all the things.

--- a/releases_test.go
+++ b/releases_test.go
@@ -22,7 +22,7 @@ func TestReleasesQuery(t *testing.T) {
 	}
 
 	tests := scopeTests{
-		{ReleasesQuery{}, "", []interface{}{}},
+		{ReleasesQuery{}, "ORDER BY version desc", []interface{}{}},
 		{ReleasesQuery{Range: rangeHeader}, "ORDER BY version desc LIMIT 20", []interface{}{}},
 		{ReleasesQuery{App: app, Range: rangeHeader}, "WHERE (app_id = $1) ORDER BY version desc LIMIT 20", []interface{}{"1234"}},
 		{ReleasesQuery{Version: &version, Range: rangeHeader}, "WHERE (version = $1) ORDER BY version desc LIMIT 20", []interface{}{1}},

--- a/releases_test.go
+++ b/releases_test.go
@@ -15,7 +15,7 @@ func TestReleasesQuery(t *testing.T) {
 		order   = "desc"
 	)
 
-	rangeHeader := &headerutil.Range{
+	rangeHeader := headerutil.Range{
 		Sort:  &sort,
 		Max:   &max,
 		Order: &order,

--- a/server/heroku/heroku.go
+++ b/server/heroku/heroku.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/remind101/empire"
+	"github.com/remind101/empire/pkg/headerutil"
 	"github.com/remind101/empire/server/authorization"
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/httpx/middleware"
@@ -118,4 +119,18 @@ func Error(w http.ResponseWriter, err error, status int) error {
 func NoContent(w http.ResponseWriter) error {
 	w.WriteHeader(http.StatusNoContent)
 	return nil
+}
+
+// RangeHeader parses the Range header and returns an headerutil.Range.
+func RangeHeader(r *http.Request) (headerutil.Range, error) {
+	header := r.Header.Get("Range")
+	if header == "" {
+		return headerutil.Range{}, nil
+	}
+
+	rangeHeader, err := headerutil.ParseRange(header)
+	if err != nil {
+		return headerutil.Range{}, err
+	}
+	return *rangeHeader, nil
 }

--- a/server/heroku/releases.go
+++ b/server/heroku/releases.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/bgentry/heroku-go"
 	"github.com/remind101/empire"
-	"github.com/remind101/empire/pkg/headerutil"
 	"github.com/remind101/pkg/httpx"
 	"golang.org/x/net/context"
 )
@@ -72,12 +71,9 @@ func (h *GetReleases) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
-	var rangeHeader *headerutil.Range
-	if header := r.Header.Get("Range"); header != "" {
-		rangeHeader, err = headerutil.ParseRange(header)
-		if err != nil {
-			return err
-		}
+	rangeHeader, err := RangeHeader(r)
+	if err != nil {
+		return err
 	}
 
 	rels, err := h.Releases(empire.ReleasesQuery{App: a, Range: rangeHeader})

--- a/store.go
+++ b/store.go
@@ -85,15 +85,15 @@ func Limit(limit int) Scope {
 }
 
 // Range returns a Scope that limits and orders the results.
-func Range(r *headerutil.Range) Scope {
+func Range(r headerutil.Range) Scope {
 	var scope ComposedScope
 
-	if max := r.Max; max != nil {
-		scope = append(scope, Limit(*max))
+	if r.Max != nil {
+		scope = append(scope, Limit(*r.Max))
 	}
 
-	if sort := r.Sort; sort != nil {
-		order := fmt.Sprintf("%s %s", *sort, *(r.Order))
+	if r.Sort != nil && r.Order != nil {
+		order := fmt.Sprintf("%s %s", *r.Sort, *r.Order)
 		scope = append(scope, Order(order))
 	}
 


### PR DESCRIPTION
A lot of things depend of ReleasesQuery returning the last release (order by `version desc`) by default. Including `ReleasesFirst` which is a bit weird since it's technically returning the last release.

Anyway, this behavior was broken everytime the Range header was missing (i.e almost always).