### PR TITLE
Force json-file logging driver for attached runs.

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -96,7 +96,11 @@ func (r *Runner) create(ctx context.Context, opts RunOpts) (*docker.Container, e
 			Cmd:          cmd,
 			Env:          envKeys(opts.Env),
 		},
-		HostConfig: &docker.HostConfig{},
+		HostConfig: &docker.HostConfig{
+			LogConfig: docker.LogConfig{
+				Type: "json-file",
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
Attached runs depends on the `json-file` logging driver, so we want to make sure it's used regardless of the logging driver set at `docker daemon` time.