### PR TITLE
Allow SSL certs to be updated on ELB's in ECS backend

### DIFF
--- a/pkg/lb/elb.go
+++ b/pkg/lb/elb.go
@@ -102,6 +102,10 @@ func (m *ELBManager) CreateLoadBalancer(ctx context.Context, o CreateLoadBalance
 	}, nil
 }
 
+func (m *ELBManager) UpdateLoadBalancer(ctx context.Context, opts UpdateLoadBalancerOpts) error {
+	return nil
+}
+
 // DestroyLoadBalancer destroys an ELB.
 func (m *ELBManager) DestroyLoadBalancer(ctx context.Context, lb *LoadBalancer) error {
 	_, err := m.elb.DeleteLoadBalancer(&elb.DeleteLoadBalancerInput{

--- a/pkg/lb/elb.go
+++ b/pkg/lb/elb.go
@@ -103,7 +103,22 @@ func (m *ELBManager) CreateLoadBalancer(ctx context.Context, o CreateLoadBalance
 }
 
 func (m *ELBManager) UpdateLoadBalancer(ctx context.Context, opts UpdateLoadBalancerOpts) error {
+	if opts.SSLCert != nil {
+		if err := m.updateSSLCert(ctx, opts.Name, *opts.SSLCert); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func (m *ELBManager) updateSSLCert(ctx context.Context, name, certID string) error {
+	_, err := m.elb.SetLoadBalancerListenerSSLCertificate(&elb.SetLoadBalancerListenerSSLCertificateInput{
+		LoadBalancerName: aws.String(name),
+		LoadBalancerPort: aws.Int64(443),
+		SSLCertificateId: aws.String(certID),
+	})
+	return err
 }
 
 // DestroyLoadBalancer destroys an ELB.

--- a/pkg/lb/elb_test.go
+++ b/pkg/lb/elb_test.go
@@ -64,6 +64,33 @@ func TestELB_CreateLoadBalancer(t *testing.T) {
 	}
 }
 
+func TestELB_UpdateLoadBalancer(t *testing.T) {
+	h := awsutil.NewHandler([]awsutil.Cycle{
+		{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Body:       `Action=SetLoadBalancerListenerSSLCertificate&LoadBalancerName=loadbalancer&LoadBalancerPort=443&SSLCertificateId=newcert&Version=2012-06-01`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body: `<?xml version="1.0"?>
+<UpdateLoadBalancerResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+</UpdateLoadBalancerResponse>`,
+			},
+		},
+	})
+	m, s := newTestELBManager(h)
+	defer s.Close()
+
+	err := m.UpdateLoadBalancer(context.Background(), UpdateLoadBalancerOpts{
+		Name:    "loadbalancer",
+		SSLCert: aws.String("newcert"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func buildLoadBalancerForDestroy() (*ELBManager, *httptest.Server, *LoadBalancer) {
 	h := awsutil.NewHandler([]awsutil.Cycle{
 		{

--- a/pkg/lb/lb.go
+++ b/pkg/lb/lb.go
@@ -29,9 +29,6 @@ type UpdateLoadBalancerOpts struct {
 
 	// The SSL Certificate
 	SSLCert *string
-
-	// The port to route requests to on the hosts.
-	InstancePort *int64
 }
 
 // LoadBalancer represents a load balancer.

--- a/pkg/lb/lb.go
+++ b/pkg/lb/lb.go
@@ -21,6 +21,19 @@ type CreateLoadBalancerOpts struct {
 	SSLCert string
 }
 
+// UpdateLoadBalancerOpts are options that can be provided when updating an
+// existing load balancer.
+type UpdateLoadBalancerOpts struct {
+	// The name of the load balancer.
+	Name string
+
+	// The SSL Certificate
+	SSLCert *string
+
+	// The port to route requests to on the hosts.
+	InstancePort *int64
+}
+
 // LoadBalancer represents a load balancer.
 type LoadBalancer struct {
 	// The name of the load balancer.
@@ -48,6 +61,9 @@ type LoadBalancer struct {
 type Manager interface {
 	// CreateLoadBalancer creates a new LoadBalancer with the given options.
 	CreateLoadBalancer(context.Context, CreateLoadBalancerOpts) (*LoadBalancer, error)
+
+	// UpdateLoadBalancer updates an existing load balancer.
+	UpdateLoadBalancer(context.Context, UpdateLoadBalancerOpts) error
 
 	// DestroyLoadBalancer destroys a load balancer by name.
 	DestroyLoadBalancer(ctx context.Context, lb *LoadBalancer) error

--- a/scheduler/ecs/lb.go
+++ b/scheduler/ecs/lb.go
@@ -121,7 +121,7 @@ func (e *LoadBalancerExposureError) Error() string {
 		lbExposure = "public"
 	}
 
-	return fmt.Sprintf("Process %s is %s, but load balancer is %s.", e.proc.Type, e.proc.Exposure, lbExposure)
+	return fmt.Sprintf("Process %s is %s, but load balancer is %s. An update would require me to delete the load balancer.", e.proc.Type, e.proc.Exposure, lbExposure)
 }
 
 // LoadBalancerPortMismatchError is returned when the port stored in the data store does not match the ELB instance port

--- a/scheduler/ecs/lb_test.go
+++ b/scheduler/ecs/lb_test.go
@@ -204,14 +204,9 @@ func TestLBProcessManager_CreateProcess_ExistingLoadBalancer_NewPort(t *testing.
 	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{
 		{Name: "lbname", External: true, InstancePort: oldport},
 	}, nil)
-	l.On("UpdateLoadBalancer", lb.UpdateLoadBalancerOpts{
-		Name:         "lbname",
-		InstancePort: &newport,
-	}).Return(nil)
-	p.On("CreateProcess", app, process).Return(nil)
 
 	err := m.CreateProcess(context.Background(), app, process)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "Process web instance port is 8081, but load balancer instance port is 8080.")
 
 	p.AssertExpectations(t)
 	l.AssertExpectations(t)

--- a/scheduler/ecs/lb_test.go
+++ b/scheduler/ecs/lb_test.go
@@ -1,0 +1,203 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/remind101/empire/pkg/lb"
+	"github.com/remind101/empire/scheduler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/net/context"
+)
+
+func TestLBProcessManager_CreateProcess_NoExposure(t *testing.T) {
+	p := new(mockProcessManager)
+	l := new(mockLBManager)
+	m := &LBProcessManager{
+		ProcessManager: p,
+		lb:             l,
+	}
+
+	app := &scheduler.App{}
+	process := &scheduler.Process{}
+
+	p.On("CreateProcess", app, process).Return(nil)
+
+	err := m.CreateProcess(context.Background(), app, process)
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+	l.AssertExpectations(t)
+}
+
+func TestLBProcessManager_CreateProcess_NoExistingLoadBalancer(t *testing.T) {
+	p := new(mockProcessManager)
+	l := new(mockLBManager)
+	m := &LBProcessManager{
+		ProcessManager: p,
+		lb:             l,
+	}
+
+	port := int64(8080)
+	app := &scheduler.App{
+		ID:   "appid",
+		Name: "appname",
+	}
+	process := &scheduler.Process{
+		Type:     "web",
+		Exposure: scheduler.ExposePrivate,
+		Ports: []scheduler.PortMap{
+			{Host: &port},
+		},
+	}
+
+	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{}, nil)
+	l.On("CreateLoadBalancer", lb.CreateLoadBalancerOpts{
+		InstancePort: 8080,
+		Tags:         map[string]string{"AppID": "appid", "ProcessType": "web", "App": "appname"},
+		External:     false,
+	}).Return(&lb.LoadBalancer{
+		Name: "lbname",
+	}, nil)
+	p.On("CreateProcess", app, &scheduler.Process{
+		Type:     "web",
+		Exposure: scheduler.ExposePrivate,
+		Ports: []scheduler.PortMap{
+			{Host: &port},
+		},
+		LoadBalancer: "lbname",
+	}).Return(nil)
+
+	err := m.CreateProcess(context.Background(), app, process)
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+	l.AssertExpectations(t)
+}
+
+func TestLBProcessManager_CreateProcess_ExistingLoadBalancer(t *testing.T) {
+	p := new(mockProcessManager)
+	l := new(mockLBManager)
+	m := &LBProcessManager{
+		ProcessManager: p,
+		lb:             l,
+	}
+
+	port := int64(8080)
+	app := &scheduler.App{
+		ID:   "appid",
+		Name: "appname",
+	}
+	process := &scheduler.Process{
+		Type:     "web",
+		Exposure: scheduler.ExposePublic,
+		Ports: []scheduler.PortMap{
+			{Host: &port},
+		},
+	}
+
+	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{
+		{Name: "lbname", InstancePort: 8080, External: true},
+	}, nil)
+	p.On("CreateProcess", app, process).Return(nil)
+
+	err := m.CreateProcess(context.Background(), app, process)
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+	l.AssertExpectations(t)
+}
+
+func TestLBProcessManager_CreateProcess_ExistingLoadBalancer_MismatchedExposure(t *testing.T) {
+	p := new(mockProcessManager)
+	l := new(mockLBManager)
+	m := &LBProcessManager{
+		ProcessManager: p,
+		lb:             l,
+	}
+
+	port := int64(8080)
+	app := &scheduler.App{
+		ID:   "appid",
+		Name: "appname",
+	}
+	process := &scheduler.Process{
+		Type:     "web",
+		Exposure: scheduler.ExposePublic,
+		Ports: []scheduler.PortMap{
+			{Host: &port},
+		},
+	}
+
+	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{
+		{Name: "lbname", External: false},
+	}, nil)
+
+	err := m.CreateProcess(context.Background(), app, process)
+	assert.EqualError(t, err, "Process web is public, but load balancer is private. An update would require me to delete the load balancer.")
+
+	p.AssertExpectations(t)
+	l.AssertExpectations(t)
+}
+
+func TestLBProcessManager_CreateProcess_ExistingLoadBalancer_NewCert(t *testing.T) {
+	p := new(mockProcessManager)
+	l := new(mockLBManager)
+	m := &LBProcessManager{
+		ProcessManager: p,
+		lb:             l,
+	}
+
+	port := int64(8080)
+	app := &scheduler.App{
+		ID:   "appid",
+		Name: "appname",
+	}
+	process := &scheduler.Process{
+		Type:     "web",
+		Exposure: scheduler.ExposePublic,
+		Ports: []scheduler.PortMap{
+			{Host: &port},
+		},
+		SSLCert: "newcert",
+	}
+
+	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{
+		{Name: "lbname", External: true, SSLCert: "oldcert"},
+	}, nil)
+
+	err := m.CreateProcess(context.Background(), app, process)
+	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+	l.AssertExpectations(t)
+}
+
+type mockProcessManager struct {
+	ProcessManager
+	mock.Mock
+}
+
+func (m *mockProcessManager) CreateProcess(ctx context.Context, app *scheduler.App, process *scheduler.Process) error {
+	args := m.Called(app, process)
+	return args.Error(0)
+}
+
+type mockLBManager struct {
+	mock.Mock
+}
+
+func (m *mockLBManager) CreateLoadBalancer(ctx context.Context, opts lb.CreateLoadBalancerOpts) (*lb.LoadBalancer, error) {
+	args := m.Called(opts)
+	return args.Get(0).(*lb.LoadBalancer), args.Error(1)
+}
+
+func (m *mockLBManager) DestroyLoadBalancer(ctx context.Context, lb *lb.LoadBalancer) error {
+	args := m.Called(lb)
+	return args.Error(0)
+}
+
+func (m *mockLBManager) LoadBalancers(ctx context.Context, tags map[string]string) ([]*lb.LoadBalancer, error) {
+	args := m.Called(tags)
+	return args.Get(0).([]*lb.LoadBalancer), args.Error(1)
+}


### PR DESCRIPTION
This allows the ECS backend to update the SSL cert on the associated ELB if it changes.

A better approach would be to provision resources using CloudFormation like talked about in https://github.com/remind101/empire/pull/696, but that's a ways off and will require a substantial migration.