### PR TITLE
Support multiple environments for Github deployments.

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -20,7 +20,7 @@ const (
 	FlagGithubApiURL       = "github.api.url"
 
 	FlagGithubWebhooksSecret           = "github.webhooks.secret"
-	FlagGithubDeploymentsEnvironment   = "github.deployments.environment"
+	FlagGithubDeploymentsEnvironments  = "github.deployments.environment"
 	FlagGithubDeploymentsImageTemplate = "github.deployments.template"
 	FlagGithubDeploymentsTugboatURL    = "github.deployments.tugboat.url"
 
@@ -105,9 +105,9 @@ var Commands = []cli.Command{
 				EnvVar: "EMPIRE_GITHUB_WEBHOOKS_SECRET",
 			},
 			cli.StringFlag{
-				Name:   FlagGithubDeploymentsEnvironment,
+				Name:   FlagGithubDeploymentsEnvironments,
 				Value:  "",
-				Usage:  "If provided, only github deployments to the specified environment will be handled.",
+				Usage:  "If provided, only github deployments to the specified environments will be handled.",
 				EnvVar: "EMPIRE_GITHUB_DEPLOYMENTS_ENVIRONMENT",
 			},
 			cli.StringFlag{

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
-
-	"golang.org/x/oauth2"
 
 	"github.com/codegangsta/cli"
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/server"
 	"github.com/remind101/empire/server/auth"
 	"github.com/remind101/empire/server/auth/github"
+	"golang.org/x/oauth2"
 )
 
 func runServer(c *cli.Context) {
@@ -36,7 +36,7 @@ func newServer(c *cli.Context, e *empire.Empire) http.Handler {
 	var opts server.Options
 	opts.Authenticator = newAuthenticator(c, e)
 	opts.GitHub.Webhooks.Secret = c.String(FlagGithubWebhooksSecret)
-	opts.GitHub.Deployments.Environment = c.String(FlagGithubDeploymentsEnvironment)
+	opts.GitHub.Deployments.Environments = strings.Split(c.String(FlagGithubDeploymentsEnvironments), ",")
 	opts.GitHub.Deployments.ImageTemplate = c.String(FlagGithubDeploymentsImageTemplate)
 	opts.GitHub.Deployments.TugboatURL = c.String(FlagGithubDeploymentsTugboatURL)
 

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -58,8 +58,8 @@ func NewServer(t testing.TB, e *empire.Empire) *httptest.Server {
 	}
 
 	server.DefaultOptions.GitHub.Webhooks.Secret = "abcd"
-	server.DefaultOptions.GitHub.Deployments.Environment = "test"
 	server.DefaultOptions.Authenticator = auth.Anyone(&empire.User{Name: "fake"})
+	server.DefaultOptions.GitHub.Deployments.Environments = []string{"test"}
 	return httptest.NewServer(server.New(e, server.DefaultOptions))
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -30,7 +30,7 @@ type Options struct {
 			Secret string
 		}
 		Deployments struct {
-			Environment   string
+			Environments  []string
 			ImageTemplate string
 			TugboatURL    string
 		}
@@ -44,7 +44,7 @@ func New(e *empire.Empire, options Options) http.Handler {
 		// Mount GitHub webhooks
 		g := github.New(e, github.Options{
 			Secret:        options.GitHub.Webhooks.Secret,
-			Environment:   options.GitHub.Deployments.Environment,
+			Environments:  options.GitHub.Deployments.Environments,
 			ImageTemplate: options.GitHub.Deployments.ImageTemplate,
 			TugboatURL:    options.GitHub.Deployments.TugboatURL,
 		})


### PR DESCRIPTION
Allow for environment aliases like `prod` for `production` for instance.