### PR TITLE
Allow emp run to be used with unofficial docker registries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Empire now supports deploying Docker images from the EC2 Container Registry [#730](https://github.com/remind101/empire/pull/730).
 
+**Bugs**
+
+* `emp run` now works with unofficial Docker registries [#740](https://github.com/remind101/empire/pull/740).
+
 **Security**
 
 * Empire is now built with Go 1.5.3 to address [CVE-2015-8618](https://groups.google.com/forum/#!topic/golang-announce/MEATuOi_ei4) [#737](https://github.com/remind101/empire/pull/737).

--- a/empire.go
+++ b/empire.go
@@ -1,7 +1,6 @@
 package empire // import "github.com/remind101/empire"
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -562,14 +561,9 @@ func PullAndExtract(c *dockerutil.Client) ProcfileExtractor {
 	)
 
 	return ProcfileExtractor(func(ctx context.Context, img image.Image, w io.Writer) (procfile.Procfile, error) {
-		repo := img.Repository
-		if img.Registry != "" {
-			repo = fmt.Sprintf("%s/%s", img.Registry, img.Repository)
-		}
-
 		if err := c.PullImage(ctx, docker.PullImageOptions{
 			Registry:      img.Registry,
-			Repository:    repo,
+			Repository:    img.Repository,
 			Tag:           img.Tag,
 			OutputStream:  w,
 			RawJSONStream: true,

--- a/pkg/dockerutil/client.go
+++ b/pkg/dockerutil/client.go
@@ -1,6 +1,7 @@
 package dockerutil
 
 import (
+	"fmt"
 	"os"
 
 	"golang.org/x/net/context"
@@ -65,6 +66,13 @@ func newClient(authProvider dockerauth.AuthProvider, c *docker.Client) *Client {
 
 // PullImage wraps the docker clients PullImage to handle authentication.
 func (c *Client) PullImage(ctx context.Context, opts docker.PullImageOptions) error {
+	// This is to workaround an issue in the Docker API, where it doesn't
+	// respect the registry param. We have to put the registry in the
+	// repository field.
+	if opts.Registry != "" {
+		opts.Repository = fmt.Sprintf("%s/%s", opts.Registry, opts.Repository)
+	}
+
 	authConf, err := authConfiguration(c.AuthProvider, opts.Registry)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/739.

This extracts the logic that we were using to pull from unofficial registries during deployments into the dockerutil client so it can be re-used for `emp run`.

Tested this locally with the quay.io/remind/acme-inc image and it works as expected.