### PR TITLE
Add an ImageBuilder implementation for Conveyor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Empire now supports deploying Docker images from the EC2 Container Registry [#730](https://github.com/remind101/empire/pull/730).
 * The Docker logging driver that the ECS backend uses is now configurable via the `--ecs.logdriver` flag [#731](https://github.com/remind101/empire/pull/731).
 * It's now possible to lock down the GitHub authorization to a specific team via the `--github.team.id` flag [#745](https://github.com/remind101/empire/pull/745).
+* Empire can now integrate with Conveyor to build Docker images on demand when using the GitHub Deployments integration [#747](https://github.com/remind101/empire/pull/747).
 
 **Bugs**
 

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -22,8 +22,11 @@ const (
 
 	FlagGithubWebhooksSecret           = "github.webhooks.secret"
 	FlagGithubDeploymentsEnvironments  = "github.deployments.environment"
+	FlagGithubDeploymentsImageBuilder  = "github.deployments.image_builder"
 	FlagGithubDeploymentsImageTemplate = "github.deployments.template"
 	FlagGithubDeploymentsTugboatURL    = "github.deployments.tugboat.url"
+
+	FlagConveyorURL = "conveyor.url"
 
 	FlagDBPath = "path"
 	FlagDB     = "db"
@@ -120,9 +123,15 @@ var Commands = []cli.Command{
 				EnvVar: "EMPIRE_GITHUB_DEPLOYMENTS_ENVIRONMENT",
 			},
 			cli.StringFlag{
+				Name:   FlagGithubDeploymentsImageBuilder,
+				Value:  "template",
+				Usage:  "Determines how the Docker image to deploy is determined when a GitHub Deployment event is received. Possible options are `template` and `conveyor`.",
+				EnvVar: "EMPIRE_GITHUB_DEPLOYMENTS_IMAGE_BUILDER",
+			},
+			cli.StringFlag{
 				Name:   FlagGithubDeploymentsImageTemplate,
 				Value:  github.DefaultTemplate,
-				Usage:  "A Go text/template that will be used to determine the docker image to deploy.",
+				Usage:  "A Go text/template that will be used to determine the docker image to deploy. This flag is only used when `--" + FlagGithubDeploymentsImageBuilder + "` is set to `template`.",
 				EnvVar: "EMPIRE_GITHUB_DEPLOYMENTS_IMAGE_TEMPLATE",
 			},
 			cli.StringFlag{
@@ -130,6 +139,12 @@ var Commands = []cli.Command{
 				Value:  "",
 				Usage:  "If provided, logs from deployments triggered via GitHub deployments will be sent to this tugboat instance.",
 				EnvVar: "EMPIRE_TUGBOAT_URL",
+			},
+			cli.StringFlag{
+				Name:   FlagConveyorURL,
+				Value:  "",
+				Usage:  "When combined with the `--" + FlagGithubDeploymentsImageBuilder + "` flag when set to `conveyor`, this determines where the location of a Conveyor instance is to perform Docker image builds.",
+				EnvVar: "EMPIRE_CONVEYOR_URL",
 			},
 		}, append(EmpireFlags, DBFlags...)...),
 		Action: runServer,

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/codegangsta/cli"
+	"github.com/remind101/conveyor/client/conveyor"
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/server"
 	"github.com/remind101/empire/server/auth"
@@ -46,8 +47,19 @@ func newServer(c *cli.Context, e *empire.Empire) http.Handler {
 }
 
 func newImageBuilder(c *cli.Context) github.ImageBuilder {
-	tmpl := template.Must(template.New("image").Parse(c.String(FlagGithubDeploymentsImageTemplate)))
-	return github.ImageFromTemplate(tmpl)
+	builder := c.String(FlagGithubDeploymentsImageBuilder)
+
+	switch builder {
+	case "template":
+		tmpl := template.Must(template.New("image").Parse(c.String(FlagGithubDeploymentsImageTemplate)))
+		return github.ImageFromTemplate(tmpl)
+	case "conveyor":
+		s := conveyor.NewService(conveyor.DefaultClient)
+		s.URL = c.String(FlagConveyorURL)
+		return github.NewConveyorImageBuilder(s)
+	default:
+		panic(fmt.Sprintf("unknown image builder: %s", builder))
+	}
 }
 
 func newAuthenticator(c *cli.Context, e *empire.Empire) auth.Authenticator {

--- a/server/github/builder.go
+++ b/server/github/builder.go
@@ -2,30 +2,34 @@ package github
 
 import (
 	"bytes"
+	"io"
 	"text/template"
 
 	"github.com/ejholmes/hookshot/events"
+	"github.com/remind101/conveyor/client/conveyor"
 	"github.com/remind101/empire/pkg/image"
 	"golang.org/x/net/context"
 )
 
 // ImageBuilder is an interface that represents something that can build and
-// return a Docker image from a GitHub commit.
+// return a Docker image from a GitHub commit. If you need to stream build logs
+// back to the user, you can use the passed in io.Writer and write plain text
+// logs to it.
 type ImageBuilder interface {
-	BuildImage(ctx context.Context, event events.Deployment) (image.Image, error)
+	BuildImage(ctx context.Context, w io.Writer, event events.Deployment) (image.Image, error)
 }
 
-type ImageBuilderFunc func(context.Context, events.Deployment) (image.Image, error)
+type ImageBuilderFunc func(context.Context, io.Writer, events.Deployment) (image.Image, error)
 
-func (fn ImageBuilderFunc) BuildImage(ctx context.Context, event events.Deployment) (image.Image, error) {
-	return fn(ctx, event)
+func (fn ImageBuilderFunc) BuildImage(ctx context.Context, w io.Writer, event events.Deployment) (image.Image, error) {
+	return fn(ctx, w, event)
 }
 
 // ImageFromTemplate returns an ImageBuilder that will execute a template to
 // determine what docker image should be deployed. Note that this doesn't not
 // actually perform any "build".
 func ImageFromTemplate(t *template.Template) ImageBuilder {
-	return ImageBuilderFunc(func(ctx context.Context, event events.Deployment) (image.Image, error) {
+	return ImageBuilderFunc(func(ctx context.Context, _ io.Writer, event events.Deployment) (image.Image, error) {
 		buf := new(bytes.Buffer)
 		if err := t.Execute(buf, event); err != nil {
 			return image.Image{}, err
@@ -33,4 +37,38 @@ func ImageFromTemplate(t *template.Template) ImageBuilder {
 
 		return image.Decode(buf.String())
 	})
+}
+
+// conveyorClient mocks the interface to the Conveyor API.
+type conveyorClient interface {
+	Build(io.Writer, conveyor.BuildCreateOpts) (*conveyor.Artifact, error)
+}
+
+// ConveyorImageBuilder provides an ImageBuilder implementation that
+// integrates with the Conveyor (https://github.com/remind101/conveyor) Docker
+// build system. If enabled, Empire will check if an Artifact in Conveyor exists
+// for the git commit, and will trigger Conveyor to build it if it doesn't
+// exist.
+type ConveyorImageBuilder struct {
+	client conveyorClient
+}
+
+// NewConveyorImageBuilder returns a new ConveyorImageBuilder implementation
+// that uses the given client.
+func NewConveyorImageBuilder(c *conveyor.Service) *ConveyorImageBuilder {
+	return &ConveyorImageBuilder{
+		client: c,
+	}
+}
+
+func (c *ConveyorImageBuilder) BuildImage(ctx context.Context, w io.Writer, event events.Deployment) (image.Image, error) {
+	a, err := c.client.Build(w, conveyor.BuildCreateOpts{
+		Repository: event.Repository.FullName,
+		Sha:        &event.Deployment.Sha,
+	})
+	if err != nil {
+		return image.Image{}, err
+	}
+
+	return image.Decode(a.Image)
 }

--- a/server/github/github_test.go
+++ b/server/github/github_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"io/ioutil"
 	"testing"
 	"text/template"
 
@@ -29,7 +30,7 @@ func TestDefaultTemplate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		img, err := b.BuildImage(context.Background(), tt.d)
+		img, err := b.BuildImage(context.Background(), ioutil.Discard, tt.d)
 		assert.NoError(t, err)
 		assert.Equal(t, tt.out, img)
 	}

--- a/vendor/github.com/ernesto-jimenez/go-querystring/query/encode.go
+++ b/vendor/github.com/ernesto-jimenez/go-querystring/query/encode.go
@@ -1,0 +1,297 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package query implements encoding of structs into URL query parameters.
+//
+// As a simple example:
+//
+// 	type Options struct {
+// 		Query   string `url:"q"`
+// 		ShowAll bool   `url:"all"`
+// 		Page    int    `url:"page"`
+// 	}
+//
+// 	opt := Options{ "foo", true, 2 }
+// 	v, _ := query.Values(opt)
+// 	fmt.Print(v.Encode()) // will output: "q=foo&all=true&page=2"
+//
+// The exact mapping between Go values and url.Values is described in the
+// documentation for the Values() function.
+package query
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+var encoderType = reflect.TypeOf(new(Encoder)).Elem()
+
+// Encoder is an interface implemented by any type that wishes to encode
+// itself into URL values in a non-standard way.
+type Encoder interface {
+	EncodeValues(key string, v *url.Values) error
+}
+
+// Values returns the url.Values encoding of v.
+//
+// Values expects to be passed a struct, and traverses it recursively using the
+// following encoding rules.
+//
+// Each exported struct field is encoded as a URL parameter unless
+//
+//	- the field's tag is "-", or
+//	- the field is empty and its tag specifies the "omitempty" option
+//
+// The empty values are false, 0, any nil pointer or interface value, any array
+// slice, map, or string of length zero, and any time.Time that returns true
+// for IsZero().
+//
+// The URL parameter name defaults to the struct field name but can be
+// specified in the struct field's tag value.  The "url" key in the struct
+// field's tag value is the key name, followed by an optional comma and
+// options.  For example:
+//
+// 	// Field is ignored by this package.
+// 	Field int `url:"-"`
+//
+// 	// Field appears as URL parameter "myName".
+// 	Field int `url:"myName"`
+//
+// 	// Field appears as URL parameter "myName" and the field is omitted if
+// 	// its value is empty
+// 	Field int `url:"myName,omitempty"`
+//
+// 	// Field appears as URL parameter "Field" (the default), but the field
+// 	// is skipped if empty.  Note the leading comma.
+// 	Field int `url:",omitempty"`
+//
+// For encoding individual field values, the following type-dependent rules
+// apply:
+//
+// Boolean values default to encoding as the strings "true" or "false".
+// Including the "int" option signals that the field should be encoded as the
+// strings "1" or "0".
+//
+// time.Time values default to encoding as RFC3339 timestamps.  Including the
+// "unix" option signals that the field should be encoded as a Unix time (see
+// time.Unix())
+//
+// Slice and Array values default to encoding as multiple URL values of the
+// same name.  Including the "comma" option signals that the field should be
+// encoded as a single comma-delimited value.  Including the "space" option
+// similarly encodes the value as a single space-delimited string.
+//
+// Anonymous struct fields are usually encoded as if their inner exported
+// fields were fields in the outer struct, subject to the standard Go
+// visibility rules.  An anonymous struct field with a name given in its URL
+// tag is treated as having that name, rather than being anonymous.
+//
+// Non-nil pointer values are encoded as the value pointed to.
+//
+// All other values are encoded using their default string representation.
+//
+// Multiple fields that encode to the same URL parameter name will be included
+// as multiple URL values of the same name.
+func Values(v interface{}) (url.Values, error) {
+	val := reflect.ValueOf(v)
+	for val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return nil, errors.New("query: Values() expects non-nil value")
+		}
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("query: Values() expects struct input. Got %v", val.Kind())
+	}
+
+	values := make(url.Values)
+	err := reflectValue(values, val, "")
+	return values, err
+}
+
+// reflectValue populates the values parameter from the struct fields in val.
+// Embedded structs are followed recursively (using the rules defined in the
+// Values function documentation) breadth-first.
+func reflectValue(values url.Values, val reflect.Value, scope string) error {
+	var embedded []reflect.Value
+
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		sf := typ.Field(i)
+		if sf.PkgPath != "" { // unexported
+			continue
+		}
+
+		sv := val.Field(i)
+		tag := sf.Tag.Get("url")
+		if tag == "-" {
+			continue
+		}
+		name, opts := parseTag(tag)
+		if name == "" {
+			if sf.Anonymous && sv.Kind() == reflect.Struct {
+				// save embedded struct for later processing
+				embedded = append(embedded, sv)
+				continue
+			}
+
+			name = sf.Name
+		}
+
+		if scope != "" {
+			name = scope + "[" + name + "]"
+		}
+
+		if opts.Contains("omitempty") && isEmptyValue(sv) {
+			continue
+		}
+
+		if sv.Type().Implements(encoderType) {
+			m := sv.Interface().(Encoder)
+			if err := m.EncodeValues(name, &values); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if sv.Kind() == reflect.Slice || sv.Kind() == reflect.Array {
+			var del byte
+			if opts.Contains("comma") {
+				del = ','
+			} else if opts.Contains("space") {
+				del = ' '
+			} else if opts.Contains("key") {
+				name = name + "[]"
+			}
+
+			if del != 0 {
+				s := new(bytes.Buffer)
+				first := true
+				for i := 0; i < sv.Len(); i++ {
+					if first {
+						first = false
+					} else {
+						s.WriteByte(del)
+					}
+					s.WriteString(valueString(sv.Index(i), opts))
+				}
+				values.Add(name, s.String())
+			} else {
+				for i := 0; i < sv.Len(); i++ {
+					values.Add(name, valueString(sv.Index(i), opts))
+				}
+			}
+			continue
+		}
+
+		if sv.Type() == timeType {
+			values.Add(name, valueString(sv, opts))
+			continue
+		}
+
+		for sv.Kind() == reflect.Ptr {
+			if sv.IsNil() {
+				break
+			}
+			sv = sv.Elem()
+		}
+
+		if sv.Kind() == reflect.Struct {
+			reflectValue(values, sv, name)
+			continue
+		}
+
+		values.Add(name, valueString(sv, opts))
+	}
+
+	for _, f := range embedded {
+		if err := reflectValue(values, f, scope); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// valueString returns the string representation of a value.
+func valueString(v reflect.Value, opts tagOptions) string {
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return ""
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() == reflect.Bool && opts.Contains("int") {
+		if v.Bool() {
+			return "1"
+		}
+		return "0"
+	}
+
+	if v.Type() == timeType {
+		t := v.Interface().(time.Time)
+		if opts.Contains("unix") {
+			return strconv.FormatInt(t.Unix(), 10)
+		}
+		return t.Format(time.RFC3339)
+	}
+
+	return fmt.Sprint(v.Interface())
+}
+
+// isEmptyValue checks if a value should be considered empty for the purposes
+// of omitting fields with the "omitempty" option.
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+
+	if v.Type() == timeType {
+		return v.Interface().(time.Time).IsZero()
+	}
+
+	return false
+}
+
+// tagOptions is the string following a comma in a struct field's "url" tag, or
+// the empty string. It does not include the leading comma.
+type tagOptions []string
+
+// parseTag splits a struct field's url tag into its name and comma-separated
+// options.
+func parseTag(tag string) (string, tagOptions) {
+	s := strings.Split(tag, ",")
+	return s[0], s[1:]
+}
+
+// Contains checks whether the tagOptions contains the specified option.
+func (o tagOptions) Contains(option string) bool {
+	for _, s := range o {
+		if s == option {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/ernesto-jimenez/go-querystring/query/encode_test.go
+++ b/vendor/github.com/ernesto-jimenez/go-querystring/query/encode_test.go
@@ -1,0 +1,282 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package query
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type Nested struct {
+	A   SubNested  `url:"a"`
+	B   *SubNested `url:"b"`
+	Ptr *SubNested `url:"ptr,omitempty"`
+}
+
+type SubNested struct {
+	Value string `url:"value"`
+}
+
+func TestValues_types(t *testing.T) {
+	str := "string"
+	strPtr := &str
+
+	tests := []struct {
+		in   interface{}
+		want url.Values
+	}{
+		{
+			// basic primitives
+			struct {
+				A string
+				B int
+				C uint
+				D float32
+				E bool
+			}{},
+			url.Values{
+				"A": {""},
+				"B": {"0"},
+				"C": {"0"},
+				"D": {"0"},
+				"E": {"false"},
+			},
+		},
+		{
+			// pointers
+			struct {
+				A *string
+				B *int
+				C **string
+			}{A: strPtr, C: &strPtr},
+			url.Values{
+				"A": {str},
+				"B": {""},
+				"C": {str},
+			},
+		},
+		{
+			// slices and arrays
+			struct {
+				A []string
+				B []string `url:",comma"`
+				C []string `url:",space"`
+				D [2]string
+				E [2]string `url:",comma"`
+				F [2]string `url:",space"`
+				G []*string `url:",space"`
+				H []bool    `url:",int,space"`
+				I []string  `url:",key"`
+			}{
+				A: []string{"a", "b"},
+				B: []string{"a", "b"},
+				C: []string{"a", "b"},
+				D: [2]string{"a", "b"},
+				E: [2]string{"a", "b"},
+				F: [2]string{"a", "b"},
+				G: []*string{&str, &str},
+				H: []bool{true, false},
+				I: []string{"a", "b"},
+			},
+			url.Values{
+				"A":   {"a", "b"},
+				"B":   {"a,b"},
+				"C":   {"a b"},
+				"D":   {"a", "b"},
+				"E":   {"a,b"},
+				"F":   {"a b"},
+				"G":   {"string string"},
+				"H":   {"1 0"},
+				"I[]": {"a", "b"},
+			},
+		},
+		{
+			// other types
+			struct {
+				A time.Time
+				B time.Time `url:",unix"`
+				C bool      `url:",int"`
+				D bool      `url:",int"`
+			}{
+				A: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
+				B: time.Date(2000, 1, 1, 12, 34, 56, 0, time.UTC),
+				C: true,
+				D: false,
+			},
+			url.Values{
+				"A": {"2000-01-01T12:34:56Z"},
+				"B": {"946730096"},
+				"C": {"1"},
+				"D": {"0"},
+			},
+		},
+		{
+			struct {
+				Nest Nested `url:"nest"`
+			}{
+				Nested{
+					A: SubNested{
+						Value: "that",
+					},
+				},
+			},
+			url.Values{
+				"nest[a][value]": {"that"},
+				"nest[b]":        {""},
+			},
+		},
+		{
+			struct {
+				Nest Nested `url:"nest"`
+			}{
+				Nested{
+					Ptr: &SubNested{
+						Value: "that",
+					},
+				},
+			},
+			url.Values{
+				"nest[a][value]":   {""},
+				"nest[b]":          {""},
+				"nest[ptr][value]": {"that"},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		v, err := Values(tt.in)
+		if err != nil {
+			t.Errorf("%d. Values(%q) returned error: %v", i, tt.in, err)
+		}
+
+		if !reflect.DeepEqual(tt.want, v) {
+			t.Errorf("%d. Values(%q) returned %v, want %v", i, tt.in, v, tt.want)
+		}
+	}
+}
+
+func TestValues_omitEmpty(t *testing.T) {
+	str := ""
+	s := struct {
+		a string
+		A string
+		B string  `url:",omitempty"`
+		C string  `url:"-"`
+		D string  `url:"omitempty"` // actually named omitempty, not an option
+		E *string `url:",omitempty"`
+	}{E: &str}
+
+	v, err := Values(s)
+	if err != nil {
+		t.Errorf("Values(%q) returned error: %v", s, err)
+	}
+
+	want := url.Values{
+		"A":         {""},
+		"omitempty": {""},
+		"E":         {""}, // E is included because the pointer is not empty, even though the string being pointed to is
+	}
+	if !reflect.DeepEqual(want, v) {
+		t.Errorf("Values(%q) returned %v, want %v", s, v, want)
+	}
+}
+
+type A struct {
+	B
+}
+
+type B struct {
+	C string
+}
+
+type D struct {
+	B
+	C string
+}
+
+func TestValues_embeddedStructs(t *testing.T) {
+	tests := []struct {
+		in   interface{}
+		want url.Values
+	}{
+		{
+			A{B{C: "foo"}},
+			url.Values{"C": {"foo"}},
+		},
+		{
+			D{B: B{C: "bar"}, C: "foo"},
+			url.Values{"C": {"foo", "bar"}},
+		},
+	}
+
+	for i, tt := range tests {
+		v, err := Values(tt.in)
+		if err != nil {
+			t.Errorf("%d. Values(%q) returned error: %v", i, tt.in, err)
+		}
+
+		if !reflect.DeepEqual(tt.want, v) {
+			t.Errorf("%d. Values(%q) returned %v, want %v", i, tt.in, v, tt.want)
+		}
+	}
+}
+
+func TestValues_invalidInput(t *testing.T) {
+	_, err := Values("")
+	if err == nil {
+		t.Errorf("expected Values() to return an error on invalid input")
+	}
+}
+
+type EncodedArgs []string
+
+func (m EncodedArgs) EncodeValues(key string, v *url.Values) error {
+	for i, arg := range m {
+		v.Set(fmt.Sprintf("%s.%d", key, i), arg)
+	}
+	return nil
+}
+
+func TestValues_Marshaler(t *testing.T) {
+	s := struct {
+		Args EncodedArgs `url:"arg"`
+	}{[]string{"a", "b", "c"}}
+	v, err := Values(s)
+	if err != nil {
+		t.Errorf("Values(%q) returned error: %v", s, err)
+	}
+
+	want := url.Values{
+		"arg.0": {"a"},
+		"arg.1": {"b"},
+		"arg.2": {"c"},
+	}
+	if !reflect.DeepEqual(want, v) {
+		t.Errorf("Values(%q) returned %v, want %v", s, v, want)
+	}
+}
+
+func TestTagParsing(t *testing.T) {
+	name, opts := parseTag("field,foobar,foo")
+	if name != "field" {
+		t.Fatalf("name = %q, want field", name)
+	}
+	for _, tt := range []struct {
+		opt  string
+		want bool
+	}{
+		{"foobar", true},
+		{"foo", true},
+		{"bar", false},
+		{"field", false},
+	} {
+		if opts.Contains(tt.opt) != tt.want {
+			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+		}
+	}
+}

--- a/vendor/github.com/remind101/conveyor/client/conveyor/build.go
+++ b/vendor/github.com/remind101/conveyor/client/conveyor/build.go
@@ -1,0 +1,81 @@
+package conveyor
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// Build is a helper around the BuildCreate, BuildInfo, LogsStream and
+// ArtifactInfo methods to ultimately return an Artifact and stream any
+// build logs.
+func (s *Service) Build(w io.Writer, o BuildCreateOpts) (*Artifact, error) {
+	if o.Sha == nil {
+		return nil, errors.New("cannot build without sha")
+	}
+
+	repoSha := fmt.Sprintf("%s@%s", o.Repository, *o.Sha)
+
+	a, err := s.ArtifactInfo(repoSha)
+	if err == nil {
+		return a, nil
+	}
+
+	if !notFound(err) {
+		return nil, err
+	}
+
+	b, err := s.BuildInfo(repoSha)
+	if err != nil {
+		if !notFound(err) {
+			return nil, err
+		}
+
+		// No build, create one
+		b, err = s.BuildCreate(o)
+		if err != nil {
+			return nil, err
+		}
+
+		io.WriteString(w, fmt.Sprintf("Build: %s\n", b.ID))
+	} else {
+		// Create a new build if the existing build is failed.
+		if b.State == "failed" {
+			b, err = s.BuildCreate(o)
+			if err != nil {
+				return nil, err
+			}
+
+			io.WriteString(w, fmt.Sprintf("Build: %s\n", b.ID))
+		}
+	}
+
+	buildID := b.ID
+
+	if err := s.LogsStream(w, buildID); err != nil {
+		fmt.Fprintf(os.Stderr, "error streaming logs: %v\n", err)
+	}
+
+	for {
+		<-time.After(5 * time.Second)
+
+		b, err = s.BuildInfo(buildID)
+		if err != nil {
+			return nil, err
+		}
+
+		// If the build failed, return an error.
+		if b.State == "failed" {
+			return nil, fmt.Errorf("build %s failed", buildID)
+		}
+
+		// If the build completed, we should have an artifact.
+		if b.CompletedAt != nil {
+			break
+		}
+	}
+
+	return s.ArtifactInfo(repoSha)
+}

--- a/vendor/github.com/remind101/conveyor/client/conveyor/conveyor.go
+++ b/vendor/github.com/remind101/conveyor/client/conveyor/conveyor.go
@@ -1,0 +1,264 @@
+// Generated service client for conveyor API.
+//
+// To be able to interact with this API, you have to
+// create a new service:
+//
+//     s := conveyor.NewService(nil)
+//
+// The Service struct has all the methods you need
+// to interact with conveyor API.
+//
+package conveyor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/ernesto-jimenez/go-querystring/query"
+	"io"
+	"net/http"
+	"reflect"
+	"runtime"
+	"time"
+)
+
+const (
+	Version          = ""
+	DefaultUserAgent = "conveyor/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
+	DefaultURL       = "http://localhost:8080"
+)
+
+// Service represents your API.
+type Service struct {
+	client *http.Client
+	URL    string
+}
+
+// NewService creates a Service using the given, if none is provided
+// it uses http.DefaultClient.
+func NewService(c *http.Client) *Service {
+	if c == nil {
+		c = http.DefaultClient
+	}
+	return &Service{
+		client: c,
+		URL:    DefaultURL,
+	}
+}
+
+// NewRequest generates an HTTP request, but does not perform the request.
+func (s *Service) NewRequest(method, path string, body interface{}, q interface{}) (*http.Request, error) {
+	var ctype string
+	var rbody io.Reader
+	switch t := body.(type) {
+	case nil:
+	case string:
+		rbody = bytes.NewBufferString(t)
+	case io.Reader:
+		rbody = t
+	default:
+		v := reflect.ValueOf(body)
+		if !v.IsValid() {
+			break
+		}
+		if v.Type().Kind() == reflect.Ptr {
+			v = reflect.Indirect(v)
+			if !v.IsValid() {
+				break
+			}
+		}
+		j, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		rbody = bytes.NewReader(j)
+		ctype = "application/json"
+	}
+	req, err := http.NewRequest(method, s.URL+path, rbody)
+	if err != nil {
+		return nil, err
+	}
+	if q != nil {
+		v, err := query.Values(q)
+		if err != nil {
+			return nil, err
+		}
+		query := v.Encode()
+		if req.URL.RawQuery != "" && query != "" {
+			req.URL.RawQuery += "&"
+		}
+		req.URL.RawQuery += query
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", DefaultUserAgent)
+	if ctype != "" {
+		req.Header.Set("Content-Type", ctype)
+	}
+	return req, nil
+}
+
+// Do sends a request and decodes the response into v.
+func (s *Service) Do(v interface{}, method, path string, body interface{}, q interface{}, lr *ListRange) error {
+	req, err := s.NewRequest(method, path, body, q)
+	if err != nil {
+		return err
+	}
+	if lr != nil {
+		lr.SetHeader(req)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	switch t := v.(type) {
+	case nil:
+	case io.Writer:
+		_, err = io.Copy(t, resp.Body)
+	default:
+		err = json.NewDecoder(resp.Body).Decode(v)
+	}
+	return err
+}
+
+// Get sends a GET request and decodes the response into v.
+func (s *Service) Get(v interface{}, path string, query interface{}, lr *ListRange) error {
+	return s.Do(v, "GET", path, nil, query, lr)
+}
+
+// Patch sends a Path request and decodes the response into v.
+func (s *Service) Patch(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "PATCH", path, body, nil, nil)
+}
+
+// Post sends a POST request and decodes the response into v.
+func (s *Service) Post(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "POST", path, body, nil, nil)
+}
+
+// Put sends a PUT request and decodes the response into v.
+func (s *Service) Put(v interface{}, path string, body interface{}) error {
+	return s.Do(v, "PUT", path, body, nil, nil)
+}
+
+// Delete sends a DELETE request.
+func (s *Service) Delete(v interface{}, path string) error {
+	return s.Do(v, "DELETE", path, nil, nil, nil)
+}
+
+// ListRange describes a range.
+type ListRange struct {
+	Field      string
+	Max        int
+	Descending bool
+	FirstID    string
+	LastID     string
+}
+
+// SetHeader set headers on the given Request.
+func (lr *ListRange) SetHeader(req *http.Request) {
+	var hdrval string
+	if lr.Field != "" {
+		hdrval += lr.Field + " "
+	}
+	hdrval += lr.FirstID + ".." + lr.LastID
+	if lr.Max != 0 {
+		hdrval += fmt.Sprintf("; max=%d", lr.Max)
+		if lr.Descending {
+			hdrval += ", "
+		}
+	}
+	if lr.Descending {
+		hdrval += ", order=desc"
+	}
+	req.Header.Set("Range", hdrval)
+	return
+}
+
+// Bool allocates a new int value returns a pointer to it.
+func Bool(v bool) *bool {
+	p := new(bool)
+	*p = v
+	return p
+}
+
+// Int allocates a new int value returns a pointer to it.
+func Int(v int) *int {
+	p := new(int)
+	*p = v
+	return p
+}
+
+// Float64 allocates a new float64 value returns a pointer to it.
+func Float64(v float64) *float64 {
+	p := new(float64)
+	*p = v
+	return p
+}
+
+// String allocates a new string value returns a pointer to it.
+func String(v string) *string {
+	p := new(string)
+	*p = v
+	return p
+}
+
+// An artifact is the result of a successful build. It represents a
+// built Docker image and will tell what what you need to pull to obtain
+// the image.
+type Artifact struct {
+	Build struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of build
+	} `json:"build" url:"build,key"`
+	ID    string `json:"id" url:"id,key"`       // unique identifier of artifact
+	Image string `json:"image" url:"image,key"` // the name of the Docker image. This can be pulled with `docker pull`
+}
+
+func (s *Service) ArtifactInfo(artifactIdentity string) (*Artifact, error) {
+	var artifact Artifact
+	return &artifact, s.Get(&artifact, fmt.Sprintf("/artifacts/%v", artifactIdentity), nil, nil)
+}
+
+// A build represents a request to build a git commit for a repo.
+type Build struct {
+	Branch string `json:"branch" url:"branch,key"` // the branch within the GitHub repository that the build was triggered
+	// from
+	CompletedAt *time.Time `json:"completed_at" url:"completed_at,key"` // when the build moved to the `"succeeded"` or `"failed"` state
+	CreatedAt   time.Time  `json:"created_at" url:"created_at,key"`     // when the build was created
+	ID          string     `json:"id" url:"id,key"`                     // unique identifier of build
+	Repository  string     `json:"repository" url:"repository,key"`     // the GitHub repository that this build is for
+	Sha         string     `json:"sha" url:"sha,key"`                   // the git commit to build
+	StartedAt   *time.Time `json:"started_at" url:"started_at,key"`     // when the build moved to the `"building"` state
+	State       string     `json:"state" url:"state,key"`               // the current state of the build
+}
+type BuildCreateOpts struct {
+	Branch *string `json:"branch,omitempty" url:"branch,omitempty,key"` // the branch within the GitHub repository that the build was triggered
+	// from
+	Repository string  `json:"repository" url:"repository,key"`       // the GitHub repository that this build is for
+	Sha        *string `json:"sha,omitempty" url:"sha,omitempty,key"` // the git commit to build
+}
+
+// Create a new build and start it. Note that you cannot start a new
+// build for a sha that is already in a "pending" or "building" state.
+// You should cancel the existing build first, or wait for it to
+// complete. You must specify either a `branch` OR a `sha`. If you
+// provide a `branch` but no `sha`, Conveyor will use the GitHub API to
+// resolve the HEAD commit on that branch to a sha. If you provide a
+// `sha` but no `branch`, branch caching will be disabled.
+func (s *Service) BuildCreate(o BuildCreateOpts) (*Build, error) {
+	var build Build
+	return &build, s.Post(&build, fmt.Sprintf("/builds"), o)
+}
+
+// Info for existing build.
+func (s *Service) BuildInfo(buildIdentity string) (*Build, error) {
+	var build Build
+	return &build, s.Get(&build, fmt.Sprintf("/builds/%v", buildIdentity), nil, nil)
+}
+
+// Defines the format that errors are returned in
+type Error struct {
+	ID      string `json:"id" url:"id,key"`           // unique identifier of error
+	Message string `json:"message" url:"message,key"` // human readable message
+}
+

--- a/vendor/github.com/remind101/conveyor/client/conveyor/errors.go
+++ b/vendor/github.com/remind101/conveyor/client/conveyor/errors.go
@@ -1,0 +1,20 @@
+package conveyor
+
+import "net/url"
+
+var (
+	ErrNotFound = &Error{
+		ID:      "not_found",
+		Message: "resource was not found",
+	}
+)
+
+func notFound(err error) bool {
+	if err, ok := err.(*url.Error); ok {
+		if err, ok := err.Err.(*Error); ok {
+			return err.ID == ErrNotFound.ID
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/remind101/conveyor/client/conveyor/logs.go
+++ b/vendor/github.com/remind101/conveyor/client/conveyor/logs.go
@@ -1,0 +1,10 @@
+package conveyor
+
+import (
+	"fmt"
+	"io"
+)
+
+func (s *Service) LogsStream(w io.Writer, buildIdentity string) error {
+	return s.Get(w, fmt.Sprintf("/logs/%s", buildIdentity), nil, nil)
+}

--- a/vendor/github.com/remind101/conveyor/client/conveyor/transport.go
+++ b/vendor/github.com/remind101/conveyor/client/conveyor/transport.go
@@ -1,0 +1,75 @@
+package conveyor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+var DefaultTransport = &Transport{}
+
+var DefaultClient = &http.Client{
+	Transport: DefaultTransport,
+}
+
+// Transport is an http.RoundTripper implementation that decodes the Error
+// format that Conveyor returns.
+type Transport struct {
+	// Transport is the HTTP transport to use when making requests.
+	// It will default to http.DefaultTransport if nil.
+	Transport http.RoundTripper
+}
+
+// Forward CancelRequest to underlying Transport
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	tr, ok := t.Transport.(canceler)
+	if !ok {
+		return
+	}
+	tr.CancelRequest(req)
+}
+
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Transport == nil {
+		t.Transport = http.DefaultTransport
+	}
+
+	resp, err := t.Transport.RoundTrip(req)
+	if err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return nil, err
+	}
+
+	if err = checkResponse(resp); err != nil {
+		if resp != nil {
+			resp.Body.Close()
+		}
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+func checkResponse(resp *http.Response) error {
+	if resp.StatusCode/100 != 2 { // 200, 201, 202, etc
+		var e Error
+		err := json.NewDecoder(resp.Body).Decode(&e)
+		if err != nil {
+			return fmt.Errorf("encountered an error : %s", resp.Status)
+		}
+		if e.ID == ErrNotFound.ID && e.Message == ErrNotFound.Message {
+			return ErrNotFound
+		}
+		return &e
+	}
+	return nil
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -233,6 +233,11 @@
 			"revision": "4802bea385193a8f3268b38a2918d46049931d6b"
 		},
 		{
+			"path": "github.com/ernesto-jimenez/go-querystring/query",
+			"revision": "a9b7f983e384616b2a317c8f345701fb1688d061",
+			"revisionTime": "2014-11-09T01:42:17Z"
+		},
+		{
 			"path": "github.com/fsouza/go-dockerclient",
 			"revision": "f6e9f5396e0e8f34472efe443d0cb7f9af162b88"
 		},
@@ -439,6 +444,11 @@
 		{
 			"path": "github.com/pmylund/go-cache",
 			"revision": "93d85800f2fa6bd0a739e7bd612bfa3bc008b72d"
+		},
+		{
+			"path": "github.com/remind101/conveyor/client/conveyor",
+			"revision": "5b863aa009646c885b7b7422f6303d2988fb5722",
+			"revisionTime": "2016-02-04T11:21:13+07:00"
 		},
 		{
 			"path": "github.com/remind101/kinesumer",


### PR DESCRIPTION
This adds an implementation of the ImageBuilder interface backed by Conveyor. This means that if you're using Conveyor to build Docker images, it's no longer necessary to wait for the image to finish building before triggering a GitHub Deployment.

If a GitHub Deployment request is received by Empire, Empire will consult with Conveyor to obtain the Docker image for the given git sha, building it if necessary.

Not yet ready to merge, still needs some testing on both Conveyor's side and Empire's side.