### PR TITLE
Allow emp run to be run against an EMPIRE_API_URL that includes ports

### DIFF
--- a/cmd/emp/run.go
+++ b/cmd/emp/run.go
@@ -131,11 +131,16 @@ func runRun(cmd *Command, args []string) {
 	address := u.Path
 	if protocol != "unix" {
 		protocol = "tcp"
-		address = u.Host + ":80"
-	}
-
-	if u.Scheme == "https" {
-		address = u.Host + ":443"
+		parts := strings.SplitN(u.Host, ":", 2)
+		if len(parts) == 2 {
+			address = u.Host
+		} else {
+			if u.Scheme == "https" {
+				address = u.Host + ":443"
+			} else {
+				address = u.Host + ":80"
+			}
+		}
 	}
 
 	var dial net.Conn

--- a/cmd/emp/run_test.go
+++ b/cmd/emp/run_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDialParams(t *testing.T) {
+	tests := []struct {
+		url string
+
+		proto, address string
+	}{
+		{"http://localhost", "tcp", "localhost:80"},
+		{"http://localhost:8080", "tcp", "localhost:8080"},
+
+		{"https://empire", "tls", "empire:443"},
+		{"https://empire:8443", "tls", "empire:8443"},
+	}
+
+	for _, tt := range tests {
+		url, err := url.Parse(tt.url)
+		assert.NoError(t, err)
+
+		proto, address := dialParams(url)
+		assert.Equal(t, tt.proto, proto)
+		assert.Equal(t, tt.address, address)
+	}
+}


### PR DESCRIPTION
Previously, if you tried to use `emp run` with an EMPIRE_API_URL that had the port in it (e.g. `http://localhost:8080`) you would get the following error:

```console
$ emp run bash -a acme-inc
error: dial tcp: too many colons in address 192.168.99.100:8080:80
```