### PR TITLE
Reduce number of DescribeTaskDefinition calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 * `emp run` now works with unofficial Docker registries [#740](https://github.com/remind101/empire/pull/740).
 * `emp scale -l` now lists configured scale, not the running processes [#769](https://github.com/remind101/empire/pull/769)
 
+**Performance**
+
+* `emp ps` should be significantly faster for services running a lot of processes [#781](https://github.com/remind101/empire/pull/781)
+
 **Security**
 
 * Empire is now built with Go 1.5.3 to address [CVE-2015-8618](https://groups.google.com/forum/#!topic/golang-announce/MEATuOi_ei4) [#737](https://github.com/remind101/empire/pull/737).

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -130,7 +130,7 @@ func TestScheduler_Instances(t *testing.T) {
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"taskArns":["arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570"]}`,
+				Body:       `{"taskArns":["arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570","arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74571"]}`,
 			},
 		},
 
@@ -150,11 +150,11 @@ func TestScheduler_Instances(t *testing.T) {
 			Request: awsutil.Request{
 				RequestURI: "/",
 				Operation:  "AmazonEC2ContainerServiceV20141113.DescribeTasks",
-				Body:       `{"cluster":"empire","tasks":["arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570"]}`,
+				Body:       `{"cluster":"empire","tasks":["arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570","arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74571"]}`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"tasks":[{"taskArn":"arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570","taskDefinitionArn":"arn:aws:ecs:us-east-1:249285743859:task-definition/1234--web","lastStatus":"RUNNING","startedAt": 1448419193}]}`,
+				Body:       `{"tasks":[{"taskArn":"arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74570","taskDefinitionArn":"arn:aws:ecs:us-east-1:249285743859:task-definition/1234--web","lastStatus":"RUNNING","startedAt": 1448419193},{"taskArn":"arn:aws:ecs:us-east-1:249285743859:task/ae69bb4c-3903-4844-82fe-548ac5b74571","taskDefinitionArn":"arn:aws:ecs:us-east-1:249285743859:task-definition/1234--web","lastStatus":"RUNNING","startedAt": 1448419193}]}`,
 			},
 		},
 
@@ -178,8 +178,8 @@ func TestScheduler_Instances(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(instances) != 1 {
-		t.Fatal("expected 1 instance")
+	if len(instances) != 2 {
+		t.Fatal("expected 2 instances")
 	}
 
 	i := instances[0]


### PR DESCRIPTION
Related to https://github.com/remind101/empire/issues/751.

Previously we naively described the task definition for each ECS task when running `emp ps`. In reality, most tasks will share the same task definition, so this means we make a lot of duplicate and unnecessary `DescribeTaskDefinition` api calls.

This will describe each unique task definition in the list of tasks, then store it in a map. The calls to DescribeTaskDefinition could also be parallelized, but I'll save that for a different PR.