### PR TITLE
Actually hide hidden commands.

### DIFF
--- a/cmd/emp/help.go
+++ b/cmd/emp/help.go
@@ -111,7 +111,7 @@ func runHelp(cmd *Command, args []string) {
 	}
 
 	for _, cmd := range commands {
-		if cmd.Name() == args[0] && !cmd.Hidden {
+		if cmd.Name() == args[0] {
 			cmd.PrintLongUsage()
 			return
 		}
@@ -135,7 +135,7 @@ Usage: emp <command> [-a <app or remote>] [options] [arguments]
 
 
 Commands:
-{{range .Commands}}{{if .Runnable}}{{if .List}}
+{{range .Commands}}{{if .Visible}}{{if .List}}
     {{.Name | printf (print "%-" $.MaxRunListName "s")}}  {{.Short}}{{end}}{{end}}{{end}}
 
 Run 'emp help [command]' for details.

--- a/cmd/emp/main.go
+++ b/cmd/emp/main.go
@@ -72,6 +72,10 @@ func (c *Command) Runnable() bool {
 	return c.Run != nil
 }
 
+func (c *Command) Visible() bool {
+	return c.Runnable() && !c.Hidden
+}
+
 const extra = " (extra)"
 
 func (c *Command) List() bool {


### PR DESCRIPTION
This hides commands marked as Hidden from the help output. Previous method was broken.

Brought up in https://github.com/remind101/empire/pull/724/files#r49390667