### PR TITLE
bootstrap: set pipefail option

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -20,6 +20,7 @@ then
 fi
 
 set -e
+set -o pipefail
 
 # Set to anything other than 1 to skip launching Empire/Postgres as a service
 # in ECS (meant for development)


### PR DESCRIPTION
There are a couple of awscli calls whose results are piped.
When these calls fail, the script should immediately exit,
but without pipefail ignores the error.