### PR TITLE
Add CrossZoneLoadBalancing to ELBs

### DIFF
--- a/pkg/lb/elb.go
+++ b/pkg/lb/elb.go
@@ -83,6 +83,9 @@ func (m *ELBManager) CreateLoadBalancer(ctx context.Context, o CreateLoadBalance
 				Enabled: aws.Boolean(true),
 				Timeout: aws.Long(defaultConnectionDrainingTimeout),
 			},
+			CrossZoneLoadBalancing: &elb.CrossZoneLoadBalancing{
+				Enabled: aws.Boolean(true),
+			},
 		},
 		LoadBalancerName: input.LoadBalancerName,
 	}); err != nil {

--- a/pkg/lb/elb_test.go
+++ b/pkg/lb/elb_test.go
@@ -30,7 +30,7 @@ func TestELB_CreateLoadBalancer(t *testing.T) {
 		{
 			Request: awsutil.Request{
 				RequestURI: "/",
-				Body:       `Action=ModifyLoadBalancerAttributes&LoadBalancerAttributes.ConnectionDraining.Enabled=true&LoadBalancerAttributes.ConnectionDraining.Timeout=30&LoadBalancerName=acme-inc&Version=2012-06-01`,
+				Body:       `Action=ModifyLoadBalancerAttributes&LoadBalancerAttributes.ConnectionDraining.Enabled=true&LoadBalancerAttributes.ConnectionDraining.Timeout=30&LoadBalancerAttributes.CrossZoneLoadBalancing.Enabled=true&LoadBalancerName=acme-inc&Version=2012-06-01`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,


### PR DESCRIPTION
This will ensure that traffic is balanced across backend containers
evenly.

http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/how-elb-works.html#request-routing

Fixes #640