### PR TITLE
Validate parsed accessed tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 * `emp run` now works with unofficial Docker registries [#740](https://github.com/remind101/empire/pull/740).
 * `emp scale -l` now lists configured scale, not the running processes [#769](https://github.com/remind101/empire/pull/769)
+* Fixed a bug where it was previously possible to create a signed access token with an empty username [#780](https://github.com/remind101/empire/pull/780)
 
 **Security**
 

--- a/access_tokens.go
+++ b/access_tokens.go
@@ -12,6 +12,15 @@ type AccessToken struct {
 	User  *User
 }
 
+// IsValid returns nil if the AccessToken is valid.
+func (t *AccessToken) IsValid() error {
+	if err := t.User.IsValid(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type accessTokensService struct {
 	Secret []byte // Secret used to sign jwt tokens.
 }
@@ -26,7 +35,7 @@ func (s *accessTokensService) AccessTokensCreate(token *AccessToken) (*AccessTok
 
 	token.Token = signed
 
-	return token, nil
+	return token, token.IsValid()
 }
 
 func (s *accessTokensService) AccessTokensFind(token string) (*AccessToken, error) {
@@ -44,7 +53,7 @@ func (s *accessTokensService) AccessTokensFind(token string) (*AccessToken, erro
 		at.Token = token
 	}
 
-	return at, nil
+	return at, at.IsValid()
 }
 
 // SignToken jwt signs the token and adds the signature to the Token field.

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -34,6 +34,31 @@ func TestMain(m *testing.M) {
 	empiretest.Run(m)
 }
 
+func TestEmpire_AccessTokens(t *testing.T) {
+	e := empiretest.NewEmpire(t)
+
+	token := &empire.AccessToken{
+		User: &empire.User{Name: "ejholmes"},
+	}
+	_, err := e.AccessTokensCreate(token)
+	assert.NoError(t, err)
+
+	token, err = e.AccessTokensFind(token.Token)
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.Equal(t, "ejholmes", token.User.Name)
+
+	token, err = e.AccessTokensFind("invalid")
+	assert.NoError(t, err)
+	assert.Nil(t, token)
+
+	token = &empire.AccessToken{
+		User: &empire.User{Name: ""},
+	}
+	_, err = e.AccessTokensCreate(token)
+	assert.Equal(t, empire.ErrUserName, err)
+}
+
 func TestEmpire_CertsAttach(t *testing.T) {
 	e := empiretest.NewEmpire(t)
 	s := new(mockScheduler)

--- a/users.go
+++ b/users.go
@@ -1,6 +1,8 @@
 package empire
 
-import "net/http"
+import "errors"
+
+var ErrUserName = errors.New("Name is required")
 
 // User represents a user of Empire.
 type User struct {
@@ -8,29 +10,11 @@ type User struct {
 	GitHubToken string `json:"-"`
 }
 
-// GitHubClient returns an http.Client that will automatically add the
-// GitHubToken to all requests.
-func (u *User) GitHubClient() *http.Client {
-	return &http.Client{
-		Transport: &githubTransport{
-			Token: u.GitHubToken,
-		},
-	}
-}
-
-// githubTransport is an http.RoundTripper that will automatically set an oauth
-// token as the basic auth credentials before dispatching a request.
-type githubTransport struct {
-	Token     string
-	Transport http.RoundTripper
-}
-
-func (t *githubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if t.Transport == nil {
-		t.Transport = http.DefaultTransport
+// IsValid returns nil if the User is valid.
+func (u *User) IsValid() error {
+	if u.Name == "" {
+		return ErrUserName
 	}
 
-	req.SetBasicAuth(t.Token, "x-oauth-basic")
-
-	return t.Transport.RoundTrip(req)
+	return nil
 }


### PR DESCRIPTION
I've seen cases where `Claims["User"]["Name"]` is an empty string. I don't have a good repro for when that can happen (last time I saw it, I had signed in when the GitHub API was having issues), but this will validate the access token before creating it and after decoding it.