### PR TITLE
Go 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## HEAD
+
+**Security**
+
+* Empire is now built with Go 1.5.3 to address [CVE-2015-8618](https://groups.google.com/forum/#!topic/golang-announce/MEATuOi_ei4) [#737](https://github.com/remind101/empire/pull/737).
+
 ## 0.10.0 (2016-01-13)
 
 **Features**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.1
+FROM golang:1.5.3
 MAINTAINER Eric Holmes <eric@remind101.com>
 
 LABEL version 0.10.0


### PR DESCRIPTION
To address [CVE-2015-8618](https://groups.google.com/forum/#!topic/golang-announce/MEATuOi_ei4)

Shouldn't actually effect Empire installations because we don't use a tls server directly.