### PR TITLE
Change scheduler.Exposure type.

### DIFF
--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -525,8 +525,10 @@ func TestScheduler_LoadBalancer_NoExistingLoadBalancer(t *testing.T) {
 		Name: "appname",
 	}
 	process := &scheduler.Process{
-		Type:     "web",
-		Exposure: scheduler.ExposePrivate,
+		Type: "web",
+		Exposure: &scheduler.Exposure{
+			Type: &scheduler.HTTPExposure{},
+		},
 	}
 
 	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{}, nil)
@@ -555,8 +557,11 @@ func TestLBProcessManager_CreateProcess_ExistingLoadBalancer(t *testing.T) {
 		Name: "appname",
 	}
 	process := &scheduler.Process{
-		Type:     "web",
-		Exposure: scheduler.ExposePublic,
+		Type: "web",
+		Exposure: &scheduler.Exposure{
+			External: true,
+			Type:     &scheduler.HTTPExposure{},
+		},
 	}
 
 	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{
@@ -581,8 +586,11 @@ func TestScheduler_LoadBalancer_ExistingLoadBalancer_MismatchedExposure(t *testi
 		Name: "appname",
 	}
 	process := &scheduler.Process{
-		Type:     "web",
-		Exposure: scheduler.ExposePublic,
+		Type: "web",
+		Exposure: &scheduler.Exposure{
+			External: true,
+			Type:     &scheduler.HTTPExposure{},
+		},
 	}
 
 	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{
@@ -607,9 +615,13 @@ func TestScheduler_LoadBalancer_ExistingLoadBalancer_NewCert(t *testing.T) {
 		Name: "appname",
 	}
 	process := &scheduler.Process{
-		Type:     "web",
-		Exposure: scheduler.ExposePublic,
-		SSLCert:  "newcert",
+		Type: "web",
+		Exposure: &scheduler.Exposure{
+			External: true,
+			Type: &scheduler.HTTPSExposure{
+				Cert: "newcert",
+			},
+		},
 	}
 
 	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{
@@ -669,7 +681,9 @@ var fakeApp = &scheduler.App{
 			},
 			MemoryLimit: 134217728, // 128
 			CPUShares:   128,
-			Exposure:    scheduler.ExposePrivate,
+			Exposure: &scheduler.Exposure{
+				Type: &scheduler.HTTPExposure{},
+			},
 		},
 	},
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -10,27 +10,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-type Exposure int
-
-func (e Exposure) String() string {
-	switch e {
-	case ExposeNone:
-		return "none"
-	case ExposePrivate:
-		return "private"
-	case ExposePublic:
-		return "public"
-	default:
-		return "unknown"
-	}
-}
-
-const (
-	ExposeNone Exposure = iota
-	ExposePrivate
-	ExposePublic
-)
-
 type App struct {
 	// The id of the app.
 	ID string
@@ -59,7 +38,7 @@ type Process struct {
 	Labels map[string]string
 
 	// Exposure is the level of exposure for this process.
-	Exposure Exposure
+	Exposure *Exposure
 
 	// Instances is the desired instances of this service to run.
 	Instances uint
@@ -73,10 +52,38 @@ type Process struct {
 
 	// ulimit -u
 	Nproc uint
-
-	// An SSL Cert associated with this process.
-	SSLCert string
 }
+
+// Exposure controls the exposure settings for a process.
+type Exposure struct {
+	// External means that this process will be exposed to internet facing
+	// traffic, as opposed to being internal. How this is used is
+	// implementation specific. For ECS, this means that the attached ELB
+	// will be "internet-facing".
+	External bool
+
+	// The exposure type (e.g. HTTPExposure, HTTPSExposure, TCPExposure).
+	Type ExposureType
+}
+
+// Exposure represents a service that a process exposes, like HTTP/HTTPS/TCP or
+// SSL.
+type ExposureType interface {
+	Protocol() string
+}
+
+// HTTPExposure represents an HTTP exposure.
+type HTTPExposure struct{}
+
+func (e *HTTPExposure) Protocol() string { return "http" }
+
+// HTTPSExposure represents an HTTPS exposure
+type HTTPSExposure struct {
+	// The certificate to attach to the process.
+	Cert string
+}
+
+func (e *HTTPSExposure) Protocol() string { return "https" }
 
 // Instance represents an Instance of a Process.
 type Instance struct {

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -102,15 +102,16 @@ func TestEmpire_Deploy(t *testing.T) {
 		Name: "acme-inc",
 		Processes: []*scheduler.Process{
 			{
-				Type:        "web",
-				Image:       img,
-				Command:     []string{"./bin/web"},
-				Exposure:    scheduler.ExposePrivate,
+				Type:    "web",
+				Image:   img,
+				Command: []string{"./bin/web"},
+				Exposure: &scheduler.Exposure{
+					Type: &scheduler.HTTPExposure{},
+				},
 				Instances:   1,
 				MemoryLimit: 536870912,
 				CPUShares:   256,
 				Nproc:       256,
-				SSLCert:     "",
 				Env: map[string]string{
 					"EMPIRE_APPID":      app.ID,
 					"EMPIRE_APPNAME":    "acme-inc",
@@ -258,15 +259,16 @@ func TestEmpire_Set(t *testing.T) {
 		Name: "acme-inc",
 		Processes: []*scheduler.Process{
 			{
-				Type:        "web",
-				Image:       img,
-				Command:     []string{"./bin/web"},
-				Exposure:    scheduler.ExposePrivate,
+				Type:    "web",
+				Image:   img,
+				Command: []string{"./bin/web"},
+				Exposure: &scheduler.Exposure{
+					Type: &scheduler.HTTPExposure{},
+				},
 				Instances:   1,
 				MemoryLimit: 536870912,
 				CPUShares:   256,
 				Nproc:       256,
-				SSLCert:     "",
 				Env: map[string]string{
 					"EMPIRE_APPID":      app.ID,
 					"EMPIRE_APPNAME":    "acme-inc",
@@ -300,15 +302,16 @@ func TestEmpire_Set(t *testing.T) {
 		Name: "acme-inc",
 		Processes: []*scheduler.Process{
 			{
-				Type:        "web",
-				Image:       img,
-				Command:     []string{"./bin/web"},
-				Exposure:    scheduler.ExposePrivate,
+				Type:    "web",
+				Image:   img,
+				Command: []string{"./bin/web"},
+				Exposure: &scheduler.Exposure{
+					Type: &scheduler.HTTPExposure{},
+				},
 				Instances:   1,
 				MemoryLimit: 536870912,
 				CPUShares:   256,
 				Nproc:       256,
-				SSLCert:     "",
 				Env: map[string]string{
 					"EMPIRE_APPID":      app.ID,
 					"EMPIRE_APPNAME":    "acme-inc",


### PR DESCRIPTION
This is step 4 in https://github.com/remind101/empire/wiki/Extended-Procfile-Roadmap#step-4---refactor-how-we-define-process-exposure

This changes how exposure settings are communicated in the `scheduler` package. After this, we can add a `TCPExposure` type and change the load balancer package to be able to create tcp load balancers.

This is all internal for now and will eventually be exposed in the extended Procfile.