### PR TITLE
Store registry along with repo to the app configuration

### DIFF
--- a/deployments.go
+++ b/deployments.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/remind101/empire/pkg/image"
@@ -52,19 +53,20 @@ type deployerService struct {
 // DeploymentsDo performs the Deployment.
 func (s *deployerService) Deploy(ctx context.Context, opts DeploymentsCreateOpts) (*Release, error) {
 	app, img := opts.App, opts.Image
+	repo := strings.Join([]string{img.Registry, img.Repository}, "/")
 
 	// If no app is specified, attempt to find the app that relates to this
 	// images repository, or create it if not found.
 	if app == nil {
 		var err error
-		app, err = s.appsService.AppsFindOrCreateByRepo(img.Repository)
+		app, err = s.appsService.AppsFindOrCreateByRepo(repo)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		// If the app doesn't already have a repo attached to it, we'll attach
 		// this image's repo.
-		if err := s.appsService.AppsEnsureRepo(app, img.Repository); err != nil {
+		if err := s.appsService.AppsEnsureRepo(app, repo); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/dockerutil/client.go
+++ b/pkg/dockerutil/client.go
@@ -1,6 +1,7 @@
 package dockerutil
 
 import (
+	"log"
 	"os"
 
 	"golang.org/x/net/context"
@@ -67,7 +68,7 @@ func (c *Client) PullImage(ctx context.Context, opts docker.PullImageOptions) er
 	var a docker.AuthConfiguration
 
 	reg := opts.Registry
-
+	log.Printf("registry: %s", reg)
 	if reg == "" {
 		reg = "https://index.docker.io/v1/"
 	}


### PR DESCRIPTION
We need to store full repo including registry in order to be able to pull correct image.