### PR TITLE
Allow empire to be put into a readonly maintenance mode.

### DIFF
--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -70,6 +70,11 @@ func newEmpire(c *cli.Context) (*empire.Empire, error) {
 	e.ExtractProcfile = empire.PullAndExtract(docker)
 	e.Logger = newLogger()
 
+	// Put Empire in maintenance mode if the flag is provided.
+	if reason := c.String(FlagMaintenanceMode); reason != "" {
+		e.SetMaintenanceMode(reason)
+	}
+
 	return e, nil
 }
 

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	FlagPort          = "port"
-	FlagAutoMigrate   = "automigrate"
-	FlagEventsBackend = "events.backend"
+	FlagPort            = "port"
+	FlagAutoMigrate     = "automigrate"
+	FlagEventsBackend   = "events.backend"
+	FlagMaintenanceMode = "maintenance"
 
 	FlagGithubClient       = "github.client.id"
 	FlagGithubClientSecret = "github.client.secret"
@@ -67,12 +68,6 @@ var Commands = []cli.Command{
 			cli.BoolFlag{
 				Name:  FlagAutoMigrate,
 				Usage: "Whether to run the migrations at startup or not",
-			},
-			cli.StringFlag{
-				Name:   FlagEventsBackend,
-				Value:  "",
-				Usage:  "The backend implementation to use to send event notifactions",
-				EnvVar: "EMPIRE_EVENTS_BACKEND",
 			},
 			cli.StringFlag{
 				Name:   FlagGithubClient,
@@ -148,6 +143,12 @@ var DBFlags = []cli.Flag{
 }
 
 var EmpireFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:   FlagMaintenanceMode,
+		Value:  "",
+		Usage:  "Set to enable maintenance (readonly) mode. The value should be a string that will be returned as an error to users",
+		EnvVar: "EMPIRE_MAINTENANCE",
+	},
 	cli.StringFlag{
 		Name:   FlagDockerSocket,
 		Value:  "unix:///var/run/docker.sock",
@@ -236,6 +237,12 @@ var EmpireFlags = []cli.Flag{
 		Value:  "",
 		Usage:  "The location of the logs to stream",
 		EnvVar: "EMPIRE_LOGS_STREAMER",
+	},
+	cli.StringFlag{
+		Name:   FlagEventsBackend,
+		Value:  "",
+		Usage:  "The backend implementation to use to send event notifactions",
+		EnvVar: "EMPIRE_EVENTS_BACKEND",
 	},
 	cli.StringFlag{
 		Name:   FlagSNSTopic,

--- a/empire.go
+++ b/empire.go
@@ -77,6 +77,10 @@ type Empire struct {
 
 	// EventStream service for publishing Empire events.
 	EventStream
+
+	// Set this to a non-nil value to put Empire in readonly maintenance
+	// mode.
+	*MaintenanceMode
 }
 
 // New returns a new Empire instance.
@@ -141,6 +145,10 @@ func (opts CreateOpts) Event() CreateEvent {
 
 // Create creates a new app.
 func (e *Empire) Create(ctx context.Context, opts CreateOpts) (*App, error) {
+	if err := e.MaintenanceMode; err != nil {
+		return nil, err
+	}
+
 	a, err := appsCreate(e.db, &App{Name: opts.Name})
 	if err != nil {
 		return a, err
@@ -167,6 +175,10 @@ func (opts DestroyOpts) Event() DestroyEvent {
 
 // Destroy destroys an app.
 func (e *Empire) Destroy(ctx context.Context, opts DestroyOpts) error {
+	if err := e.MaintenanceMode; err != nil {
+		return err
+	}
+
 	tx := e.db.Begin()
 
 	if err := e.apps.Destroy(ctx, tx, opts.App); err != nil {
@@ -227,6 +239,10 @@ func (opts SetOpts) Event() SetEvent {
 // Config. If the app has a running release, a new release will be created and
 // run.
 func (e *Empire) Set(ctx context.Context, opts SetOpts) (*Config, error) {
+	if err := e.MaintenanceMode; err != nil {
+		return nil, err
+	}
+
 	tx := e.db.Begin()
 
 	c, err := e.configs.Set(ctx, tx, opts)
@@ -254,6 +270,10 @@ func (e *Empire) Domains(q DomainsQuery) ([]*Domain, error) {
 
 // DomainsCreate adds a new Domain for an App.
 func (e *Empire) DomainsCreate(ctx context.Context, domain *Domain) (*Domain, error) {
+	if err := e.MaintenanceMode; err != nil {
+		return nil, err
+	}
+
 	tx := e.db.Begin()
 
 	d, err := e.domains.DomainsCreate(ctx, tx, domain)
@@ -271,6 +291,10 @@ func (e *Empire) DomainsCreate(ctx context.Context, domain *Domain) (*Domain, er
 
 // DomainsDestroy removes a Domain for an App.
 func (e *Empire) DomainsDestroy(ctx context.Context, domain *Domain) error {
+	if err := e.MaintenanceMode; err != nil {
+		return err
+	}
+
 	tx := e.db.Begin()
 
 	if err := e.domains.DomainsDestroy(ctx, tx, domain); err != nil {
@@ -314,6 +338,10 @@ func (opts RestartOpts) Event() RestartEvent {
 // Restart restarts processes matching the given prefix for the given Release.
 // If the prefix is empty, it will match all processes for the release.
 func (e *Empire) Restart(ctx context.Context, opts RestartOpts) error {
+	if err := e.MaintenanceMode; err != nil {
+		return err
+	}
+
 	if err := e.apps.Restart(ctx, e.db, opts); err != nil {
 		return err
 	}
@@ -359,6 +387,10 @@ func (opts RunOpts) Event() RunEvent {
 
 // Run runs a one-off process for a given App and command.
 func (e *Empire) Run(ctx context.Context, opts RunOpts) error {
+	if err := e.MaintenanceMode; err != nil {
+		return err
+	}
+
 	if err := e.runner.Run(ctx, opts); err != nil {
 		return err
 	}
@@ -399,6 +431,10 @@ func (opts RollbackOpts) Event() RollbackEvent {
 // Rollback rolls an app back to a specific release version. Returns a
 // new release.
 func (e *Empire) Rollback(ctx context.Context, opts RollbackOpts) (*Release, error) {
+	if err := e.MaintenanceMode; err != nil {
+		return nil, err
+	}
+
 	tx := e.db.Begin()
 
 	r, err := e.releases.Rollback(ctx, tx, opts)
@@ -444,6 +480,10 @@ func (opts DeploymentsCreateOpts) Event() DeployEvent {
 
 // Deploy deploys an image and streams the output to w.
 func (e *Empire) Deploy(ctx context.Context, opts DeploymentsCreateOpts) (*Release, error) {
+	if err := e.MaintenanceMode; err != nil {
+		return nil, err
+	}
+
 	tx := e.db.Begin()
 
 	r, err := e.deployer.Deploy(ctx, tx, opts)
@@ -488,6 +528,10 @@ func (opts ScaleOpts) Event() ScaleEvent {
 
 // Scale scales an apps process.
 func (e *Empire) Scale(ctx context.Context, opts ScaleOpts) (*Process, error) {
+	if err := e.MaintenanceMode; err != nil {
+		return nil, err
+	}
+
 	tx := e.db.Begin()
 
 	p, err := e.apps.Scale(ctx, tx, opts)
@@ -506,6 +550,10 @@ func (e *Empire) StreamLogs(app *App, w io.Writer) error {
 
 // CertsAttach attaches an SSL certificate to the app.
 func (e *Empire) CertsAttach(ctx context.Context, app *App, cert string) error {
+	if err := e.MaintenanceMode; err != nil {
+		return err
+	}
+
 	tx := e.db.Begin()
 
 	if err := e.certs.CertsAttach(ctx, tx, app, cert); err != nil {
@@ -525,6 +573,14 @@ func (e *Empire) Reset() error {
 // the services it depends on.
 func (e *Empire) IsHealthy() bool {
 	return e.DB.IsHealthy()
+}
+
+// SetMaintenanceMode puts Empire in maintenance mode. Calls to actions that are
+// not readonly will return the given error.
+func (e *Empire) SetMaintenanceMode(reason string) {
+	e.MaintenanceMode = &MaintenanceMode{
+		Reason: reason,
+	}
 }
 
 // ValidationError is returned when a model is not valid.

--- a/maintenance.go
+++ b/maintenance.go
@@ -1,0 +1,15 @@
+package empire
+
+import "fmt"
+
+// MaintenanceMode is an error implementation that can be returned to indicate
+// that Empire is in maintenance mode.
+type MaintenanceMode struct {
+	// A human readable description for why Empire is in maintenance mode.
+	Reason string
+}
+
+// Error implements the error interface.
+func (e *MaintenanceMode) Error() string {
+	return fmt.Sprintf("maintenance mode: %s", e.Reason)
+}

--- a/server/heroku/errors.go
+++ b/server/heroku/errors.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"fmt"
 	"net/http"
 
 	"golang.org/x/net/context"
@@ -65,6 +66,12 @@ func newError(err error) *ErrorResource {
 		return err
 	case *empire.ValidationError:
 		return ErrBadRequest
+	case *empire.MaintenanceMode:
+		return &ErrorResource{
+			Status:  http.StatusBadRequest,
+			ID:      "maintenance_mode",
+			Message: fmt.Sprintf("The API is currently in maintenance mode: %s", err.Reason),
+		}
 	default:
 		return &ErrorResource{
 			Message: err.Error(),


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/714

This allows you start Empire with a `--maintenance` flag. Doing this will cause any non-readonly actions to return an error indicating that maintenance mode is enabled for the API:

```console
$ emp set FOO=foobar -a acme-inc
error: The API is currently in maintenance mode: "We're performing a migration sorry!"
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/remind101/empire/717)
<!-- Reviewable:end -->
