### PR TITLE
The step of manually deleting the ECS service is no longer required.

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,7 +3,3 @@
 ## Deleting an Empire CloudFormation stack
 
 If you've created an Empire CloudFormation stack and deployed an app to it, you have created an ECS Service with an attached ELB inside the VPC of your Empire stack. Before you can delete the stack, you must no longer have any services or ELBs running inside of it. You can do this by running `emp destroy <app>` for each app in your Empire cluster.
-
-Additionally, you must [manually delete][deletingaservice] the Empire ECS Service in the Amazon console. After that, make sure you've deleted the ELB associated with the service as well. Once all dependent ECS Services and ELBs have removed from the VPC of Empire stack, you should be able to delete the stack from the CloudFormation console.
-
-[deletingaservice]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/delete-service.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,8 +23,8 @@ pages:
     - "Contribution Guidelines & Bug Reporting": "contributing.md"
     - "Reporting Security Vulnerabilities - TODO": "reporting_security_vulnerabilities.md"
   - Reference:
-    - "Configuration - TODO": "configuration.md"
+    - "Configuration": "configuration.md"
     - "Command Line - TODO": "command_line.md"
-    - "Troubleshooting - TODO": "troubleshooting.md"
+    - "Troubleshooting": "troubleshooting.md"
 
 


### PR DESCRIPTION
This was fixed in https://github.com/remind101/empire/pull/576.

I actually had trouble finding the uninstallation guide, we should probably put this near the installation section.