### PR TITLE
Expose errors in Tugboat properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Allow floating point numbers to be provided when scaling the memory on a process [#694](https://github.com/remind101/empire/pull/694).
 * Empire will now update the SSL certificate on the associated ELB if it changes from `emp cert-attach` [#700](https://github.com/remind101/empire/pull/700).
+* The Tugboat integration now updates the deployment status with any errors that occurred [#709](https://github.com/remind101/empire/pull/709).
 
 **Security**
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -260,8 +260,8 @@
 		},
 		{
 			"ImportPath": "github.com/remind101/tugboat",
-			"Comment": "v0.0.1-275-g26c5f5c",
-			"Rev": "26c5f5ca2a0098a94b9335c805e3cbbc2636a46f"
+			"Comment": "v0.0.1-283-g3db4293",
+			"Rev": "3db4293668426d1a185153e1dd794d744c331542"
 		},
 		{
 			"ImportPath": "github.com/stretchr/objx",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -260,8 +260,8 @@
 		},
 		{
 			"ImportPath": "github.com/remind101/tugboat",
-			"Comment": "v0.0.1-283-g3db4293",
-			"Rev": "3db4293668426d1a185153e1dd794d744c331542"
+			"Comment": "v0.0.1-284-gcc7c2a3",
+			"Rev": "cc7c2a3162f5445339387bf3b5146b8da5c43f19"
 		},
 		{
 			"ImportPath": "github.com/stretchr/objx",

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/README.md
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/README.md
@@ -94,7 +94,9 @@ POST /deployments/:id/status
 
 ## Setup
 
-**TODO**
+1. Git clone this repo into `$GOPATH/src/github.com/remind101/tugboat`
+2. Run the `before_install` steps in `.travis.yml` to set up dependencies and env.
+3. Run the `script` steps in `.travis.yml` to test your setup.
 
 ## Roadmap
 

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/bin/build
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/bin/build
@@ -2,10 +2,11 @@
 
 set -e
 
-echo "@edge http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-packages="curl git go@edge"
+echo "hosts: files dns" >> /etc/nsswitch.conf
+echo "@edge-community http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+packages="curl git go@edge-community"
 
-apk add --update curl git go@edge
+apk add --update $packages
 
 GOPATH=/go go get github.com/tools/godep
 cd /go/src/github.com/remind101/tugboat

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/deployments.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/deployments.go
@@ -70,7 +70,7 @@ func NewDeployOptsFromReader(r io.Reader) (DeployOpts, error) {
 // StatusUpdate is used to update the status of a Deployment.
 type StatusUpdate struct {
 	Status DeploymentStatus
-	Error  *error
+	Error  *string
 }
 
 // DeploymentStatus represents the status of a deployment.

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/frontend/dist/app.js
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/frontend/dist/app.js
@@ -431,6 +431,8 @@ module.run(['$templateCache', function($templateCache) {
     '      <th>Environment</th>\n' +
     '      <th>Provider</th>\n' +
     '      <th>Status</th>\n' +
+    '      <th>Started At</th>\n' +
+    '      <th>Completed At</th>\n' +
     '    </tr>\n' +
     '  </thead>\n' +
     '  <tbody>\n' +
@@ -444,6 +446,8 @@ module.run(['$templateCache', function($templateCache) {
     '    <td ng-bind="job.environment" title="{{ job.environment }}"></td>\n' +
     '    <td ng-bind="job.provider" title="{{ job.provider }}"></td>\n' +
     '    <td ng-bind="job.status"></td>\n' +
+    '    <td ng-bind="job.startedAt"></td>\n' +
+    '    <td ng-bind="job.completedAt"></td>\n' +
     '  </tr>\n' +
     '  </tbody>\n' +
     '</table>\n' +

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/frontend/templates/jobs/list.html
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/frontend/templates/jobs/list.html
@@ -9,6 +9,8 @@
       <th>Environment</th>
       <th>Provider</th>
       <th>Status</th>
+      <th>Started At</th>
+      <th>Completed At</th>
     </tr>
   </thead>
   <tbody>
@@ -22,6 +24,8 @@
     <td ng-bind="job.environment" title="{{ job.environment }}"></td>
     <td ng-bind="job.provider" title="{{ job.provider }}"></td>
     <td ng-bind="job.status"></td>
+    <td ng-bind="job.startedAt"></td>
+    <td ng-bind="job.completedAt"></td>
   </tr>
   </tbody>
 </table>

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/server/api/deployments.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/server/api/deployments.go
@@ -4,23 +4,27 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/remind101/tugboat"
 )
 
 type Deployment struct {
-	ID          string `json:"id"`
-	GitHubID    int64  `json:"github_id"`
-	User        string `json:"user"`
-	Repo        string `json:"repo"`
-	Sha         string `json:"sha"`
-	Ref         string `json:"ref"`
-	Environment string `json:"environment"`
-	Status      string `json:"status"`
-	Output      string `json:"output"`
-	Error       string `json:"error"`
-	Provider    string `json:"provider"`
+	ID          string     `json:"id"`
+	GitHubID    int64      `json:"github_id"`
+	User        string     `json:"user"`
+	Repo        string     `json:"repo"`
+	Sha         string     `json:"sha"`
+	Ref         string     `json:"ref"`
+	Environment string     `json:"environment"`
+	Status      string     `json:"status"`
+	Output      string     `json:"output"`
+	Error       string     `json:"error"`
+	Provider    string     `json:"provider"`
+	CreatedAt   time.Time  `json:"createdAt"` // always set
+	StartedAt   *time.Time `json:"startedAt"` // nil until started
+	CompletedAt *time.Time `json:"completedAt"`
 }
 
 func newDeployment(d *tugboat.Deployment) *Deployment {
@@ -35,6 +39,9 @@ func newDeployment(d *tugboat.Deployment) *Deployment {
 		Status:      d.Status.String(),
 		Error:       d.Error,
 		Provider:    d.Provider,
+		CreatedAt:   d.CreatedAt,
+		StartedAt:   d.StartedAt,
+		CompletedAt: d.CompletedAt,
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/tests/api/api_test.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/tests/api/api_test.go
@@ -42,6 +42,14 @@ func TestDeploymentsCreate(t *testing.T) {
 	if got, want := d.Provider, "heroku"; got != want {
 		t.Fatalf("Provider => %s; want %s", got, want)
 	}
+
+	if d.StartedAt == nil {
+		t.Fatalf("expected StartedAt to not be nil")
+	}
+
+	if d.CompletedAt != nil {
+		t.Fatalf("expected CompletedAt to be nil")
+	}
 }
 
 func TestDeploymentsCreate_Unauthorized(t *testing.T) {

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 
 	"code.google.com/p/goauth2/oauth"
 	"github.com/google/go-github/github"
@@ -230,8 +229,7 @@ func deploy(ctx context.Context, opts DeployOpts, p Provider, t client) (deploym
 	logsDone := make(chan struct{}, 1)
 	go func() {
 		// we're ignoring err here.
-		werr := t.WriteLogs(deployment, r)
-		log.Printf("write logs error: %v\n", werr)
+		_ = t.WriteLogs(deployment, r)
 		close(logsDone)
 	}()
 

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 
 	"code.google.com/p/goauth2/oauth"
 	"github.com/google/go-github/github"
@@ -229,7 +230,8 @@ func deploy(ctx context.Context, opts DeployOpts, p Provider, t client) (deploym
 	logsDone := make(chan struct{}, 1)
 	go func() {
 		// we're ignoring err here.
-		_ = t.WriteLogs(deployment, r)
+		werr := t.WriteLogs(deployment, r)
+		log.Printf("write logs error: %v\n", werr)
 		close(logsDone)
 	}()
 

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
@@ -131,7 +131,7 @@ func (t *Tugboat) UpdateStatus(d *Deployment, update StatusUpdate) error {
 	case StatusErrored:
 		var err error
 		if update.Error != nil {
-			err = *update.Error
+			err = errors.New(*update.Error)
 		} else {
 			err = errors.New("no error provided")
 		}
@@ -274,8 +274,9 @@ func statusUpdate(fn func() error) (update StatusUpdate) {
 		if err == ErrFailed {
 			update.Status = StatusFailed
 		} else {
+			msg := err.Error()
 			update.Status = StatusErrored
-			update.Error = &err
+			update.Error = &msg
 		}
 	}()
 

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 
 	"code.google.com/p/goauth2/oauth"
 	"github.com/google/go-github/github"
@@ -229,9 +228,11 @@ func deploy(ctx context.Context, opts DeployOpts, p Provider, t client) (deploym
 
 	logsDone := make(chan struct{}, 1)
 	go func() {
-		// we're ignoring err here.
-		werr := t.WriteLogs(deployment, r)
-		log.Printf("write error: %v\n", werr)
+		if werr := t.WriteLogs(deployment, r); werr != nil {
+			// If there was an error writing the logs, close the
+			// Write side of the pipe.
+			r.CloseWithError(err)
+		}
 		close(logsDone)
 	}()
 

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 
 	"code.google.com/p/goauth2/oauth"
 	"github.com/google/go-github/github"
@@ -229,7 +230,8 @@ func deploy(ctx context.Context, opts DeployOpts, p Provider, t client) (deploym
 	logsDone := make(chan struct{}, 1)
 	go func() {
 		// we're ignoring err here.
-		_ = t.WriteLogs(deployment, r)
+		werr := t.WriteLogs(deployment, r)
+		log.Printf("write error: %v\n", werr)
 		close(logsDone)
 	}()
 

--- a/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat_test.go
+++ b/Godeps/_workspace/src/github.com/remind101/tugboat/tugboat_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestUpdateStatus(t *testing.T) {
-	boom := errors.New("boom")
+	boom := "boom"
 
 	tests := []struct {
 		fn     func() error
@@ -31,7 +31,7 @@ func TestUpdateStatus(t *testing.T) {
 		},
 		{
 			fn: func() error {
-				return boom
+				return errors.New(boom)
 			},
 			status: StatusUpdate{
 				Status: StatusErrored,

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -1,8 +1,6 @@
 package empiretest
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 	"net/http/httptest"
 	"os"
@@ -10,9 +8,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/ejholmes/flock"
 	"github.com/remind101/empire"
+	"github.com/remind101/empire/pkg/dockerutil"
 	"github.com/remind101/empire/pkg/image"
 	"github.com/remind101/empire/procfile"
 	"github.com/remind101/empire/scheduler"
@@ -75,24 +73,7 @@ func Run(m *testing.M) {
 
 // ExtractProcfile extracts a fake procfile.
 func ExtractProcfile(ctx context.Context, img image.Image, w io.Writer) (procfile.Procfile, error) {
-	messages := []jsonmessage.JSONMessage{
-		{Status: fmt.Sprintf("Pulling repository %s", img.Repository)},
-		{Status: fmt.Sprintf("Pulling image (%s) from %s", img.Tag, img.Repository), Progress: &jsonmessage.JSONProgress{}, ID: "345c7524bc96"},
-		{Status: fmt.Sprintf("Pulling image (%s) from %s, endpoint: https://registry-1.docker.io/v1/", img.Tag, img.Repository), Progress: &jsonmessage.JSONProgress{}, ID: "345c7524bc96"},
-		{Status: "Pulling dependent layers", Progress: &jsonmessage.JSONProgress{}, ID: "345c7524bc96"},
-		{Status: "Download complete", Progress: &jsonmessage.JSONProgress{}, ID: "a1dd7097a8e8"},
-		{Status: fmt.Sprintf("Status: Image is up to date for %s", img)},
-	}
-
-	enc := json.NewEncoder(w)
-
-	for _, m := range messages {
-		if err := enc.Encode(&m); err != nil {
-			return nil, err
-		}
-	}
-
 	return procfile.Procfile{
 		"web": "./bin/web",
-	}, nil
+	}, dockerutil.FakePull(img, w)
 }

--- a/pkg/dockerutil/dockerutil.go
+++ b/pkg/dockerutil/dockerutil.go
@@ -1,0 +1,32 @@
+package dockerutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/remind101/empire/pkg/image"
+)
+
+// FakePull writes a jsonmessage stream to w that looks like a Docker pull.
+func FakePull(img image.Image, w io.Writer) error {
+	messages := []jsonmessage.JSONMessage{
+		{Status: fmt.Sprintf("Pulling repository %s", img.Repository)},
+		{Status: fmt.Sprintf("Pulling image (%s) from %s", img.Tag, img.Repository), Progress: &jsonmessage.JSONProgress{}, ID: "345c7524bc96"},
+		{Status: fmt.Sprintf("Pulling image (%s) from %s, endpoint: https://registry-1.docker.io/v1/", img.Tag, img.Repository), Progress: &jsonmessage.JSONProgress{}, ID: "345c7524bc96"},
+		{Status: "Pulling dependent layers", Progress: &jsonmessage.JSONProgress{}, ID: "345c7524bc96"},
+		{Status: "Download complete", Progress: &jsonmessage.JSONProgress{}, ID: "a1dd7097a8e8"},
+		{Status: fmt.Sprintf("Status: Image is up to date for %s", img)},
+	}
+
+	enc := json.NewEncoder(w)
+
+	for _, m := range messages {
+		if err := enc.Encode(&m); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/dockerutil/dockerutil_test.go
+++ b/pkg/dockerutil/dockerutil_test.go
@@ -1,0 +1,44 @@
+package dockerutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/remind101/empire/pkg/image"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeJSONMessageStream(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := DecodeJSONMessageStream(buf)
+
+	err := json.NewEncoder(w).Encode(&jsonmessage.JSONMessage{
+		Status: "Doing stuff",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "Doing stuff\n", buf.String())
+}
+
+func TestDecodeJSONMessageStream_JSONMessageError(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := DecodeJSONMessageStream(buf)
+
+	err := json.NewEncoder(w).Encode(&jsonmessage.JSONMessage{
+		Error: &jsonmessage.JSONError{
+			Message: "error message",
+		},
+	})
+	assert.NoError(t, err)
+	assert.EqualError(t, w.Err(), "error message")
+}
+
+func TestDecodeJSONMessageStream_DockerPull(t *testing.T) {
+	buf := new(bytes.Buffer)
+	w := DecodeJSONMessageStream(buf)
+
+	err := FakePull(image.Image{Repository: "remind101/acme-inc", Tag: "latest"}, w)
+	assert.NoError(t, err)
+	assert.Equal(t, "Pulling repository remind101/acme-inc\n345c7524bc96: Pulling image (latest) from remind101/acme-inc\n345c7524bc96: Pulling image (latest) from remind101/acme-inc, endpoint: https://registry-1.docker.io/v1/\n345c7524bc96: Pulling dependent layers\na1dd7097a8e8: Download complete\nStatus: Image is up to date for remind101/acme-inc:latest\n", buf.String())
+}

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -22,8 +22,9 @@ type deployer interface {
 // depending on the options.
 func newDeployer(e *empire.Empire, opts Options) deployer {
 	var d deployer
-	d = &tracedDeployer{newEmpireDeployer(e, opts.ImageTemplate)}
+	d = newEmpireDeployer(e, opts.ImageTemplate)
 	d = &prettyDeployer{deployer: d}
+	d = &tracedDeployer{d}
 
 	if opts.TugboatURL != "" {
 		d = newTugboatDeployer(d, opts.TugboatURL)

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -116,6 +116,7 @@ func (d *tugboatDeployer) Deploy(ctx context.Context, p events.Deployment, out i
 	// write hte logs to tugboat and update the deployment status when this
 	// function returns.
 	_, err := d.client.Deploy(ctx, opts, provider(func(ctx context.Context, _ *tugboat.Deployment, w io.Writer) error {
+		io.WriteString(w, "Starting")
 		// If tugboat is running on something like Heroku, we need to
 		// send some occasional heartbeats.
 		defer close(streamhttp.Heartbeat(w, time.Second*30))

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"io"
-	"log"
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
@@ -117,14 +116,13 @@ func (d *tugboatDeployer) Deploy(ctx context.Context, p events.Deployment, out i
 	_, err := d.client.Deploy(ctx, opts, provider(func(ctx context.Context, _ *tugboat.Deployment, w io.Writer) error {
 		// Write logs to both tugboat as well as the writer we were
 		// provided (probably stdout).
-		combined := io.MultiWriter(w, out)
+		w = io.MultiWriter(w, out)
 
-		if err := d.deployer.Deploy(ctx, p, combined); err != nil {
+		if err := d.deployer.Deploy(ctx, p, w); err != nil {
 			// If we got a deployment error, write the error to
 			// tugboat and return tugboat.ErrFailed to indicate the
 			// failure.
-			_, werr := io.WriteString(w, err.Error())
-			log.Printf("write error: %v\n", werr)
+			io.WriteString(w, err.Error())
 			return tugboat.ErrFailed
 		}
 

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -24,7 +24,6 @@ func newDeployer(e *empire.Empire, opts Options) deployer {
 	var d deployer
 	d = newEmpireDeployer(e, opts.ImageTemplate)
 	d = &prettyDeployer{deployer: d}
-	d = &tracedDeployer{d}
 
 	if opts.TugboatURL != "" {
 		d = newTugboatDeployer(d, opts.TugboatURL)

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -18,6 +18,12 @@ type deployer interface {
 	Deploy(context.Context, events.Deployment, io.Writer) error
 }
 
+type deployerFunc func(context.Context, events.Deployment, io.Writer) error
+
+func (fn deployerFunc) Deploy(ctx context.Context, event events.Deployment, w io.Writer) error {
+	return fn(ctx, event, w)
+}
+
 // newDeployer is a factory method that generates a composed deployer instance
 // depending on the options.
 func newDeployer(e *empire.Empire, opts Options) deployer {
@@ -60,10 +66,15 @@ func (d *prettyDeployer) Deploy(ctx context.Context, p events.Deployment, out io
 	return err
 }
 
+// Empire mocks the Empire interface we use.
+type Empire interface {
+	Deploy(context.Context, empire.DeploymentsCreateOpts) (*empire.Release, error)
+}
+
 // empireDeployer is a deployer implementation that uses the Deploy method in
 // Empire to perform the deployment.
 type empireDeployer struct {
-	*empire.Empire
+	Empire
 	imageTmpl string
 }
 

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -2,13 +2,11 @@ package github
 
 import (
 	"io"
-	"time"
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
 	"github.com/ejholmes/hookshot/events"
 	"github.com/remind101/empire"
-	streamhttp "github.com/remind101/empire/pkg/stream/http"
 	"github.com/remind101/pkg/trace"
 	"github.com/remind101/tugboat"
 	"golang.org/x/net/context"
@@ -116,24 +114,11 @@ func (d *tugboatDeployer) Deploy(ctx context.Context, p events.Deployment, out i
 	// write hte logs to tugboat and update the deployment status when this
 	// function returns.
 	_, err := d.client.Deploy(ctx, opts, provider(func(ctx context.Context, _ *tugboat.Deployment, w io.Writer) error {
-		io.WriteString(w, "Starting")
-		// If tugboat is running on something like Heroku, we need to
-		// send some occasional heartbeats.
-		defer close(streamhttp.Heartbeat(w, time.Second*30))
-
 		// Write logs to both tugboat as well as the writer we were
 		// provided (probably stdout).
 		w = io.MultiWriter(w, out)
-
-		if err := d.deployer.Deploy(ctx, p, w); err != nil {
-			// If we got a deployment error, write the error to
-			// tugboat and return tugboat.ErrFailed to indicate the
-			// failure.
-			io.WriteString(w, err.Error())
-			return tugboat.ErrFailed
-		}
-
-		return nil
+		err := d.deployer.Deploy(ctx, p, w)
+		return err
 	}))
 
 	return err

--- a/server/github/deployer_test.go
+++ b/server/github/deployer_test.go
@@ -1,0 +1,96 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/ejholmes/hookshot/events"
+	"github.com/remind101/empire"
+	"github.com/remind101/empire/pkg/dockerutil"
+	"github.com/remind101/empire/pkg/image"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEmpireDeployer_Deploy(t *testing.T) {
+	e := new(mockEmpire)
+	d := &empireDeployer{
+		Empire: e,
+	}
+
+	var event events.Deployment
+	event.Repository.FullName = "remind101/acme-inc"
+	event.Deployment.Sha = "abcd123"
+	event.Deployment.Creator.Login = "ejholmes"
+
+	w := ioutil.Discard
+
+	e.On("Deploy", empire.DeploymentsCreateOpts{
+		User: &empire.User{Name: "ejholmes"},
+		Image: image.Image{
+			Repository: "remind101/acme-inc",
+			Tag:        "abcd123",
+		},
+		Output: w,
+	}).Return(nil)
+
+	err := d.Deploy(context.Background(), event, w)
+	assert.NoError(t, err)
+}
+
+func TestPrettyDeployer_Deploy(t *testing.T) {
+	d := &prettyDeployer{
+		deployer: deployerFunc(func(ctx context.Context, event events.Deployment, w io.Writer) error {
+			img := image.Image{
+				Repository: "remind101/acme-inc",
+				Tag:        "abcd1234",
+			}
+			return dockerutil.FakePull(img, w)
+		}),
+	}
+
+	var event events.Deployment
+	buf := new(bytes.Buffer)
+	err := d.Deploy(context.Background(), event, buf)
+	assert.NoError(t, err)
+	assert.Equal(t, `Pulling repository remind101/acme-inc
+345c7524bc96: Pulling image (abcd1234) from remind101/acme-inc
+345c7524bc96: Pulling image (abcd1234) from remind101/acme-inc, endpoint: https://registry-1.docker.io/v1/
+345c7524bc96: Pulling dependent layers
+a1dd7097a8e8: Download complete
+Status: Image is up to date for remind101/acme-inc:abcd1234
+`, buf.String())
+}
+
+func TestPrettyDeployer_Deploy_Error(t *testing.T) {
+	errMsg := "Get https://registry-1.docker.io/v1/repositories/remind101/acme-inc/tags: read tcp 54.208.52.137:443: i/o timeout"
+	d := &prettyDeployer{
+		deployer: deployerFunc(func(ctx context.Context, event events.Deployment, w io.Writer) error {
+			err := jsonmessage.JSONMessage{
+				Error:        &jsonmessage.JSONError{Message: errMsg},
+				ErrorMessage: errMsg,
+			}
+			return json.NewEncoder(w).Encode(&err)
+		}),
+	}
+
+	var event events.Deployment
+	buf := new(bytes.Buffer)
+	err := d.Deploy(context.Background(), event, buf)
+	assert.EqualError(t, err, errMsg)
+}
+
+type mockEmpire struct {
+	mock.Mock
+}
+
+func (m *mockEmpire) Deploy(ctx context.Context, opts empire.DeploymentsCreateOpts) (*empire.Release, error) {
+	args := m.Called(opts)
+	return nil, args.Error(0)
+}

--- a/server/github/deployer_test.go
+++ b/server/github/deployer_test.go
@@ -1,18 +1,13 @@
 package github
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
 	"io/ioutil"
 	"testing"
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/ejholmes/hookshot/events"
 	"github.com/remind101/empire"
-	"github.com/remind101/empire/pkg/dockerutil"
 	"github.com/remind101/empire/pkg/image"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -42,48 +37,6 @@ func TestEmpireDeployer_Deploy(t *testing.T) {
 
 	err := d.Deploy(context.Background(), event, w)
 	assert.NoError(t, err)
-}
-
-func TestPrettyDeployer_Deploy(t *testing.T) {
-	d := &prettyDeployer{
-		deployer: deployerFunc(func(ctx context.Context, event events.Deployment, w io.Writer) error {
-			img := image.Image{
-				Repository: "remind101/acme-inc",
-				Tag:        "abcd1234",
-			}
-			return dockerutil.FakePull(img, w)
-		}),
-	}
-
-	var event events.Deployment
-	buf := new(bytes.Buffer)
-	err := d.Deploy(context.Background(), event, buf)
-	assert.NoError(t, err)
-	assert.Equal(t, `Pulling repository remind101/acme-inc
-345c7524bc96: Pulling image (abcd1234) from remind101/acme-inc
-345c7524bc96: Pulling image (abcd1234) from remind101/acme-inc, endpoint: https://registry-1.docker.io/v1/
-345c7524bc96: Pulling dependent layers
-a1dd7097a8e8: Download complete
-Status: Image is up to date for remind101/acme-inc:abcd1234
-`, buf.String())
-}
-
-func TestPrettyDeployer_Deploy_Error(t *testing.T) {
-	errMsg := "Get https://registry-1.docker.io/v1/repositories/remind101/acme-inc/tags: read tcp 54.208.52.137:443: i/o timeout"
-	d := &prettyDeployer{
-		deployer: deployerFunc(func(ctx context.Context, event events.Deployment, w io.Writer) error {
-			err := jsonmessage.JSONMessage{
-				Error:        &jsonmessage.JSONError{Message: errMsg},
-				ErrorMessage: errMsg,
-			}
-			return json.NewEncoder(w).Encode(&err)
-		}),
-	}
-
-	var event events.Deployment
-	buf := new(bytes.Buffer)
-	err := d.Deploy(context.Background(), event, buf)
-	assert.EqualError(t, err, errMsg)
 }
 
 type mockEmpire struct {


### PR DESCRIPTION
This "fixes" https://app.honeybadger.io/projects/43058/faults/14165058 in that it makes the error visible. Previously, it would get silenced and people would be confused why they're deployment failed (tag wasn't found in the docker registry. See https://github.com/remind101/empire/issues/644). It's the biggest source of errors that we see from Empire, so it's annoying when you just see a blank error.

The behavior before was to write the error to the log stream, then update the deployment status in Tugboat as failed. But if there was an error writing to the log stream, then the error would just be silenced. It's better if we just update the deployment status in Tugboat passing it the actual error that happened.

![](https://s3.amazonaws.com/ejholmes.github.com/610Hz.png)

Depends on https://github.com/remind101/tugboat/pull/41

**TODO**

* [ ] Merge https://github.com/remind101/tugboat/pull/41