### PR TITLE
Update Cloudformation template to use latest ECS optimized AMI

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -17,7 +17,7 @@
     "AmiId" : {
       "Type": "AWS::EC2::Image::Id",
       "Description": "AMI Id. Defaults to the official ECS Optimized Linux.",
-      "Default": "ami-e2b1f988"
+      "Default": "ami-e7acf78d"
     },
     "KeyName": {
       "Type": "AWS::EC2::KeyPair::KeyName",


### PR DESCRIPTION
The old one stopped being able to be found by `aws ec2 describe-images` in `bin/bootstrap`