### PR TITLE
Support setting nproc limit

### DIFF
--- a/migrations/0012_add_max_processes_column.down.sql
+++ b/migrations/0012_add_max_processes_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE processes DROP COLUMN nproc;

--- a/migrations/0012_add_max_processes_column.up.sql
+++ b/migrations/0012_add_max_processes_column.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE processes ADD COLUMN nproc bigint;
+UPDATE processes SET nproc = 0;

--- a/pkg/constraints/constraints.go
+++ b/pkg/constraints/constraints.go
@@ -155,17 +155,29 @@ func parseMemory(s string) (uint, error) {
 	return uint(n * float64(mult)), nil
 }
 
-// Constraints is a composition of CPUShares and Memory constraints.
+type Nproc uint
+
+func ParseNproc(s string) (Nproc, error) {
+	n, err := strconv.ParseUint(s, 10, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return Nproc(n), nil
+}
+
+// Constraints is a composition of CPUShares, Memory and Nproc constraints.
 type Constraints struct {
 	CPUShare
 	Memory
+	Nproc
 }
 
 func Parse(s string) (Constraints, error) {
 	var c Constraints
 
-	p := strings.SplitN(s, ConstraintsSeparator, 2)
-	if len(p) != 2 {
+	p := strings.SplitN(s, ConstraintsSeparator, 3)
+	if len(p) < 2 {
 		return c, ErrInvalidConstraint
 	}
 
@@ -182,6 +194,25 @@ func Parse(s string) (Constraints, error) {
 	}
 
 	c.Memory = m
+
+	if len(p) == 3 {
+		for _, kvspec := range strings.Split(p[2], ",") {
+			kv := strings.SplitN(kvspec, "=", 2)
+			if len(kv) != 2 {
+				return c, ErrInvalidConstraint
+			}
+
+			if kv[0] == "nproc" {
+				n, err := ParseNproc(kv[1])
+				if err != nil {
+					return c, err
+				}
+				c.Nproc = n
+			} else {
+				return c, ErrInvalidConstraint
+			}
+		}
+	}
 
 	return c, nil
 }

--- a/pkg/constraints/constraints_test.go
+++ b/pkg/constraints/constraints_test.go
@@ -104,10 +104,13 @@ func TestConstraints_Parse(t *testing.T) {
 		out Constraints
 		err error
 	}{
-		{"512:1KB", Constraints{512, 1024}, nil},
+		{"512:1KB", Constraints{512, 1024, 0}, nil},
+		{"512:1KB:nproc=512", Constraints{512, 1024, 512}, nil},
 		{"1025:1KB", Constraints{}, ErrInvalidCPUShare},
 
 		{"1024", Constraints{}, ErrInvalidConstraint},
+		{"1024:1KB:nproc", Constraints{}, ErrInvalidConstraint},
+		{"1024:1KB:nporc=512", Constraints{}, ErrInvalidConstraint},
 	}
 
 	for i, tt := range tests {

--- a/processes.go
+++ b/processes.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	Constraints1X = Constraints{constraints.CPUShare(256), constraints.Memory(512 * MB)}
-	Constraints2X = Constraints{constraints.CPUShare(512), constraints.Memory(1 * GB)}
-	ConstraintsPX = Constraints{constraints.CPUShare(1024), constraints.Memory(6 * GB)}
+	Constraints1X = Constraints{constraints.CPUShare(256), constraints.Memory(512 * MB), constraints.Nproc(256)}
+	Constraints2X = Constraints{constraints.CPUShare(512), constraints.Memory(1 * GB), constraints.Nproc(512)}
+	ConstraintsPX = Constraints{constraints.CPUShare(1024), constraints.Memory(6 * GB), 0}
 
 	// NamedConstraints maps a heroku dynos size to a Constraints.
 	NamedConstraints = map[string]Constraints{
@@ -189,7 +189,11 @@ func (c Constraints) String() string {
 		}
 	}
 
-	return fmt.Sprintf("%d:%s", c.CPUShare, c.Memory)
+	if c.Nproc == 0 {
+		return fmt.Sprintf("%d:%s", c.CPUShare, c.Memory)
+	} else {
+		return fmt.Sprintf("%d:%s:nproc=%d", c.CPUShare, c.Memory, c.Nproc)
+	}
 }
 
 // Formation maps a process ProcessType to a Process.

--- a/processes_test.go
+++ b/processes_test.go
@@ -107,7 +107,8 @@ func TestConstraints_UnmarshalJSON(t *testing.T) {
 		out Constraints
 		err error
 	}{
-		{"512:1KB", Constraints{512, 1024}, nil},
+		{"512:1KB", Constraints{512, 1024, 0}, nil},
+		{"512:1KB:nproc=512", Constraints{512, 1024, 512}, nil},
 		{"1025:1KB", Constraints{}, constraints.ErrInvalidCPUShare},
 
 		{"1024", Constraints{}, constraints.ErrInvalidConstraint},
@@ -141,7 +142,8 @@ func TestConstraints_String(t *testing.T) {
 		{Constraints2X, "2X"},
 		{ConstraintsPX, "PX"},
 
-		{Constraints{100, constraints.Memory(1 * MB)}, "100:1.00mb"},
+		{Constraints{100, constraints.Memory(1 * MB), 0}, "100:1.00mb"},
+		{Constraints{100, constraints.Memory(1 * MB), 512}, "100:1.00mb:nproc=512"},
 	}
 
 	for _, tt := range tests {

--- a/releases.go
+++ b/releases.go
@@ -319,6 +319,7 @@ func newServiceProcess(release *Release, p *Process) *scheduler.Process {
 		Instances:   uint(p.Quantity),
 		MemoryLimit: uint(p.Constraints.Memory),
 		CPUShares:   uint(p.Constraints.CPUShare),
+		Nproc:       uint(p.Constraints.Nproc),
 		Ports:       ports,
 		Exposure:    procExp,
 		SSLCert:     release.App.Cert,

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -82,6 +82,9 @@ type Process struct {
 	// the --cpu-shares flag for docker.
 	CPUShares uint
 
+	// ulimit -u
+	Nproc uint
+
 	// A load balancer to attach to the process.
 	LoadBalancer string
 

--- a/tasks.go
+++ b/tasks.go
@@ -54,6 +54,7 @@ func taskFromInstance(i *scheduler.Instance) *Task {
 		Constraints: Constraints{
 			CPUShare: constraints.CPUShare(i.Process.CPUShares),
 			Memory:   constraints.Memory(i.Process.MemoryLimit),
+			Nproc:    constraints.Nproc(i.Process.Nproc),
 		},
 		State:     i.State,
 		UpdatedAt: i.UpdatedAt,

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -88,6 +88,7 @@ func TestEmpire_Deploy(t *testing.T) {
 				Instances:   1,
 				MemoryLimit: 536870912,
 				CPUShares:   256,
+				Nproc:       256,
 				SSLCert:     "",
 				Env: map[string]string{
 					"EMPIRE_APPID":      app.ID,
@@ -248,6 +249,7 @@ func TestEmpire_Set(t *testing.T) {
 				Instances:   1,
 				MemoryLimit: 536870912,
 				CPUShares:   256,
+				Nproc:       256,
 				SSLCert:     "",
 				Env: map[string]string{
 					"EMPIRE_APPID":      app.ID,
@@ -293,6 +295,7 @@ func TestEmpire_Set(t *testing.T) {
 				Instances:   1,
 				MemoryLimit: 536870912,
 				CPUShares:   256,
+				Nproc:       256,
 				SSLCert:     "",
 				Env: map[string]string{
 					"EMPIRE_APPID":      app.ID,


### PR DESCRIPTION
This PR introduces the ability to set the `nproc` limit on containers. There are at least two use cases for this. The first being compatibility with Heroku's buildpacks, which use `ulimit -u` ([example 1](https://github.com/heroku/heroku-buildpack-jvm-common/blob/0d5c56c87a625f465a6103a5aead910fb6d00e04/opt/jvmcommon.sh), [example 2](https://github.com/heroku/heroku-buildpack-php/blob/4a787b268576d00f9adca57485d8c954adcefd06/bin/heroku-hhvm-nginx)) to detect dyno size and adjust parameters accordingly. The second being that `nproc` control is great for security purposes.

It is meant to be an optional part of the constraints spec, and not enabled by default for anything but the fixed dyno sizes. Note that this PR sets `nproc` for `1X` and `2X` dynos, but not `PX`. This is because `buildpack-jvm-common` sets too high of a heap size limit for the [legacy dyno spec](https://devcenter.heroku.com/articles/legacy-dynos) that Empire is using, and I fear that might lead to bad things. A custom `nproc` can be set by appending a third value to the constraints spec.