### PR TITLE
Describe task definitions in parallel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 **Performance**
 
-* `emp ps` should be significantly faster for services running a lot of processes [#781](https://github.com/remind101/empire/pull/781)
+* `emp ps` should be significantly faster for services running a lot of processes [#781](https://github.com/remind101/empire/pull/781), [#782](https://github.com/remind101/empire/pull/782)
 
 **Security**
 


### PR DESCRIPTION
For apps with a large number of processes defined in the Procfile, describing each task definition sequentially can take some time. The ECS api doesn't provide an endpoint for describing multiple task definitions, so this describes them in parallel.