### PR TITLE
Implement detached runs for ECS backend.

### DIFF
--- a/pkg/ecsutil/client_test.go
+++ b/pkg/ecsutil/client_test.go
@@ -109,6 +109,18 @@ func TestListAppTasks(t *testing.T) {
 				Body:       `{"taskArns":["arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570"]}`,
 			},
 		},
+
+		awsutil.Cycle{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Operation:  "AmazonEC2ContainerServiceV20141113.ListTasks",
+				Body:       `{"cluster":"cluster","startedBy":"ae69bb4c-3903-4844-82fe-548ac5b74570"}`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body:       `{"taskArns":[]}`,
+			},
+		},
 	})
 	m, s := newTestClient(h)
 	defer s.Close()
@@ -160,6 +172,18 @@ func TestListAppTasks_Paginate(t *testing.T) {
 			Response: awsutil.Response{
 				StatusCode: 200,
 				Body:       `{"taskArns":["arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570"]}`,
+			},
+		},
+
+		awsutil.Cycle{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Operation:  "AmazonEC2ContainerServiceV20141113.ListTasks",
+				Body:       `{"cluster":"cluster","startedBy":"ae69bb4c-3903-4844-82fe-548ac5b74570"}`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body:       `{"taskArns":[]}`,
 			},
 		},
 	})

--- a/pkg/ecsutil/ecs.go
+++ b/pkg/ecsutil/ecs.go
@@ -27,6 +27,7 @@ type ECS interface {
 	ListTasksPages(context.Context, *ecs.ListTasksInput, func(*ecs.ListTasksOutput, bool) bool) error
 	StopTask(context.Context, *ecs.StopTaskInput) (*ecs.StopTaskOutput, error)
 	DescribeTasks(context.Context, *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error)
+	RunTask(context.Context, *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
 }
 
 // newECSClient builds a new ECS client with autopagination and tracing.
@@ -124,6 +125,13 @@ func (c *ecsClient) StopTask(ctx context.Context, input *ecs.StopTaskInput) (*ec
 	ctx, done := trace.Trace(ctx)
 	resp, err := c.ECS.StopTask(input)
 	done(err, "StopTask", "task", stringField(input.Task))
+	return resp, err
+}
+
+func (c *ecsClient) RunTask(ctx context.Context, input *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
+	ctx, done := trace.Trace(ctx)
+	resp, err := c.ECS.RunTask(input)
+	done(err, "RunTask", "taskDefinition", stringField(input.TaskDefinition))
 	return resp, err
 }
 


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/570

This implements detached runs for ECS.

This is a continuation of https://github.com/remind101/empire/pull/573, with the issues presented in https://github.com/remind101/empire/pull/573#issuecomment-127304743 addressed so that detached processes show up in `emp ps`:

```console
$ emp run sleep 60 -d -a acme-inc
Ran `sleep 60` on acme-inc as run, detached.
$ emp ps -a acme-inc
v1.run.eddbb21a-1b89-4f0e-bb72-8193c54e1cb7  1X  RUNNING   3s  "sleep 60"
v1.web.907a716b-84d0-46f4-affe-616c2dc10399  1X  RUNNING   2h  "acme-inc server"
```