### PR TITLE
Return process type in get processes endpoint

### DIFF
--- a/processes.go
+++ b/processes.go
@@ -292,6 +292,7 @@ func processesUpdate(db *gorm.DB, process *Process) error {
 // ProcessState represents the state of a Process.
 type ProcessState struct {
 	Name        string
+	Type        string
 	Command     string
 	State       string
 	UpdatedAt   time.Time
@@ -333,6 +334,7 @@ func processStateFromInstance(i *service.Instance) *ProcessState {
 
 	return &ProcessState{
 		Name:    fmt.Sprintf("%s.%s.%s", version, i.Process.Type, i.ID),
+		Type:    string(i.Process.Type),
 		Command: i.Process.Command,
 		Constraints: Constraints{
 			CPUShare: constraints.CPUShare(i.Process.CPUShares),

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -18,8 +18,9 @@ type Dyno heroku.Dyno
 
 func newDyno(j *empire.ProcessState) *Dyno {
 	return &Dyno{
-		Command:   string(j.Command),
-		Name:      string(j.Name),
+		Command:   j.Command,
+		Type:      j.Type,
+		Name:      j.Name,
 		State:     j.State,
 		Size:      j.Constraints.String(),
 		UpdatedAt: j.UpdatedAt,

--- a/tests/api/processes_test.go
+++ b/tests/api/processes_test.go
@@ -6,6 +6,34 @@ import (
 	"github.com/bgentry/heroku-go"
 )
 
+func TestProcessesGet(t *testing.T) {
+	c, s := NewTestClient(t)
+	defer s.Close()
+
+	mustDeploy(t, c, DefaultImage)
+
+	q := 1
+	mustFormationBatchUpdate(t, c, "acme-inc", []heroku.FormationBatchUpdateOpts{
+		{
+			Process:  "web",
+			Quantity: &q,
+		},
+	})
+
+	dynos, err := c.DynoList("acme-inc", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(dynos), q; got != want {
+		t.Errorf("DynoList => %d; want %d", got, want)
+	}
+
+	if got, want := dynos[0].Type, "web"; got != want {
+		t.Errorf("dyno.Type => %s; want %s", got, want)
+	}
+}
+
 func TestProcessesPost(t *testing.T) {
 	c, s := NewTestClient(t)
 	defer s.Close()


### PR DESCRIPTION
This allows me to add a `scale -l` option to the `emp` command that will query dynos and group them by type to show the current process scales.