### PR TITLE
Trace empire deployer.

### DIFF
--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -22,7 +22,7 @@ type deployer interface {
 // depending on the options.
 func newDeployer(e *empire.Empire, opts Options) deployer {
 	var d deployer
-	d = newEmpireDeployer(e, opts.ImageTemplate)
+	d = &tracedDeployer{newEmpireDeployer(e, opts.ImageTemplate)}
 	d = &prettyDeployer{deployer: d}
 
 	if opts.TugboatURL != "" {


### PR DESCRIPTION
I'm seeing https://app.honeybadger.io/projects/43058/faults/14165058 occasionally, which isn't very helpful because the error is overridden by [tugboat.ErrFailed](https://github.com/remind101/empire/blob/792c4e7fb74005f85d15fb3253a0f4e940122fbb/server/github/deployer.go#L125). This should trace the original error as well.