### PR TITLE
Exit LoadBalancers loop when there are no more returned

### DIFF
--- a/pkg/lb/elb.go
+++ b/pkg/lb/elb.go
@@ -125,7 +125,7 @@ func (m *ELBManager) LoadBalancers(ctx context.Context, tags map[string]string) 
 		}
 
 		if len(out.LoadBalancerDescriptions) == 0 {
-			continue
+			break
 		}
 
 		// Create a names slice and descriptions map.

--- a/pkg/lb/elb_test.go
+++ b/pkg/lb/elb_test.go
@@ -266,6 +266,35 @@ func TestELB_LoadBalancers(t *testing.T) {
 	}
 }
 
+func TestELB_EmptyLoadBalancers(t *testing.T) {
+	h := awsutil.NewHandler([]awsutil.Cycle{
+		{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Body:       `Action=DescribeLoadBalancers&PageSize=20&Version=2012-06-01`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body: `<DescribeLoadBalancersResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
+	  <DescribeLoadBalancersResult>
+	    <LoadBalancerDescriptions/>
+	  </DescribeLoadBalancersResult>
+	</DescribeLoadBalancersResponse>`,
+			},
+		},
+	})
+	m, s := newTestELBManager(h)
+	defer s.Close()
+
+	lbs, err := m.LoadBalancers(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(lbs), 0; got != want {
+		t.Fatalf("%v load balancers; want %v", got, want)
+	}
+}
+
 func TestELBwDNS_DestroyLoadBalancer(t *testing.T) {
 	m, s, lb := buildLoadBalancerForDestroy()
 	defer s.Close()


### PR DESCRIPTION
This was causing an infinite loop polling the AWS API when
there were no ELB's running in the region.