### PR TITLE
Bind mount docker socket.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,12 @@ server:
     - "8080:8080"
   volumes:
     - ~/.dockercfg:/root/.dockercfg
-    - "$DOCKER_CERT_PATH:/root/certs:ro"
+    - "/var/run/docker.sock:/var/run/docker.sock"
   env_file: .env
   user: root
   environment:
     EMPIRE_DATABASE_URL: postgres://postgres:postgres@postgres/postgres?sslmode=disable
-    DOCKER_HOST:
-    DOCKER_CERT_PATH: /root/certs
+    DOCKER_HOST: unix:///var/run/docker.sock
 postgres:
   image: postgres
   ports:


### PR DESCRIPTION
This is simpler and works on linux and boot2docker.