### PR TITLE
ECR auth: multi-region support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * `emp run` now works with unofficial Docker registries [#740](https://github.com/remind101/empire/pull/740).
 * `emp scale -l` now lists configured scale, not the running processes [#769](https://github.com/remind101/empire/pull/769)
 * Fixed a bug where it was previously possible to create a signed access token with an empty username [#780](https://github.com/remind101/empire/pull/780)
+* ECR authentication now supports multiple regions, and works independently of ECS region [#784](https://github.com/remind101/empire/pull/784)
 
 **Performance**
 

--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -268,8 +268,11 @@ func newHBReporter(key, env string) (reporter.Reporter, error) {
 // Auth provider =======================
 
 func newAuthProvider(c *cli.Context) (dockerauth.AuthProvider, error) {
+	awsSession := newConfigProvider(c)
 	provider := dockerauth.NewMultiAuthProvider()
-	provider.AddProvider(dockerauth.NewECRAuthProvider(ecr.New(newConfigProvider(c))))
+	provider.AddProvider(dockerauth.NewECRAuthProvider(func(region string) dockerauth.ECR {
+		return ecr.New(awsSession, &aws.Config{Region: aws.String(region)})
+	}))
 
 	if dockerConfigPath := c.String(FlagDockerAuth); dockerConfigPath != "" {
 		dockerConfigFile, err := os.Open(dockerConfigPath)


### PR DESCRIPTION
Since ECR has [launched in additional regions](https://aws.amazon.com/about-aws/whats-new/2016/03/amazon-ec2-container-registry-available-in-eu-ireland/), I've added support by passing a factory function to `NewECRAuthProvider`.

This also addresses a stupid oversight with my original implementation, when running Empire in a region different from the ECR image it is trying to pull.