### PR TITLE
Refactor out an ImageBuilder interface.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,16 @@
 REPO = remind101/empire
 TYPE = patch
 
+cmds: build/empire build/emp
+
+clean:
+	rm -rf build/*
+
 build/empire:
 	go build -o build/empire ./cmd/empire
 
 build/emp:
 	go build -o build/emp ./cmd/emp
-
-cmds: build/empire build/emp
 
 bootstrap: cmds
 	createdb empire || true

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"text/template"
 
 	"golang.org/x/net/context"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/remind101/empire/scheduler"
 	"github.com/remind101/empire/server"
 	"github.com/remind101/empire/server/auth"
+	"github.com/remind101/empire/server/github"
 )
 
 var (
@@ -60,6 +62,7 @@ func NewServer(t testing.TB, e *empire.Empire) *httptest.Server {
 	server.DefaultOptions.GitHub.Webhooks.Secret = "abcd"
 	server.DefaultOptions.Authenticator = auth.Anyone(&empire.User{Name: "fake"})
 	server.DefaultOptions.GitHub.Deployments.Environments = []string{"test"}
+	server.DefaultOptions.GitHub.Deployments.ImageBuilder = github.ImageFromTemplate(template.Must(template.New("image").Parse(github.DefaultTemplate)))
 	return httptest.NewServer(server.New(e, server.DefaultOptions))
 }
 

--- a/server/github/builder.go
+++ b/server/github/builder.go
@@ -1,0 +1,36 @@
+package github
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/ejholmes/hookshot/events"
+	"github.com/remind101/empire/pkg/image"
+	"golang.org/x/net/context"
+)
+
+// ImageBuilder is an interface that represents something that can build and
+// return a Docker image from a GitHub commit.
+type ImageBuilder interface {
+	BuildImage(ctx context.Context, event events.Deployment) (image.Image, error)
+}
+
+type ImageBuilderFunc func(context.Context, events.Deployment) (image.Image, error)
+
+func (fn ImageBuilderFunc) BuildImage(ctx context.Context, event events.Deployment) (image.Image, error) {
+	return fn(ctx, event)
+}
+
+// ImageFromTemplate returns an ImageBuilder that will execute a template to
+// determine what docker image should be deployed. Note that this doesn't not
+// actually perform any "build".
+func ImageFromTemplate(t *template.Template) ImageBuilder {
+	return ImageBuilderFunc(func(ctx context.Context, event events.Deployment) (image.Image, error) {
+		buf := new(bytes.Buffer)
+		if err := t.Execute(buf, event); err != nil {
+			return image.Image{}, err
+		}
+
+		return image.Decode(buf.String())
+	})
+}

--- a/server/github/deployer_test.go
+++ b/server/github/deployer_test.go
@@ -15,8 +15,9 @@ import (
 
 func TestEmpireDeployer_Deploy(t *testing.T) {
 	e := new(mockEmpire)
-	d := &empireDeployer{
-		Empire: e,
+	d := &EmpireDeployer{
+		empire:       e,
+		ImageBuilder: ImageFromTemplate(defaultTemplate),
 	}
 
 	var event events.Deployment

--- a/server/github/github_test.go
+++ b/server/github/github_test.go
@@ -2,18 +2,25 @@ package github
 
 import (
 	"testing"
+	"text/template"
+
+	"golang.org/x/net/context"
 
 	"github.com/ejholmes/hookshot/events"
 	"github.com/remind101/empire/pkg/image"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestImage(t *testing.T) {
+var defaultTemplate = template.Must(template.New("image").Parse(DefaultTemplate))
+
+func TestDefaultTemplate(t *testing.T) {
+	b := ImageFromTemplate(defaultTemplate)
+
 	tests := []struct {
-		t   string
 		d   events.Deployment
 		out image.Image
 	}{
-		{DefaultTemplate, func() events.Deployment {
+		{func() events.Deployment {
 			var d events.Deployment
 			d.Repository.FullName = "remind101/acme-inc"
 			d.Deployment.Sha = "827fecd2d36ebeaa2fd05aa8ef3eed1e56a8cd57"
@@ -22,13 +29,8 @@ func TestImage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		img, err := Image(tt.t, tt.d)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if got, want := img, tt.out; got != want {
-			t.Fatalf("Image => %v; want %v", got, want)
-		}
+		img, err := b.BuildImage(context.Background(), tt.d)
+		assert.NoError(t, err)
+		assert.Equal(t, tt.out, img)
 	}
 }


### PR DESCRIPTION
This is a pre-req for the "build on demand" feature in https://github.com/remind101/empire/wiki/Roadmap.

This refactors out an `ImageBuilder` interface in `package server/github`, which can be used to provide various implementations to support building a docker image on demand when a GitHub Deployment is triggered.

Right now, the only implementation is the `ImageFromTemplate` function which directly maps a GitHub deployment event to a docker image like before.

Once [Conveyor](https://github.com/remind101/conveyor) supports a build API, you'll be able to provide a CLI flag to enable Empire to trigger a build and wait for it to complete before deploying it to ECS. I'd like to provide implementations for Docker Hub and Quay if possible, but their API's kinda suck for manually triggering builds. Maybe we should make Conveyor into a paid service? ;)