### PR TITLE
Default to the docker daemon default log driver.

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -207,7 +207,7 @@ var EmpireFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:   FlagECSLogDriver,
-		Value:  "json-file",
+		Value:  "",
 		Usage:  "Log driver to use when running containers. Maps to the --log-driver docker cli arg",
 		EnvVar: "EMPIRE_ECS_LOG_DRIVER",
 	},

--- a/pkg/ecsutil/ecs.go
+++ b/pkg/ecsutil/ecs.go
@@ -246,6 +246,10 @@ var validLogDrivers = map[string]bool{
 }
 
 func NewLogConfiguration(logDriver string, logOpts []string) *ecs.LogConfiguration {
+	if logDriver == "" {
+		// Default to the docker daemon default logging driver.
+		return nil
+	}
 
 	logOptions := make(map[string]*string)
 


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/762

In certain configurations, it's more desirable to use the default logging driver provided when running `docker daemon`, which won't always be `json-file`.