### PR TITLE
Use []string internally for commands

### DIFF
--- a/empire.go
+++ b/empire.go
@@ -337,7 +337,7 @@ type RunOpts struct {
 	App *App
 
 	// The command to run.
-	Command string
+	Command Command
 
 	// If provided, input will be read from this.
 	Input io.Reader

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -88,6 +88,6 @@ func Run(m *testing.M) {
 // ExtractProcfile extracts a fake procfile.
 func ExtractProcfile(ctx context.Context, img image.Image, w io.Writer) (procfile.Procfile, error) {
 	return procfile.Procfile{
-		"web": "./bin/web",
+		"web": []string{"./bin/web"},
 	}, dockerutil.FakePull(img, w)
 }

--- a/events.go
+++ b/events.go
@@ -10,7 +10,7 @@ import (
 type RunEvent struct {
 	User     string
 	App      string
-	Command  string
+	Command  Command
 	URL      string
 	Attached bool
 }
@@ -24,7 +24,7 @@ func (e RunEvent) String() string {
 	if e.Attached {
 		attachment = "attached"
 	}
-	msg := fmt.Sprintf("%s ran `%s` (%s) on %s", e.User, e.Command, attachment, e.App)
+	msg := fmt.Sprintf("%s ran `%s` (%s) on %s", e.User, e.Command.String(), attachment, e.App)
 	if e.URL != "" {
 		msg = fmt.Sprintf("%s (<%s|logs>)", msg, e.URL)
 	}

--- a/events_test.go
+++ b/events_test.go
@@ -12,9 +12,9 @@ func TestEvents_String(t *testing.T) {
 		out   string
 	}{
 		// RunEvent
-		{RunEvent{User: "ejholmes", App: "acme-inc", Command: "bash"}, "ejholmes ran `bash` (detached) on acme-inc"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: "bash"}, "ejholmes ran `bash` (attached) on acme-inc"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: "bash"}, "ejholmes ran `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>)"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}}, "ejholmes ran `bash` (detached) on acme-inc"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}}, "ejholmes ran `bash` (attached) on acme-inc"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}}, "ejholmes ran `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>)"},
 
 		// RestartEvent
 		{RestartEvent{User: "ejholmes", App: "acme-inc"}, "ejholmes restarted acme-inc"},

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -9,7 +9,6 @@ import (
 	"code.google.com/p/go-uuid/uuid"
 
 	"github.com/fsouza/go-dockerclient"
-	shellwords "github.com/mattn/go-shellwords"
 	"github.com/remind101/empire/pkg/dockerutil"
 	"github.com/remind101/empire/pkg/image"
 	"golang.org/x/net/context"
@@ -25,7 +24,7 @@ type RunOpts struct {
 	Image image.Image
 
 	// Command is the command to run.
-	Command string
+	Command []string
 
 	// Environment variables to set.
 	Env map[string]string
@@ -79,11 +78,6 @@ func (r *Runner) pull(ctx context.Context, img image.Image, out io.Writer) error
 }
 
 func (r *Runner) create(ctx context.Context, opts RunOpts) (*docker.Container, error) {
-	cmd, err := shellwords.Parse(opts.Command)
-	if err != nil {
-		return nil, err
-	}
-
 	return r.client.CreateContainer(ctx, docker.CreateContainerOptions{
 		Name: uuid.New(),
 		Config: &docker.Config{
@@ -93,7 +87,7 @@ func (r *Runner) create(ctx context.Context, opts RunOpts) (*docker.Container, e
 			AttachStderr: true,
 			OpenStdin:    true,
 			Image:        opts.Image.String(),
-			Cmd:          cmd,
+			Cmd:          opts.Command,
 			Env:          envKeys(opts.Env),
 		},
 		HostConfig: &docker.HostConfig{

--- a/processes_test.go
+++ b/processes_test.go
@@ -21,13 +21,13 @@ func TestNewFormation(t *testing.T) {
 		{
 			f: nil,
 			cm: CommandMap{
-				"web": "./bin/web",
+				"web": Command{"./bin/web"},
 			},
 			expected: Formation{
 				"web": &Process{
 					Type:        "web",
 					Quantity:    1,
-					Command:     "./bin/web",
+					Command:     Command{"./bin/web"},
 					Constraints: NamedConstraints["1X"],
 				},
 			},
@@ -36,13 +36,13 @@ func TestNewFormation(t *testing.T) {
 		{
 			f: Formation{},
 			cm: CommandMap{
-				"web": "./bin/web",
+				"web": Command{"./bin/web"},
 			},
 			expected: Formation{
 				"web": &Process{
 					Type:        "web",
 					Quantity:    1,
-					Command:     "./bin/web",
+					Command:     Command{"./bin/web"},
 					Constraints: NamedConstraints["1X"],
 				},
 			},
@@ -51,13 +51,13 @@ func TestNewFormation(t *testing.T) {
 		{
 			f: Formation{},
 			cm: CommandMap{
-				"worker": "sidekiq",
+				"worker": Command{"sidekiq"},
 			},
 			expected: Formation{
 				"worker": &Process{
 					Type:        "worker",
 					Quantity:    0,
-					Command:     "sidekiq",
+					Command:     Command{"sidekiq"},
 					Constraints: NamedConstraints["1X"],
 				},
 			},
@@ -68,24 +68,24 @@ func TestNewFormation(t *testing.T) {
 				"web": &Process{
 					Type:        "web",
 					Quantity:    5,
-					Command:     "rackup",
+					Command:     Command{"rackup"},
 					Constraints: NamedConstraints["1X"],
 				},
 				"worker": &Process{
 					Type:        "worker",
 					Quantity:    2,
-					Command:     "sidekiq",
+					Command:     Command{"sidekiq"},
 					Constraints: NamedConstraints["1X"],
 				},
 			},
 			cm: CommandMap{
-				"web": "./bin/web",
+				"web": Command{"./bin/web"},
 			},
 			expected: Formation{
 				"web": &Process{
 					Type:        "web",
 					Quantity:    5,
-					Command:     "./bin/web",
+					Command:     Command{"./bin/web"},
 					Constraints: NamedConstraints["1X"],
 				},
 			},

--- a/procfile/extractor.go
+++ b/procfile/extractor.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"strings"
 
 	"github.com/remind101/empire/pkg/image"
 
@@ -50,7 +49,7 @@ func (e *CMDExtractor) Extract(img image.Image) (Procfile, error) {
 		return pm, err
 	}
 
-	pm["web"] = strings.Join(i.Config.Cmd, " ")
+	pm["web"] = i.Config.Cmd
 
 	return pm, nil
 }

--- a/procfile/extractor_test.go
+++ b/procfile/extractor_test.go
@@ -35,7 +35,7 @@ func TestCMDExtractor(t *testing.T) {
 	}
 
 	want := Procfile{
-		"web": "/go/bin/app server",
+		"web": []string{"/go/bin/app", "server"},
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -74,7 +74,7 @@ func TestProcfileExtractor(t *testing.T) {
 	}
 
 	want := Procfile{
-		"web": "rails server",
+		"web": []string{"rails", "server"},
 	}
 
 	if !reflect.DeepEqual(got, want) {
@@ -118,7 +118,7 @@ func TestProcfileFallbackExtractor(t *testing.T) {
 	}
 
 	want := Procfile{
-		"web": "/go/bin/app server",
+		"web": []string{"/go/bin/app", "server"},
 	}
 
 	if !reflect.DeepEqual(got, want) {

--- a/procfile/procfile.go
+++ b/procfile/procfile.go
@@ -1,20 +1,33 @@
 package procfile
 
-import "gopkg.in/yaml.v2"
+import (
+	"github.com/mattn/go-shellwords"
+	"gopkg.in/yaml.v2"
+)
 
 // Procfile is a Go representation of a Procfile, which maps a named process to
 // a command to run.
-//
-// TODO: This would be better represented as a map[string][]string.
-type Procfile map[string]string
+type Procfile map[string][]string
+
+// yamlProcfile is a struct that we can yaml.Unmarshal into.
+type yamlProcfile map[string]string
 
 // ParseProcfile takes a byte slice representing a YAML Procfile and parses it
 // into a Procfile.
 func ParseProcfile(b []byte) (Procfile, error) {
-	p := make(Procfile)
+	y := make(yamlProcfile)
 
-	if err := yaml.Unmarshal(b, &p); err != nil {
-		return p, err
+	if err := yaml.Unmarshal(b, &y); err != nil {
+		return nil, err
+	}
+
+	p := make(Procfile)
+	for process, command := range y {
+		args, err := shellwords.Parse(command)
+		if err != nil {
+			return nil, err
+		}
+		p[process] = args
 	}
 
 	return p, nil

--- a/releases.go
+++ b/releases.go
@@ -292,7 +292,7 @@ func newServiceProcess(release *Release, p *Process) *scheduler.Process {
 		Type:        string(p.Type),
 		Env:         env,
 		Labels:      labels,
-		Command:     string(p.Command),
+		Command:     []string(p.Command),
 		Image:       release.Slug.Image,
 		Instances:   uint(p.Quantity),
 		MemoryLimit: uint(p.Constraints.Memory),

--- a/runner.go
+++ b/runner.go
@@ -63,7 +63,7 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 	}
 
 	a := newServiceApp(release)
-	p := newServiceProcess(release, NewProcess("run", Command(opts.Command)))
+	p := newServiceProcess(release, NewProcess("run", opts.Command))
 
 	for k, v := range opts.Env {
 		p.Env[k] = v

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -7,14 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	shellwords "github.com/mattn/go-shellwords"
 	"github.com/remind101/empire/pkg/arn"
 	. "github.com/remind101/empire/pkg/bytesize"
 	"github.com/remind101/empire/pkg/ecsutil"
@@ -344,14 +342,9 @@ func (m *Scheduler) createTaskDefinition(ctx context.Context, app *scheduler.App
 }
 
 func (m *Scheduler) taskDefinitionInput(p *scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.RegisterTaskDefinitionInput, error) {
-	args, err := shellwords.Parse(p.Command)
-	if err != nil {
-		return nil, err
-	}
-
 	// ecs.ContainerDefinition{Command} is expecting a []*string
 	var command []*string
-	for _, s := range args {
+	for _, s := range p.Command {
 		ss := s
 		command = append(command, &ss)
 	}
@@ -684,7 +677,7 @@ func taskDefinitionToProcess(td *ecs.TaskDefinition) (*scheduler.Process, error)
 
 	return &scheduler.Process{
 		Type:        safeString(container.Name),
-		Command:     strings.Join(command, " "),
+		Command:     command,
 		Env:         env,
 		CPUShares:   uint(*container.Cpu),
 		MemoryLimit: uint(*container.Memory) * MB,

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -61,7 +61,7 @@ func TestScheduler_Submit(t *testing.T) {
 			Request: awsutil.Request{
 				RequestURI: "/",
 				Operation:  "AmazonEC2ContainerServiceV20141113.RegisterTaskDefinition",
-				Body:       `{"containerDefinitions":[{"cpu":128,"command":["acme-inc", "web", "--port 80"],"environment":[{"name":"USER","value":"foo"},{"name":"PORT","value":"8080"}],"dockerLabels":{"label1":"foo","label2":"bar"},"essential":true,"image":"remind101/acme-inc:latest","memory":128,"name":"web","portMappings":[{"containerPort":8080,"hostPort":8080}]}],"family":"1234--web"}`,
+				Body:       `{"containerDefinitions":[{"cpu":128,"command":["acme-inc", "web", "--port", "80"],"environment":[{"name":"USER","value":"foo"},{"name":"PORT","value":"8080"}],"dockerLabels":{"label1":"foo","label2":"bar"},"essential":true,"image":"remind101/acme-inc:latest","memory":128,"name":"web","portMappings":[{"containerPort":8080,"hostPort":8080}]}],"family":"1234--web"}`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
@@ -176,7 +176,7 @@ func TestScheduler_Instances(t *testing.T) {
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
-				Body:       `{"taskDefinition":{"containerDefinitions":[{"name":"web","cpu":256,"memory":256,"command":["acme-inc", "web", "--port 80"]}]}}`,
+				Body:       `{"taskDefinition":{"containerDefinitions":[{"name":"web","cpu":256,"memory":256,"command":["acme-inc", "web", "--port", "80"]}]}}`,
 			},
 		},
 	})
@@ -202,7 +202,7 @@ func TestScheduler_Instances(t *testing.T) {
 		t.Fatalf("UpdatedAt => %s; want %s", got, want)
 	}
 
-	if got, want := i.Process.Command, "acme-inc web --port 80"; got != want {
+	if got, want := i.Process.Command, []string{"acme-inc", "web", "--port", "80"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Command => %s; want %s", got, want)
 	}
 
@@ -432,7 +432,7 @@ func TestScheduler_Run(t *testing.T) {
 			Request: awsutil.Request{
 				RequestURI: "/",
 				Operation:  "AmazonEC2ContainerServiceV20141113.RegisterTaskDefinition",
-				Body:       `{"containerDefinitions":[{"cpu":128,"command":["acme-inc", "web", "--port 80"],"environment":[{"name":"USER","value":"foo"}],"dockerLabels":{"label1":"foo","label2":"bar"},"essential":true,"image":"remind101/acme-inc:latest","memory":128,"name":"run"}],"family":"1234--run"}`,
+				Body:       `{"containerDefinitions":[{"cpu":128,"command":["acme-inc", "web", "--port", "80"],"environment":[{"name":"USER","value":"foo"}],"dockerLabels":{"label1":"foo","label2":"bar"},"essential":true,"image":"remind101/acme-inc:latest","memory":128,"name":"run"}],"family":"1234--run"}`,
 			},
 			Response: awsutil.Response{
 				StatusCode: 200,
@@ -458,7 +458,7 @@ func TestScheduler_Run(t *testing.T) {
 	process := &scheduler.Process{
 		Type:    "run",
 		Image:   image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
-		Command: "acme-inc web '--port 80'",
+		Command: []string{"acme-inc", "web", "--port", "80"},
 		Env: map[string]string{
 			"USER": "foo",
 		},
@@ -659,7 +659,7 @@ var fakeApp = &scheduler.App{
 		&scheduler.Process{
 			Type:    "web",
 			Image:   image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
-			Command: "acme-inc web '--port 80'",
+			Command: []string{"acme-inc", "web", "--port", "80"},
 			Env: map[string]string{
 				"USER": "foo",
 			},

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -50,7 +50,7 @@ type Process struct {
 	Image image.Image
 
 	// The Command to run.
-	Command string
+	Command []string
 
 	// Environment variables to set.
 	Env map[string]string

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -18,7 +18,7 @@ type Dyno heroku.Dyno
 
 func newDyno(task *empire.Task) *Dyno {
 	return &Dyno{
-		Command:   task.Command,
+		Command:   task.Command.String(),
 		Type:      task.Type,
 		Name:      task.Name,
 		State:     task.State,
@@ -80,10 +80,15 @@ func (h *PostProcess) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
+	command, err := empire.ParseCommand(form.Command)
+	if err != nil {
+		return err
+	}
+
 	opts := empire.RunOpts{
 		User:    UserFromContext(ctx),
 		App:     a,
-		Command: form.Command,
+		Command: command,
 		Env:     form.Env,
 	}
 

--- a/tasks.go
+++ b/tasks.go
@@ -13,7 +13,7 @@ import (
 type Task struct {
 	Name        string
 	Type        string
-	Command     string
+	Command     Command
 	State       string
 	UpdatedAt   time.Time
 	Constraints Constraints
@@ -50,7 +50,7 @@ func taskFromInstance(i *scheduler.Instance) *Task {
 	return &Task{
 		Name:    fmt.Sprintf("%s.%s.%s", version, i.Process.Type, i.ID),
 		Type:    string(i.Process.Type),
-		Command: i.Process.Command,
+		Command: Command(i.Process.Command),
 		Constraints: Constraints{
 			CPUShare: constraints.CPUShare(i.Process.CPUShares),
 			Memory:   constraints.Memory(i.Process.MemoryLimit),

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -104,7 +104,7 @@ func TestEmpire_Deploy(t *testing.T) {
 			{
 				Type:        "web",
 				Image:       img,
-				Command:     "./bin/web",
+				Command:     []string{"./bin/web"},
 				Exposure:    scheduler.ExposePrivate,
 				Instances:   1,
 				MemoryLimit: 536870912,
@@ -260,7 +260,7 @@ func TestEmpire_Set(t *testing.T) {
 			{
 				Type:        "web",
 				Image:       img,
-				Command:     "./bin/web",
+				Command:     []string{"./bin/web"},
 				Exposure:    scheduler.ExposePrivate,
 				Instances:   1,
 				MemoryLimit: 536870912,
@@ -302,7 +302,7 @@ func TestEmpire_Set(t *testing.T) {
 			{
 				Type:        "web",
 				Image:       img,
-				Command:     "./bin/web",
+				Command:     []string{"./bin/web"},
 				Exposure:    scheduler.ExposePrivate,
 				Instances:   1,
 				MemoryLimit: 536870912,


### PR DESCRIPTION
Passing a string is error prone, because we have to parse it in a way that matches bash's behavior (e.g. single quotes are 1 argument). It's a lot simpler and less prone to errors if we do this parsing at the very edge of user input, then use a `[]string` internally, since a `[]string` is a more accurate representation of command arguments (e.g. `os.Args` is a []string).

We should change the `command` field on the processes table to a postgres array and store it as such internally, but that requires a migration that uses the shellwords lib, which we don't have good support for right now.