### PR TITLE
Allow floating point numbers when scaling process size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * `emp ps` now shows the correct uptime of the process thanks to ECS support [#683](https://github.com/remind101/empire/pull/683).
 
+**Bugs**
+
+* Allow floating point numbers to be provided when scaling the memory on a process [#694](https://github.com/remind101/empire/pull/694).
+
 ## 0.9.2 (2015-10-27)
 
 **Documentation**

--- a/pkg/constraints/constraints.go
+++ b/pkg/constraints/constraints.go
@@ -59,7 +59,7 @@ func ParseCPUShare(s string) (CPUShare, error) {
 }
 
 // memRegex parses the number of units from a string.
-var memRegex = regexp.MustCompile(`(\d+)(\S*)?`)
+var memRegex = regexp.MustCompile(`([\d\.]+)(\S*)?`)
 
 // Memory represents a memory limit.
 type Memory uint
@@ -116,7 +116,7 @@ func parseMemory(s string) (uint, error) {
 
 	var (
 		// n is the number part of the memory
-		n uint
+		n float64
 		// u is the units parts
 		u string
 		// mult is a number that will be used to
@@ -125,15 +125,13 @@ func parseMemory(s string) (uint, error) {
 	)
 
 	if len(p) == 0 {
-		return n, ErrInvalidMemory
+		return 0, ErrInvalidMemory
 	}
 
-	i, err := strconv.Atoi(p[1])
+	n, err := strconv.ParseFloat(p[1], 32)
 	if err != nil {
-		return n, err
+		return 0, err
 	}
-
-	n = uint(i)
 
 	if len(p) > 2 {
 		u = strings.ToUpper(p[2])
@@ -151,10 +149,10 @@ func parseMemory(s string) (uint, error) {
 	case "TB":
 		mult = TB
 	default:
-		return n, ErrInvalidMemory
+		return 0, ErrInvalidMemory
 	}
 
-	return n * mult, nil
+	return uint(n * float64(mult)), nil
 }
 
 // Constraints is a composition of CPUShares and Memory constraints.

--- a/pkg/constraints/constraints_test.go
+++ b/pkg/constraints/constraints_test.go
@@ -42,6 +42,8 @@ func TestMemory_ParseMemory(t *testing.T) {
 		{"1KB", 1024, nil},
 		{"1MB", 1048576, nil},
 		{"1GB", 1073741824, nil},
+		{"1.00GB", 1073741824, nil},
+		{"1.25GB", 1342177280, nil},
 
 		{"1kB", 1024, nil},
 		{"1kb", 1024, nil},


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/653

This allows you to provide floating point numbers for the memory portion of a process size when scaling:

```console
$ emp scale web=1:256:0.5gb -a acme-inc
Scaled acme-inc to web=1:1X.
$ emp scale web=1:256:0.9gb -a acme-inc
Scaled acme-inc to web=1:256:921.60mb.
$ emp scale web=1:256:0.95gb -a acme-inc
Scaled acme-inc to web=1:256:972.80mb.
```