### PR TITLE
GitHub team auth

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -18,6 +18,7 @@ const (
 	FlagGithubClientSecret = "github.client.secret"
 	FlagGithubOrg          = "github.organization"
 	FlagGithubApiURL       = "github.api.url"
+	FlagGithubTeam         = "github.team.id"
 
 	FlagGithubWebhooksSecret           = "github.webhooks.secret"
 	FlagGithubDeploymentsEnvironments  = "github.deployments.environment"
@@ -93,6 +94,12 @@ var Commands = []cli.Command{
 				Value:  "",
 				Usage:  "The organization to allow access to",
 				EnvVar: "EMPIRE_GITHUB_ORGANIZATION",
+			},
+			cli.StringFlag{
+				Name:   FlagGithubTeam,
+				Value:  "",
+				Usage:  "The ID of the github team to allow access to",
+				EnvVar: "EMPIRE_GITHUB_TEAM_ID",
 			},
 			cli.StringFlag{
 				Name:   FlagGithubApiURL,

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -109,12 +109,12 @@ func newAuthenticator(c *cli.Context, e *empire.Empire) auth.Authenticator {
 	}
 
 	// After the user is authenticated, check their GitHub Team membership.
-	if teamId := c.String(FlagGithubTeam); teamId != "" {
+	if teamID := c.String(FlagGithubTeam); teamID != "" {
 		authorizer := githubauth.NewTeamAuthorizer(client)
-		authorizer.TeamId = teamId
+		authorizer.TeamID = teamID
 
 		log.Println("Adding GitHub Team authorizer with the following configuration:")
-		log.Println(fmt.Sprintf("  Team ID: %v ", teamId))
+		log.Println(fmt.Sprintf("  Team ID: %v ", teamID))
 
 		return auth.WithAuthorization(
 			authenticator,

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -116,7 +116,11 @@ func newAuthenticator(c *cli.Context, e *empire.Empire) auth.Authenticator {
 		log.Println("Adding GitHub Team authorizer with the following configuration:")
 		log.Println(fmt.Sprintf("  Team ID: %v ", teamId))
 
-		return auth.WithAuthorization(authenticator, authorizer)
+		return auth.WithAuthorization(
+			authenticator,
+			// Cache the team check for 30 minutes
+			auth.CacheAuthorization(authorizer, 30*time.Minute),
+		)
 	}
 
 	return authenticator

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -110,7 +110,7 @@ func newAuthenticator(c *cli.Context, e *empire.Empire) auth.Authenticator {
 
 	// After the user is authenticated, check their GitHub Team membership.
 	if teamId := c.String(FlagGithubTeam); teamId != "" {
-		authorizer := github.NewTeamAuthorizer(client)
+		authorizer := githubauth.NewTeamAuthorizer(client)
 		authorizer.TeamId = teamId
 
 		log.Println("Adding GitHub Team authorizer with the following configuration:")

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -108,5 +108,16 @@ func newAuthenticator(c *cli.Context, e *empire.Empire) auth.Authenticator {
 		)
 	}
 
+	// After the user is authenticated, check their GitHub Team membership.
+	if teamId := c.String(FlagGithubTeam); teamId != "" {
+		authorizer := github.NewTeamAuthorizer(client)
+		authorizer.TeamId = teamId
+
+		log.Println("Adding GitHub Team authorizer with the following configuration:")
+		log.Println(fmt.Sprintf("  Team ID: %v ", teamId))
+
+		return auth.WithAuthorization(authenticator, authorizer)
+	}
+
 	return authenticator
 }

--- a/server/auth/github/client.go
+++ b/server/auth/github/client.go
@@ -178,8 +178,8 @@ func (c *Client) IsOrganizationMember(organization, token string) (bool, error) 
 }
 
 // IsTeamMember returns true if the given user is a member of the team.
-func (c *Client) IsTeamMember(teamId, name string, token string) (bool, error) {
-	req, err := c.NewRequest("GET", fmt.Sprintf("/teams/%s/memberships/%s", teamId, name), nil)
+func (c *Client) IsTeamMember(teamID, name string, token string) (bool, error) {
+	req, err := c.NewRequest("GET", fmt.Sprintf("/teams/%s/memberships/%s", teamID, name), nil)
 	if err != nil {
 		return false, err
 	}

--- a/server/auth/github/client.go
+++ b/server/auth/github/client.go
@@ -151,9 +151,9 @@ func (c *Client) GetUser(token string) (*User, error) {
 	return &u, nil
 }
 
-// IsMember returns true of the authenticated user is a member of the
+// IsOrganizationMember returns true of the authenticated user is a member of the
 // organization.
-func (c *Client) IsMember(organization, token string) (bool, error) {
+func (c *Client) IsOrganizationMember(organization, token string) (bool, error) {
 	req, err := c.NewRequest("HEAD", fmt.Sprintf("/user/memberships/orgs/%s", organization), nil)
 	if err != nil {
 		return false, err

--- a/server/auth/github/client.go
+++ b/server/auth/github/client.go
@@ -178,8 +178,13 @@ func (c *Client) IsOrganizationMember(organization, token string) (bool, error) 
 }
 
 // IsTeamMember returns true if the given user is a member of the team.
-func (c *Client) IsTeamMember(teamID, name string, token string) (bool, error) {
-	req, err := c.NewRequest("GET", fmt.Sprintf("/teams/%s/memberships/%s", teamID, name), nil)
+func (c *Client) IsTeamMember(teamID, token string) (bool, error) {
+	u, err := c.GetUser(token)
+	if err != nil {
+		return false, err
+	}
+
+	req, err := c.NewRequest("GET", fmt.Sprintf("/teams/%s/memberships/%s", teamID, u.Login), nil)
 	if err != nil {
 		return false, err
 	}

--- a/server/auth/github/client.go
+++ b/server/auth/github/client.go
@@ -79,6 +79,10 @@ type User struct {
 	Login string `json:"login"`
 }
 
+type TeamMembership struct {
+	State string `json:"state"`
+}
+
 // CreateAuthorization creates a new GitHub authorization (or returns the
 // existing authorization if present) for the GitHub OAuth application. See
 // http://goo.gl/bs9I3o.
@@ -171,6 +175,29 @@ func (c *Client) IsOrganizationMember(organization, token string) (bool, error) 
 	}
 
 	return true, nil
+}
+
+// IsTeamMember returns true if the given user is a member of the team.
+func (c *Client) IsTeamMember(teamId, name string, token string) (bool, error) {
+	req, err := c.NewRequest("GET", fmt.Sprintf("/teams/%s/memberships/%s", teamId, name), nil)
+	if err != nil {
+		return false, err
+	}
+
+	tokenAuth(req, token)
+
+	var t TeamMembership
+
+	resp, err := c.Do(req, &t)
+	if err != nil {
+		return false, err
+	}
+
+	if err := checkResponse(resp); err != nil {
+		return false, nil
+	}
+
+	return t.State == "active", nil
 }
 
 func (c *Client) NewRequest(method, path string, v interface{}) (*http.Request, error) {

--- a/server/auth/github/client_test.go
+++ b/server/auth/github/client_test.go
@@ -171,7 +171,7 @@ func TestClient_GetUser(t *testing.T) {
 	assert.Equal(t, "ejholmes", user.Login)
 }
 
-func TestClient_IsMember(t *testing.T) {
+func TestClient_IsOrganizationMember(t *testing.T) {
 	tests := []struct {
 		status int
 		member bool
@@ -198,7 +198,7 @@ func TestClient_IsMember(t *testing.T) {
 			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"login":"ejholmes"}`)),
 		}, nil)
 
-		ok, err := c.IsMember("remind101", "access_token")
+		ok, err := c.IsOrganizationMember("remind101", "access_token")
 		assert.NoError(t, err)
 		assert.Equal(t, tt.member, ok)
 	}

--- a/server/auth/github/client_test.go
+++ b/server/auth/github/client_test.go
@@ -223,7 +223,17 @@ func TestClient_IsTeamMember(t *testing.T) {
 			client: h,
 		}
 
-		req, _ := http.NewRequest("GET", "https://api.github.com/teams/123/memberships/ejholmes", nil)
+		req, _ := http.NewRequest("GET", "https://api.github.com/user", nil)
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+		req.SetBasicAuth("access_token", "x-oauth-basic")
+
+		h.On("Do", req).Return(&http.Response{
+			Request:    req,
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBufferString(`{"login":"ejholmes"}`)),
+		}, nil)
+
+		req, _ = http.NewRequest("GET", "https://api.github.com/teams/123/memberships/ejholmes", nil)
 		req.Header.Set("Accept", "application/vnd.github.v3+json")
 		req.SetBasicAuth("access_token", "x-oauth-basic")
 
@@ -233,7 +243,7 @@ func TestClient_IsTeamMember(t *testing.T) {
 			Body:       ioutil.NopCloser(bytes.NewBufferString(fmt.Sprintf("{\"state\": \"%s\"}", tt.state))),
 		}, nil)
 
-		ok, err := c.IsTeamMember("123", "ejholmes", "access_token")
+		ok, err := c.IsTeamMember("123", "access_token")
 		assert.NoError(t, err)
 		assert.Equal(t, tt.member, ok)
 	}

--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -60,7 +60,7 @@ type OrganizationAuthorizer struct {
 	Organization string
 
 	client interface {
-		IsMember(organization, token string) (bool, error)
+		IsOrganizationMember(organization, token string) (bool, error)
 	}
 }
 
@@ -75,7 +75,7 @@ func (a *OrganizationAuthorizer) Authorize(user *empire.User) error {
 		panic("no organization set")
 	}
 
-	ok, err := a.client.IsMember(a.Organization, user.GitHubToken)
+	ok, err := a.client.IsOrganizationMember(a.Organization, user.GitHubToken)
 	if err != nil {
 		return err
 	}

--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -92,10 +92,10 @@ func (a *OrganizationAuthorizer) Authorize(user *empire.User) error {
 // TeamAuthorizer is an implementation of the auth.Authorizer interface that
 // checks that the user is a member of the given GitHub team.
 type TeamAuthorizer struct {
-	TeamId string
+	TeamID string
 
 	client interface {
-		IsTeamMember(teamId, name string, token string) (bool, error)
+		IsTeamMember(teamID, name string, token string) (bool, error)
 	}
 }
 
@@ -104,18 +104,18 @@ func NewTeamAuthorizer(c *Client) *TeamAuthorizer {
 }
 
 func (a *TeamAuthorizer) Authorize(user *empire.User) error {
-	if a.TeamId == "" {
+	if a.TeamID == "" {
 		panic("no team id set")
 	}
 
-	ok, err := a.client.IsTeamMember(a.TeamId, user.Name, user.GitHubToken)
+	ok, err := a.client.IsTeamMember(a.TeamID, user.Name, user.GitHubToken)
 	if err != nil {
 		return err
 	}
 
 	if !ok {
 		return &auth.UnauthorizedError{
-			Reason: fmt.Sprintf("%s is not a member of team %s.", user.Name, a.TeamId),
+			Reason: fmt.Sprintf("%s is not a member of team %s.", user.Name, a.TeamID),
 		}
 	}
 

--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -95,7 +95,7 @@ type TeamAuthorizer struct {
 	TeamID string
 
 	client interface {
-		IsTeamMember(teamID, name string, token string) (bool, error)
+		IsTeamMember(teamID, token string) (bool, error)
 	}
 }
 
@@ -108,7 +108,7 @@ func (a *TeamAuthorizer) Authorize(user *empire.User) error {
 		panic("no team id set")
 	}
 
-	ok, err := a.client.IsTeamMember(a.TeamID, user.Name, user.GitHubToken)
+	ok, err := a.client.IsTeamMember(a.TeamID, user.GitHubToken)
 	if err != nil {
 		return err
 	}

--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -82,7 +82,7 @@ func (a *OrganizationAuthorizer) Authorize(user *empire.User) error {
 
 	if !ok {
 		return &auth.UnauthorizedError{
-			Reason: fmt.Sprintf("%s is not a member of the \"%s\" organization", user.Name, a.Organization),
+			Reason: fmt.Sprintf("%s is not a member of the \"%s\" organization.", user.Name, a.Organization),
 		}
 	}
 
@@ -115,7 +115,7 @@ func (a *TeamAuthorizer) Authorize(user *empire.User) error {
 
 	if !ok {
 		return &auth.UnauthorizedError{
-			Reason: fmt.Sprintf("%s is not a member of team %s", user.Name, a.TeamId),
+			Reason: fmt.Sprintf("%s is not a member of team %s.", user.Name, a.TeamId),
 		}
 	}
 

--- a/server/auth/github/github_test.go
+++ b/server/auth/github/github_test.go
@@ -86,7 +86,7 @@ func TestOrganizationAuthorizer_Unauthorized(t *testing.T) {
 		GitHubToken: "access_token"},
 	)
 	assert.IsType(t, &auth.UnauthorizedError{}, err)
-	assert.EqualError(t, err, `ejholmes is not a member of the "remind101" organization`)
+	assert.EqualError(t, err, `ejholmes is not a member of the "remind101" organization.`)
 }
 
 func TestTeamAuthorizer(t *testing.T) {
@@ -119,7 +119,7 @@ func TestTeamAuthorizer_Unauthorized(t *testing.T) {
 		GitHubToken: "access_token",
 	})
 	assert.IsType(t, &auth.UnauthorizedError{}, err)
-	assert.EqualError(t, err, `ejholmes is not a member of team 123`)
+	assert.EqualError(t, err, `ejholmes is not a member of team 123.`)
 }
 
 type mockClient struct {

--- a/server/auth/github/github_test.go
+++ b/server/auth/github/github_test.go
@@ -66,7 +66,7 @@ func TestOrganizationAuthorizer(t *testing.T) {
 		client:       c,
 	}
 
-	c.On("IsMember", "remind101", "access_token").Return(true, nil)
+	c.On("IsOrganizationMember", "remind101", "access_token").Return(true, nil)
 
 	err := a.Authorize(&empire.User{GitHubToken: "access_token"})
 	assert.NoError(t, err)
@@ -79,7 +79,7 @@ func TestOrganizationAuthorizer_Unauthorized(t *testing.T) {
 		client:       c,
 	}
 
-	c.On("IsMember", "remind101", "access_token").Return(false, nil)
+	c.On("IsOrganizationMember", "remind101", "access_token").Return(false, nil)
 
 	err := a.Authorize(&empire.User{
 		Name:        "ejholmes",
@@ -111,7 +111,7 @@ func (m *mockClient) GetUser(token string) (*User, error) {
 	return nil, args.Error(1)
 }
 
-func (m *mockClient) IsMember(organization, token string) (bool, error) {
+func (m *mockClient) IsOrganizationMember(organization, token string) (bool, error) {
 	args := m.Called(organization, token)
 	return args.Bool(0), args.Error(1)
 }

--- a/server/auth/github/github_test.go
+++ b/server/auth/github/github_test.go
@@ -96,7 +96,7 @@ func TestTeamAuthorizer(t *testing.T) {
 		client: c,
 	}
 
-	c.On("IsTeamMember", "123", "ejholmes", "access_token").Return(true, nil)
+	c.On("IsTeamMember", "123", "access_token").Return(true, nil)
 
 	err := a.Authorize(&empire.User{
 		Name:        "ejholmes",
@@ -112,7 +112,7 @@ func TestTeamAuthorizer_Unauthorized(t *testing.T) {
 		client: c,
 	}
 
-	c.On("IsTeamMember", "123", "ejholmes", "access_token").Return(false, nil)
+	c.On("IsTeamMember", "123", "access_token").Return(false, nil)
 
 	err := a.Authorize(&empire.User{
 		Name:        "ejholmes",
@@ -149,7 +149,7 @@ func (m *mockClient) IsOrganizationMember(organization, token string) (bool, err
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *mockClient) IsTeamMember(teamID, name string, token string) (bool, error) {
-	args := m.Called(teamID, name, token)
+func (m *mockClient) IsTeamMember(teamID, token string) (bool, error) {
+	args := m.Called(teamID, token)
 	return args.Bool(0), args.Error(1)
 }

--- a/server/auth/github/github_test.go
+++ b/server/auth/github/github_test.go
@@ -92,7 +92,7 @@ func TestOrganizationAuthorizer_Unauthorized(t *testing.T) {
 func TestTeamAuthorizer(t *testing.T) {
 	c := new(mockClient)
 	a := &TeamAuthorizer{
-		TeamId: "123",
+		TeamID: "123",
 		client: c,
 	}
 
@@ -108,7 +108,7 @@ func TestTeamAuthorizer(t *testing.T) {
 func TestTeamAuthorizer_Unauthorized(t *testing.T) {
 	c := new(mockClient)
 	a := &TeamAuthorizer{
-		TeamId: "123",
+		TeamID: "123",
 		client: c,
 	}
 
@@ -149,7 +149,7 @@ func (m *mockClient) IsOrganizationMember(organization, token string) (bool, err
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *mockClient) IsTeamMember(teamId, name string, token string) (bool, error) {
-	args := m.Called(teamId, name, token)
+func (m *mockClient) IsTeamMember(teamID, name string, token string) (bool, error) {
+	args := m.Called(teamID, name, token)
 	return args.Bool(0), args.Error(1)
 }


### PR DESCRIPTION
This allows users to limit empire access to members of a specific team within a github organization.

Github doesn't support fetching teams by name without a non trivial amount of work, so you have to use the team id.

To get the team id:

`curl  -i -u <username>:<password> https://api.github.com/orgs/<organization>/teams`

testing:
- wrote tests
- tested locally that i was rejected when not a member of a team, allowed access once i was a member