### PR TITLE
Lock migrations.

### DIFF
--- a/db.go
+++ b/db.go
@@ -15,6 +15,8 @@ type DB struct {
 	*gorm.DB
 
 	uri string
+
+	migrator *migrate.Migrator
 }
 
 // OpenDB returns a new gorm.DB instance.
@@ -35,14 +37,15 @@ func OpenDB(uri string) (*DB, error) {
 	}
 
 	return &DB{
-		DB:  &db,
-		uri: uri,
+		DB:       &db,
+		uri:      uri,
+		migrator: migrate.NewPostgresMigrator(conn),
 	}, nil
 }
 
 // MigrateUp migrates the database to the latest version of the schema.
 func (db *DB) MigrateUp() error {
-	return migrate.Exec(db.DB.DB(), migrate.Up, Migrations...)
+	return db.migrator.Exec(migrate.Up, Migrations...)
 }
 
 // Reset resets the database to a pristine state.

--- a/vendor/github.com/remind101/migrate/README.md
+++ b/vendor/github.com/remind101/migrate/README.md
@@ -44,3 +44,14 @@ migrations := []migrate.Migration{
 db, _ := sql.Open("sqlite3", ":memory:")
 _ = migrate.Exec(db, migrate.Up, migrations...)
 ```
+
+### Locking
+
+All migrations are run in a transaction, but if you attempt to run a single long running migration concurrently, you could run into a deadlock. For Postgres connections, `migrate` can use [pg_advisory_lock](http://www.postgresql.org/docs/9.1/static/explicit-locking.html) to ensure that only 1 migration is run at a time.
+
+To use this, simply instantiate a `Migrator` instance using `migrate.NewPostgresMigrator`:
+
+```go
+migrator := NewPostgresMigrator(db)
+_ = migrator.Exec(migrate.Up, migrations...)
+```

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -494,8 +494,8 @@
 		},
 		{
 			"path": "github.com/remind101/migrate",
-			"revision": "030a045725163190a8e32cdc11c4d9d364fd614c",
-			"revisionTime": "2016-04-15T12:41:51+07:00"
+			"revision": "6a911e1904d23e8ad3de5b9fab2f6530241c6183",
+			"revisionTime": "2016-04-20T11:09:36+07:00"
 		},
 		{
 			"path": "github.com/remind101/newrelic",


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/789

This will cause the migrations to obtain an advisory lock before running, so we can ensure that migrations aren't run twice across multiple processes (easy to do with the `--automigrate` flag).

Once https://github.com/remind101/migrate/pull/3 is reviewed, I'll update the dependency here.