### PR TITLE
Package 12factor

### DIFF
--- a/12factor/12factor.go
+++ b/12factor/12factor.go
@@ -1,0 +1,121 @@
+// Package twelvefactor provides types to represents 12factor applications,
+// which are defined in http://12factor.net/
+package twelvefactor
+
+import "github.com/remind101/empire/pkg/image"
+
+// Manifest describes a 12factor application and it's processes.
+type Manifest struct {
+	App
+	Processes []Process
+}
+
+// App represents a 12factor application. We define an application as a
+// collection of processes that share a common environment and container image.
+type App struct {
+	// Unique identifier of the application.
+	ID string
+
+	// Name of the application.
+	Name string
+
+	// The container image for this app.
+	Image image.Image
+
+	// The shared environment variables for the individual processes.
+	Env map[string]string
+
+	// The shared labels for the individual processes.
+	Labels map[string]string
+
+	Processes []Process
+}
+
+// Process represents an individual Process of an App, which defines the command
+// to run within the container image.
+type Process struct {
+	// A unique identifier for this process, within the scope of the app.
+	// Generally this would be something like "web" or "worker.
+	Type string
+
+	// Exposure is used by schedulers to determine if the process exposes any
+	// TCP/HTTP/HTTPS services. Schedulers can use the Protocol method or
+	// perform a type assertion to determine the exposure and settings for
+	// the exposure.
+	Exposure *Exposure
+
+	// The command to run when running this process.
+	Command []string
+
+	// Additional environment variables to merge with the App's environment
+	// when running this process.
+	Env map[string]string
+
+	// Free form labels to attach to this process.
+	Labels map[string]string
+
+	// The desired number of instances to run.
+	Instances uint
+
+	// The amount of memory to allocate to this process, in bytes.
+	MemoryLimit uint
+
+	// The number of CPU Shares to allocate to this process.
+	CPUShares uint
+
+	// ulimit -u
+	Nproc uint
+}
+
+// Exposure controls the exposure settings for a process.
+type Exposure struct {
+	// External means that this process will be exposed to internet facing
+	// traffic, as opposed to being internal. How this is used is
+	// implementation specific. For ECS, this means that the attached ELB
+	// will be "internet-facing".
+	External bool
+
+	// The exposure type (e.g. HTTPExposure, HTTPSExposure, TCPExposure).
+	Type ExposureType
+}
+
+// Exposure represents a service that a process exposes, like HTTP/HTTPS/TCP or
+// SSL.
+type ExposureType interface {
+	Protocol() string
+}
+
+// HTTPExposure represents an HTTP exposure.
+type HTTPExposure struct{}
+
+func (e *HTTPExposure) Protocol() string { return "http" }
+
+// HTTPSExposure represents an HTTPS exposure
+type HTTPSExposure struct {
+	// The certificate to attach to the process.
+	Cert string
+}
+
+func (e *HTTPSExposure) Protocol() string { return "https" }
+
+// ProcessEnv merges the App environment with any environment variables provided
+// in the process.
+func ProcessEnv(app App, process Process) map[string]string {
+	return merge(app.Env, process.Env)
+}
+
+// ProcessLabels merges the App labels with any labels provided in the process.
+func ProcessLabels(app App, process Process) map[string]string {
+	return merge(app.Labels, process.Labels)
+}
+
+// merges the maps together, favoring keys from the right to the left.
+func merge(envs ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for _, env := range envs {
+		for k, v := range env {
+			merged[k] = v
+		}
+	}
+	return merged
+}

--- a/12factor/12factor.go
+++ b/12factor/12factor.go
@@ -27,8 +27,6 @@ type App struct {
 
 	// The shared labels for the individual processes.
 	Labels map[string]string
-
-	Processes []Process
 }
 
 // Process represents an individual Process of an App, which defines the command

--- a/12factor/README.md
+++ b/12factor/README.md
@@ -1,0 +1,17 @@
+# 12factor
+
+12factor is a Go library for describing and running [12factor](http://12factor.net/) applications.
+
+## Terminology
+
+### App
+
+An App describes a common environment and root filesystem, which is generally specified as a Docker container.
+
+### Process
+
+A Process represents a named command that can be scaled horizontally.
+
+### Manifest
+
+A manifest is the composition of an App and its Processes.

--- a/releases.go
+++ b/releases.go
@@ -258,6 +258,9 @@ func releasesCreate(db *gorm.DB, release *Release) (*Release, error) {
 	return release, nil
 }
 
+// new12factorManifest builds a twelvefactor.Manifest from a Release, which
+// represents a 12factor application that we can submit to the scheduler
+// backend.
 func new12factorManifest(release *Release) twelvefactor.Manifest {
 	app := new12factorApp(release)
 
@@ -272,6 +275,8 @@ func new12factorManifest(release *Release) twelvefactor.Manifest {
 	}
 }
 
+// new12factorApp returns a new twelvefactor.App description for the given
+// release.
 func new12factorApp(release *Release) twelvefactor.App {
 	env := environment(release.Config.Vars)
 	env["EMPIRE_APPID"] = release.App.ID
@@ -294,6 +299,8 @@ func new12factorApp(release *Release) twelvefactor.App {
 	}
 }
 
+// new12factorProcess returns a new twelvefactor.Process description for the
+// given process.
 func new12factorProcess(release *Release, p *Process) twelvefactor.Process {
 	env := map[string]string{
 		"EMPIRE_PROCESS": string(p.Type),

--- a/releases.go
+++ b/releases.go
@@ -258,8 +258,8 @@ func releasesCreate(db *gorm.DB, release *Release) (*Release, error) {
 	return release, nil
 }
 
-func newServiceApp(release *Release) *scheduler.App {
-	var processes []*scheduler.Process
+func newServiceApp(release *Release) scheduler.App {
+	var processes []scheduler.Process
 
 	for _, p := range release.Processes {
 		processes = append(processes, newServiceProcess(release, p))
@@ -277,7 +277,7 @@ func newServiceApp(release *Release) *scheduler.App {
 		"empire.app.release": fmt.Sprintf("v%d", release.Version),
 	}
 
-	return &scheduler.App{
+	return scheduler.App{
 		ID:        release.App.ID,
 		Name:      release.App.Name,
 		Image:     release.Slug.Image,
@@ -287,7 +287,7 @@ func newServiceApp(release *Release) *scheduler.App {
 	}
 }
 
-func newServiceProcess(release *Release, p *Process) *scheduler.Process {
+func newServiceProcess(release *Release, p *Process) scheduler.Process {
 	env := map[string]string{
 		"EMPIRE_PROCESS": string(p.Type),
 		"SOURCE":         fmt.Sprintf("%s.%s.v%d", release.App.Name, p.Type, release.Version),
@@ -297,7 +297,7 @@ func newServiceProcess(release *Release, p *Process) *scheduler.Process {
 		"empire.app.process": string(p.Type),
 	}
 
-	return &scheduler.Process{
+	return scheduler.Process{
 		Type:        string(p.Type),
 		Env:         env,
 		Labels:      labels,

--- a/releases.go
+++ b/releases.go
@@ -268,6 +268,7 @@ func newServiceApp(release *Release) *scheduler.App {
 	return &scheduler.App{
 		ID:        release.App.ID,
 		Name:      release.App.Name,
+		Image:     release.Slug.Image,
 		Processes: processes,
 	}
 }
@@ -293,7 +294,6 @@ func newServiceProcess(release *Release, p *Process) *scheduler.Process {
 		Env:         env,
 		Labels:      labels,
 		Command:     []string(p.Command),
-		Image:       release.Slug.Image,
 		Instances:   uint(p.Quantity),
 		MemoryLimit: uint(p.Constraints.Memory),
 		CPUShares:   uint(p.Constraints.CPUShare),

--- a/runner.go
+++ b/runner.go
@@ -62,8 +62,8 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 		return err
 	}
 
-	a := newServiceApp(release)
-	p := newServiceProcess(release, NewProcess("run", opts.Command))
+	a := new12factorApp(release)
+	p := new12factorProcess(release, NewProcess("run", opts.Command))
 
 	for k, v := range opts.Env {
 		p.Env[k] = v

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -350,7 +350,7 @@ func (m *Scheduler) taskDefinitionInput(app *scheduler.App, p *scheduler.Process
 	}
 
 	var environment []*ecs.KeyValuePair
-	for k, v := range p.Env {
+	for k, v := range scheduler.ProcessEnv(app, p) {
 		environment = append(environment, &ecs.KeyValuePair{
 			Name:  aws.String(k),
 			Value: aws.String(v),
@@ -373,7 +373,7 @@ func (m *Scheduler) taskDefinitionInput(app *scheduler.App, p *scheduler.Process
 	}
 
 	labels := make(map[string]*string)
-	for k, v := range p.Labels {
+	for k, v := range scheduler.ProcessLabels(app, p) {
 		labels[k] = aws.String(v)
 	}
 

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -172,19 +172,21 @@ func validateLoadBalancedConfig(c Config) error {
 // removed from ECS. For example, if you previously submitted an app with a
 // `web` and `worker` process, then submit an app with the `web` process, the
 // ECS service for the old `worker` process will be removed.
-func (m *Scheduler) Submit(ctx context.Context, app twelvefactor.App) error {
+func (m *Scheduler) Submit(ctx context.Context, manifest twelvefactor.Manifest) error {
+	app := manifest.App
+
 	processes, err := m.Processes(ctx, app.ID)
 	if err != nil {
 		return err
 	}
 
-	for _, p := range app.Processes {
+	for _, p := range manifest.Processes {
 		if err := m.CreateProcess(ctx, app, p); err != nil {
 			return err
 		}
 	}
 
-	toRemove := diffProcessTypes(processes, app.Processes)
+	toRemove := diffProcessTypes(processes, manifest.Processes)
 	for _, p := range toRemove {
 		if err := m.RemoveProcess(ctx, app.ID, p); err != nil {
 			return err

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/remind101/empire/12factor"
 	"github.com/remind101/empire/pkg/arn"
 	. "github.com/remind101/empire/pkg/bytesize"
 	"github.com/remind101/empire/pkg/ecsutil"
@@ -171,7 +172,7 @@ func validateLoadBalancedConfig(c Config) error {
 // removed from ECS. For example, if you previously submitted an app with a
 // `web` and `worker` process, then submit an app with the `web` process, the
 // ECS service for the old `worker` process will be removed.
-func (m *Scheduler) Submit(ctx context.Context, app scheduler.App) error {
+func (m *Scheduler) Submit(ctx context.Context, app twelvefactor.App) error {
 	processes, err := m.Processes(ctx, app.ID)
 	if err != nil {
 		return err
@@ -297,7 +298,7 @@ func (m *Scheduler) Stop(ctx context.Context, instanceID string) error {
 }
 
 // CreateProcess creates an ECS service for the process.
-func (m *Scheduler) CreateProcess(ctx context.Context, app scheduler.App, p scheduler.Process) error {
+func (m *Scheduler) CreateProcess(ctx context.Context, app twelvefactor.App, p twelvefactor.Process) error {
 	loadBalancer, err := m.loadBalancer(ctx, app, p)
 	if err != nil {
 		return err
@@ -311,7 +312,7 @@ func (m *Scheduler) CreateProcess(ctx context.Context, app scheduler.App, p sche
 	return err
 }
 
-func (m *Scheduler) Run(ctx context.Context, app scheduler.App, process scheduler.Process, in io.Reader, out io.Writer) error {
+func (m *Scheduler) Run(ctx context.Context, app twelvefactor.App, process twelvefactor.Process, in io.Reader, out io.Writer) error {
 	if out != nil {
 		return errors.New("running an attached process is not implemented by the ECS manager.")
 	}
@@ -331,7 +332,7 @@ func (m *Scheduler) Run(ctx context.Context, app scheduler.App, process schedule
 }
 
 // createTaskDefinition creates a Task Definition in ECS for the service.
-func (m *Scheduler) createTaskDefinition(ctx context.Context, app scheduler.App, process scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.TaskDefinition, error) {
+func (m *Scheduler) createTaskDefinition(ctx context.Context, app twelvefactor.App, process twelvefactor.Process, loadBalancer *lb.LoadBalancer) (*ecs.TaskDefinition, error) {
 	taskDef, err := m.taskDefinitionInput(app, process, loadBalancer)
 	if err != nil {
 		return nil, err
@@ -341,7 +342,7 @@ func (m *Scheduler) createTaskDefinition(ctx context.Context, app scheduler.App,
 	return resp.TaskDefinition, err
 }
 
-func (m *Scheduler) taskDefinitionInput(app scheduler.App, p scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.RegisterTaskDefinitionInput, error) {
+func (m *Scheduler) taskDefinitionInput(app twelvefactor.App, p twelvefactor.Process, loadBalancer *lb.LoadBalancer) (*ecs.RegisterTaskDefinitionInput, error) {
 	// ecs.ContainerDefinition{Command} is expecting a []*string
 	var command []*string
 	for _, s := range p.Command {
@@ -350,7 +351,7 @@ func (m *Scheduler) taskDefinitionInput(app scheduler.App, p scheduler.Process, 
 	}
 
 	var environment []*ecs.KeyValuePair
-	for k, v := range scheduler.ProcessEnv(app, p) {
+	for k, v := range twelvefactor.ProcessEnv(app, p) {
 		environment = append(environment, &ecs.KeyValuePair{
 			Name:  aws.String(k),
 			Value: aws.String(v),
@@ -373,7 +374,7 @@ func (m *Scheduler) taskDefinitionInput(app scheduler.App, p scheduler.Process, 
 	}
 
 	labels := make(map[string]*string)
-	for k, v := range scheduler.ProcessLabels(app, p) {
+	for k, v := range twelvefactor.ProcessLabels(app, p) {
 		labels[k] = aws.String(v)
 	}
 
@@ -409,7 +410,7 @@ func (m *Scheduler) taskDefinitionInput(app scheduler.App, p scheduler.Process, 
 }
 
 // createService creates a Service in ECS for the service.
-func (m *Scheduler) createService(ctx context.Context, app scheduler.App, p scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.Service, error) {
+func (m *Scheduler) createService(ctx context.Context, app twelvefactor.App, p twelvefactor.Process, loadBalancer *lb.LoadBalancer) (*ecs.Service, error) {
 	var role *string
 	var loadBalancers []*ecs.LoadBalancer
 
@@ -436,7 +437,7 @@ func (m *Scheduler) createService(ctx context.Context, app scheduler.App, p sche
 }
 
 // updateService updates an existing Service in ECS.
-func (m *Scheduler) updateService(ctx context.Context, app scheduler.App, p scheduler.Process) (*ecs.Service, error) {
+func (m *Scheduler) updateService(ctx context.Context, app twelvefactor.App, p twelvefactor.Process) (*ecs.Service, error) {
 	_, err := m.loadBalancer(ctx, app, p)
 	if err != nil {
 		return nil, err
@@ -458,7 +459,7 @@ func (m *Scheduler) updateService(ctx context.Context, app scheduler.App, p sche
 }
 
 // updateCreateService will perform an upsert for the service in ECS.
-func (m *Scheduler) updateCreateService(ctx context.Context, app scheduler.App, p scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.Service, error) {
+func (m *Scheduler) updateCreateService(ctx context.Context, app twelvefactor.App, p twelvefactor.Process, loadBalancer *lb.LoadBalancer) (*ecs.Service, error) {
 	s, err := m.updateService(ctx, app, p)
 	if err != nil {
 		return nil, err
@@ -473,7 +474,7 @@ func (m *Scheduler) updateCreateService(ctx context.Context, app scheduler.App, 
 
 // loadBalancer creates (or updates) a a load balancer for the given process, if
 // the process is exposed. It returns the name of the load balancer.
-func (m *Scheduler) loadBalancer(ctx context.Context, app scheduler.App, p scheduler.Process) (*lb.LoadBalancer, error) {
+func (m *Scheduler) loadBalancer(ctx context.Context, app twelvefactor.App, p twelvefactor.Process) (*lb.LoadBalancer, error) {
 	// No exposure, no load balancer.
 	if p.Exposure == nil {
 		return nil, nil
@@ -514,7 +515,7 @@ func (m *Scheduler) loadBalancer(ctx context.Context, app scheduler.App, p sched
 			Tags:     tags,
 		}
 
-		if e, ok := p.Exposure.Type.(*scheduler.HTTPSExposure); ok {
+		if e, ok := p.Exposure.Type.(*twelvefactor.HTTPSExposure); ok {
 			opts.SSLCert = e.Cert
 		}
 
@@ -554,8 +555,8 @@ func (m *Scheduler) findLoadBalancer(ctx context.Context, app string, process st
 	return lbs[0], nil
 }
 
-func (m *Scheduler) Processes(ctx context.Context, appID string) ([]scheduler.Process, error) {
-	var processes []scheduler.Process
+func (m *Scheduler) Processes(ctx context.Context, appID string) ([]twelvefactor.Process, error) {
+	var processes []twelvefactor.Process
 
 	list, err := m.ecs.ListAppServices(ctx, appID, &ecs.ListServicesInput{
 		Cluster: aws.String(m.cluster),
@@ -659,11 +660,11 @@ func noService(err error) bool {
 
 // taskDefinitionToProcess takes an ECS Task Definition and converts it to a
 // Process.
-func taskDefinitionToProcess(td *ecs.TaskDefinition) (scheduler.Process, error) {
+func taskDefinitionToProcess(td *ecs.TaskDefinition) (twelvefactor.Process, error) {
 	// If this task definition has no container definitions, then something
 	// funky is up.
 	if len(td.ContainerDefinitions) == 0 {
-		return scheduler.Process{}, errors.New("task definition had no container definitions")
+		return twelvefactor.Process{}, errors.New("task definition had no container definitions")
 	}
 
 	container := td.ContainerDefinitions[0]
@@ -680,7 +681,7 @@ func taskDefinitionToProcess(td *ecs.TaskDefinition) (scheduler.Process, error) 
 		}
 	}
 
-	return scheduler.Process{
+	return twelvefactor.Process{
 		Type:        safeString(container.Name),
 		Command:     command,
 		Env:         env,
@@ -704,7 +705,7 @@ func softLimit(ulimits []*ecs.Ulimit, name string) int64 {
 	return 0
 }
 
-func diffProcessTypes(old, new []scheduler.Process) []string {
+func diffProcessTypes(old, new []twelvefactor.Process) []string {
 	var types []string
 
 	om := processTypes(old)
@@ -719,7 +720,7 @@ func diffProcessTypes(old, new []scheduler.Process) []string {
 	return types
 }
 
-func processTypes(processes []scheduler.Process) map[string]struct{} {
+func processTypes(processes []twelvefactor.Process) map[string]struct{} {
 	m := make(map[string]struct{})
 
 	for _, p := range processes {
@@ -740,7 +741,7 @@ func lbTags(app string, process string) map[string]string {
 
 // LoadBalancerExposureError is returned when the exposure of the process in the data store does not match the exposure of the ELB
 type LoadBalancerExposureError struct {
-	proc scheduler.Process
+	proc twelvefactor.Process
 	lb   *lb.LoadBalancer
 }
 
@@ -759,7 +760,7 @@ func (e external) String() string {
 }
 
 // canUpdate checks if the load balancer is suitable for the process.
-func canUpdate(p scheduler.Process, lb *lb.LoadBalancer) error {
+func canUpdate(p twelvefactor.Process, lb *lb.LoadBalancer) error {
 	if p.Exposure.External && !lb.External {
 		return &LoadBalancerExposureError{p, lb}
 	}
@@ -771,7 +772,7 @@ func canUpdate(p scheduler.Process, lb *lb.LoadBalancer) error {
 	return nil
 }
 
-func updateOpts(p scheduler.Process, b *lb.LoadBalancer) (*lb.UpdateLoadBalancerOpts, error) {
+func updateOpts(p twelvefactor.Process, b *lb.LoadBalancer) (*lb.UpdateLoadBalancerOpts, error) {
 	// This load balancer can't be updated to make it work for the process.
 	// Return an error.
 	if err := canUpdate(p, b); err != nil {
@@ -783,7 +784,7 @@ func updateOpts(p scheduler.Process, b *lb.LoadBalancer) (*lb.UpdateLoadBalancer
 	}
 
 	// Requires an update to the Cert.
-	if e, ok := p.Exposure.Type.(*scheduler.HTTPSExposure); ok {
+	if e, ok := p.Exposure.Type.(*twelvefactor.HTTPSExposure); ok {
 		if e.Cert != b.SSLCert {
 			opts.SSLCert = &e.Cert
 		}

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -332,7 +332,7 @@ func (m *Scheduler) Run(ctx context.Context, app *scheduler.App, process *schedu
 
 // createTaskDefinition creates a Task Definition in ECS for the service.
 func (m *Scheduler) createTaskDefinition(ctx context.Context, app *scheduler.App, process *scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.TaskDefinition, error) {
-	taskDef, err := m.taskDefinitionInput(process, loadBalancer)
+	taskDef, err := m.taskDefinitionInput(app, process, loadBalancer)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +341,7 @@ func (m *Scheduler) createTaskDefinition(ctx context.Context, app *scheduler.App
 	return resp.TaskDefinition, err
 }
 
-func (m *Scheduler) taskDefinitionInput(p *scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.RegisterTaskDefinitionInput, error) {
+func (m *Scheduler) taskDefinitionInput(app *scheduler.App, p *scheduler.Process, loadBalancer *lb.LoadBalancer) (*ecs.RegisterTaskDefinitionInput, error) {
 	// ecs.ContainerDefinition{Command} is expecting a []*string
 	var command []*string
 	for _, s := range p.Command {
@@ -395,7 +395,7 @@ func (m *Scheduler) taskDefinitionInput(p *scheduler.Process, loadBalancer *lb.L
 				Name:             aws.String(p.Type),
 				Cpu:              aws.Int64(int64(p.CPUShares)),
 				Command:          command,
-				Image:            aws.String(p.Image.String()),
+				Image:            aws.String(app.Image.String()),
 				Essential:        aws.Bool(true),
 				Memory:           aws.Int64(int64(p.MemoryLimit / MB)),
 				Environment:      environment,

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -454,10 +454,12 @@ func TestScheduler_Run(t *testing.T) {
 	m, s := newTestScheduler(h)
 	defer s.Close()
 
-	app := &scheduler.App{ID: "1234"}
+	app := &scheduler.App{
+		ID:    "1234",
+		Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
+	}
 	process := &scheduler.Process{
 		Type:    "run",
-		Image:   image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
 		Command: []string{"acme-inc", "web", "--port", "80"},
 		Env: map[string]string{
 			"USER": "foo",
@@ -666,11 +668,11 @@ func (m *mockLBManager) LoadBalancers(ctx context.Context, tags map[string]strin
 
 // fake app for testing.
 var fakeApp = &scheduler.App{
-	ID: "1234",
+	ID:    "1234",
+	Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
 	Processes: []*scheduler.Process{
 		&scheduler.Process{
 			Type:    "web",
-			Image:   image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
 			Command: []string{"acme-inc", "web", "--port", "80"},
 			Env: map[string]string{
 				"USER": "foo",

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -670,14 +670,16 @@ func (m *mockLBManager) LoadBalancers(ctx context.Context, tags map[string]strin
 }
 
 // fake app for testing.
-var fakeApp = twelvefactor.App{
-	ID:    "1234",
-	Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
-	Env: map[string]string{
-		"USER": "foo",
-	},
-	Labels: map[string]string{
-		"label1": "foo",
+var fakeApp = twelvefactor.Manifest{
+	App: twelvefactor.App{
+		ID:    "1234",
+		Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
+		Env: map[string]string{
+			"USER": "foo",
+		},
+		Labels: map[string]string{
+			"label1": "foo",
+		},
 	},
 	Processes: []twelvefactor.Process{
 		twelvefactor.Process{

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -457,15 +457,17 @@ func TestScheduler_Run(t *testing.T) {
 	app := &scheduler.App{
 		ID:    "1234",
 		Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
-	}
-	process := &scheduler.Process{
-		Type:    "run",
-		Command: []string{"acme-inc", "web", "--port", "80"},
 		Env: map[string]string{
 			"USER": "foo",
 		},
 		Labels: map[string]string{
 			"label1": "foo",
+		},
+	}
+	process := &scheduler.Process{
+		Type:    "run",
+		Command: []string{"acme-inc", "web", "--port", "80"},
+		Labels: map[string]string{
 			"label2": "bar",
 		},
 		MemoryLimit: 134217728, // 128
@@ -670,15 +672,17 @@ func (m *mockLBManager) LoadBalancers(ctx context.Context, tags map[string]strin
 var fakeApp = &scheduler.App{
 	ID:    "1234",
 	Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
+	Env: map[string]string{
+		"USER": "foo",
+	},
+	Labels: map[string]string{
+		"label1": "foo",
+	},
 	Processes: []*scheduler.Process{
 		&scheduler.Process{
 			Type:    "web",
 			Command: []string{"acme-inc", "web", "--port", "80"},
-			Env: map[string]string{
-				"USER": "foo",
-			},
 			Labels: map[string]string{
-				"label1": "foo",
 				"label2": "bar",
 			},
 			MemoryLimit: 134217728, // 128

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -454,7 +454,7 @@ func TestScheduler_Run(t *testing.T) {
 	m, s := newTestScheduler(h)
 	defer s.Close()
 
-	app := &scheduler.App{
+	app := scheduler.App{
 		ID:    "1234",
 		Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
 		Env: map[string]string{
@@ -464,7 +464,7 @@ func TestScheduler_Run(t *testing.T) {
 			"label1": "foo",
 		},
 	}
-	process := &scheduler.Process{
+	process := scheduler.Process{
 		Type:    "run",
 		Command: []string{"acme-inc", "web", "--port", "80"},
 		Labels: map[string]string{
@@ -473,6 +473,7 @@ func TestScheduler_Run(t *testing.T) {
 		MemoryLimit: 134217728, // 128
 		CPUShares:   128,
 	}
+
 	if err := m.Run(context.Background(), app, process, nil, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -480,13 +481,13 @@ func TestScheduler_Run(t *testing.T) {
 
 func TestDiffProcessTypes(t *testing.T) {
 	tests := []struct {
-		old, new []*scheduler.Process
+		old, new []scheduler.Process
 		out      []string
 	}{
 		{nil, nil, []string{}},
-		{[]*scheduler.Process{{Type: "web"}}, []*scheduler.Process{{Type: "web"}}, []string{}},
-		{[]*scheduler.Process{{Type: "web"}}, nil, []string{"web"}},
-		{[]*scheduler.Process{{Type: "web"}, {Type: "worker"}}, []*scheduler.Process{{Type: "web"}}, []string{"worker"}},
+		{[]scheduler.Process{{Type: "web"}}, []scheduler.Process{{Type: "web"}}, []string{}},
+		{[]scheduler.Process{{Type: "web"}}, nil, []string{"web"}},
+		{[]scheduler.Process{{Type: "web"}, {Type: "worker"}}, []scheduler.Process{{Type: "web"}}, []string{"worker"}},
 	}
 
 	for i, tt := range tests {
@@ -508,8 +509,8 @@ func TestScheduler_LoadBalancer_NoExposure(t *testing.T) {
 		lb: l,
 	}
 
-	app := &scheduler.App{}
-	process := &scheduler.Process{}
+	app := scheduler.App{}
+	process := scheduler.Process{}
 
 	loadBalancer, err := s.loadBalancer(context.Background(), app, process)
 	assert.NoError(t, err)
@@ -524,11 +525,11 @@ func TestScheduler_LoadBalancer_NoExistingLoadBalancer(t *testing.T) {
 		lb: l,
 	}
 
-	app := &scheduler.App{
+	app := scheduler.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := &scheduler.Process{
+	process := scheduler.Process{
 		Type: "web",
 		Exposure: &scheduler.Exposure{
 			Type: &scheduler.HTTPExposure{},
@@ -556,11 +557,11 @@ func TestLBProcessManager_CreateProcess_ExistingLoadBalancer(t *testing.T) {
 		lb: l,
 	}
 
-	app := &scheduler.App{
+	app := scheduler.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := &scheduler.Process{
+	process := scheduler.Process{
 		Type: "web",
 		Exposure: &scheduler.Exposure{
 			External: true,
@@ -585,11 +586,11 @@ func TestScheduler_LoadBalancer_ExistingLoadBalancer_MismatchedExposure(t *testi
 		lb: l,
 	}
 
-	app := &scheduler.App{
+	app := scheduler.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := &scheduler.Process{
+	process := scheduler.Process{
 		Type: "web",
 		Exposure: &scheduler.Exposure{
 			External: true,
@@ -614,11 +615,11 @@ func TestScheduler_LoadBalancer_ExistingLoadBalancer_NewCert(t *testing.T) {
 	}
 
 	port := int64(8080)
-	app := &scheduler.App{
+	app := scheduler.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := &scheduler.Process{
+	process := scheduler.Process{
 		Type: "web",
 		Exposure: &scheduler.Exposure{
 			External: true,
@@ -669,7 +670,7 @@ func (m *mockLBManager) LoadBalancers(ctx context.Context, tags map[string]strin
 }
 
 // fake app for testing.
-var fakeApp = &scheduler.App{
+var fakeApp = scheduler.App{
 	ID:    "1234",
 	Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
 	Env: map[string]string{
@@ -678,8 +679,8 @@ var fakeApp = &scheduler.App{
 	Labels: map[string]string{
 		"label1": "foo",
 	},
-	Processes: []*scheduler.Process{
-		&scheduler.Process{
+	Processes: []scheduler.Process{
+		scheduler.Process{
 			Type:    "web",
 			Command: []string{"acme-inc", "web", "--port", "80"},
 			Labels: map[string]string{

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/remind101/empire/12factor"
 	"github.com/remind101/empire/pkg/awsutil"
 	"github.com/remind101/empire/pkg/image"
-	"github.com/remind101/empire/scheduler"
 	"github.com/remind101/empire/scheduler/ecs/lb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -454,7 +454,7 @@ func TestScheduler_Run(t *testing.T) {
 	m, s := newTestScheduler(h)
 	defer s.Close()
 
-	app := scheduler.App{
+	app := twelvefactor.App{
 		ID:    "1234",
 		Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
 		Env: map[string]string{
@@ -464,7 +464,7 @@ func TestScheduler_Run(t *testing.T) {
 			"label1": "foo",
 		},
 	}
-	process := scheduler.Process{
+	process := twelvefactor.Process{
 		Type:    "run",
 		Command: []string{"acme-inc", "web", "--port", "80"},
 		Labels: map[string]string{
@@ -481,13 +481,13 @@ func TestScheduler_Run(t *testing.T) {
 
 func TestDiffProcessTypes(t *testing.T) {
 	tests := []struct {
-		old, new []scheduler.Process
+		old, new []twelvefactor.Process
 		out      []string
 	}{
 		{nil, nil, []string{}},
-		{[]scheduler.Process{{Type: "web"}}, []scheduler.Process{{Type: "web"}}, []string{}},
-		{[]scheduler.Process{{Type: "web"}}, nil, []string{"web"}},
-		{[]scheduler.Process{{Type: "web"}, {Type: "worker"}}, []scheduler.Process{{Type: "web"}}, []string{"worker"}},
+		{[]twelvefactor.Process{{Type: "web"}}, []twelvefactor.Process{{Type: "web"}}, []string{}},
+		{[]twelvefactor.Process{{Type: "web"}}, nil, []string{"web"}},
+		{[]twelvefactor.Process{{Type: "web"}, {Type: "worker"}}, []twelvefactor.Process{{Type: "web"}}, []string{"worker"}},
 	}
 
 	for i, tt := range tests {
@@ -509,8 +509,8 @@ func TestScheduler_LoadBalancer_NoExposure(t *testing.T) {
 		lb: l,
 	}
 
-	app := scheduler.App{}
-	process := scheduler.Process{}
+	app := twelvefactor.App{}
+	process := twelvefactor.Process{}
 
 	loadBalancer, err := s.loadBalancer(context.Background(), app, process)
 	assert.NoError(t, err)
@@ -525,14 +525,14 @@ func TestScheduler_LoadBalancer_NoExistingLoadBalancer(t *testing.T) {
 		lb: l,
 	}
 
-	app := scheduler.App{
+	app := twelvefactor.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := scheduler.Process{
+	process := twelvefactor.Process{
 		Type: "web",
-		Exposure: &scheduler.Exposure{
-			Type: &scheduler.HTTPExposure{},
+		Exposure: &twelvefactor.Exposure{
+			Type: &twelvefactor.HTTPExposure{},
 		},
 	}
 
@@ -557,15 +557,15 @@ func TestLBProcessManager_CreateProcess_ExistingLoadBalancer(t *testing.T) {
 		lb: l,
 	}
 
-	app := scheduler.App{
+	app := twelvefactor.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := scheduler.Process{
+	process := twelvefactor.Process{
 		Type: "web",
-		Exposure: &scheduler.Exposure{
+		Exposure: &twelvefactor.Exposure{
 			External: true,
-			Type:     &scheduler.HTTPExposure{},
+			Type:     &twelvefactor.HTTPExposure{},
 		},
 	}
 
@@ -586,15 +586,15 @@ func TestScheduler_LoadBalancer_ExistingLoadBalancer_MismatchedExposure(t *testi
 		lb: l,
 	}
 
-	app := scheduler.App{
+	app := twelvefactor.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := scheduler.Process{
+	process := twelvefactor.Process{
 		Type: "web",
-		Exposure: &scheduler.Exposure{
+		Exposure: &twelvefactor.Exposure{
 			External: true,
-			Type:     &scheduler.HTTPExposure{},
+			Type:     &twelvefactor.HTTPExposure{},
 		},
 	}
 
@@ -615,15 +615,15 @@ func TestScheduler_LoadBalancer_ExistingLoadBalancer_NewCert(t *testing.T) {
 	}
 
 	port := int64(8080)
-	app := scheduler.App{
+	app := twelvefactor.App{
 		ID:   "appid",
 		Name: "appname",
 	}
-	process := scheduler.Process{
+	process := twelvefactor.Process{
 		Type: "web",
-		Exposure: &scheduler.Exposure{
+		Exposure: &twelvefactor.Exposure{
 			External: true,
-			Type: &scheduler.HTTPSExposure{
+			Type: &twelvefactor.HTTPSExposure{
 				Cert: "newcert",
 			},
 		},
@@ -670,7 +670,7 @@ func (m *mockLBManager) LoadBalancers(ctx context.Context, tags map[string]strin
 }
 
 // fake app for testing.
-var fakeApp = scheduler.App{
+var fakeApp = twelvefactor.App{
 	ID:    "1234",
 	Image: image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
 	Env: map[string]string{
@@ -679,8 +679,8 @@ var fakeApp = scheduler.App{
 	Labels: map[string]string{
 		"label1": "foo",
 	},
-	Processes: []scheduler.Process{
-		scheduler.Process{
+	Processes: []twelvefactor.Process{
+		twelvefactor.Process{
 			Type:    "web",
 			Command: []string{"acme-inc", "web", "--port", "80"},
 			Labels: map[string]string{
@@ -688,8 +688,8 @@ var fakeApp = scheduler.App{
 			},
 			MemoryLimit: 134217728, // 128
 			CPUShares:   128,
-			Exposure: &scheduler.Exposure{
-				Type: &scheduler.HTTPExposure{},
+			Exposure: &twelvefactor.Exposure{
+				Type: &twelvefactor.HTTPExposure{},
 			},
 		},
 	},

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -9,51 +9,46 @@ import (
 )
 
 type FakeScheduler struct {
-	apps map[string]*App
+	apps    map[string]App
+	running map[string]map[string]uint
 }
 
 func NewFakeScheduler() *FakeScheduler {
 	return &FakeScheduler{
-		apps: make(map[string]*App),
+		apps:    make(map[string]App),
+		running: make(map[string]map[string]uint),
 	}
 }
 
-func (m *FakeScheduler) Submit(ctx context.Context, app *App) error {
-	for _, p := range app.Processes {
-		p.Env = ProcessEnv(app, p)
-		p.Labels = ProcessLabels(app, p)
-	}
+func (m *FakeScheduler) Submit(ctx context.Context, app App) error {
 	m.apps[app.ID] = app
+	for _, p := range app.Processes {
+		if m.running[app.ID] == nil {
+			m.running[app.ID] = make(map[string]uint)
+		}
+		m.running[app.ID][p.Type] = p.Instances
+	}
 	return nil
 }
 
 func (m *FakeScheduler) Scale(ctx context.Context, app string, ptype string, instances uint) error {
-	if a, ok := m.apps[app]; ok {
-		var process *Process
-		for _, p := range a.Processes {
-			if p.Type == ptype {
-				process = p
-			}
-		}
-
-		if process != nil {
-			process.Instances = instances
-		}
-	}
+	m.running[app][ptype] = instances
 	return nil
 }
 
 func (m *FakeScheduler) Remove(ctx context.Context, appID string) error {
 	delete(m.apps, appID)
+	delete(m.running, appID)
 	return nil
 }
 
-func (m *FakeScheduler) Instances(ctx context.Context, appID string) ([]*Instance, error) {
-	var instances []*Instance
+func (m *FakeScheduler) Instances(ctx context.Context, appID string) ([]Instance, error) {
+	var instances []Instance
 	if a, ok := m.apps[appID]; ok {
 		for _, p := range a.Processes {
-			for i := uint(1); i <= p.Instances; i++ {
-				instances = append(instances, &Instance{
+			for i := uint(1); i <= m.running[a.ID][p.Type]; i++ {
+				p.Env = ProcessEnv(a, p)
+				instances = append(instances, Instance{
 					ID:        fmt.Sprintf("%d", i),
 					State:     "running",
 					Process:   p,
@@ -69,7 +64,7 @@ func (m *FakeScheduler) Stop(ctx context.Context, instanceID string) error {
 	return nil
 }
 
-func (m *FakeScheduler) Run(ctx context.Context, app *App, p *Process, in io.Reader, out io.Writer) error {
+func (m *FakeScheduler) Run(ctx context.Context, app App, p Process, in io.Reader, out io.Writer) error {
 	if out != nil {
 		fmt.Fprintf(out, "Fake output for `%s` on %s\n", p.Command, app.Name)
 	}

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -4,23 +4,24 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/remind101/empire/12factor"
 	"github.com/remind101/pkg/timex"
 	"golang.org/x/net/context"
 )
 
 type FakeScheduler struct {
-	apps    map[string]App
+	apps    map[string]twelvefactor.App
 	running map[string]map[string]uint
 }
 
 func NewFakeScheduler() *FakeScheduler {
 	return &FakeScheduler{
-		apps:    make(map[string]App),
+		apps:    make(map[string]twelvefactor.App),
 		running: make(map[string]map[string]uint),
 	}
 }
 
-func (m *FakeScheduler) Submit(ctx context.Context, app App) error {
+func (m *FakeScheduler) Submit(ctx context.Context, app twelvefactor.App) error {
 	m.apps[app.ID] = app
 	for _, p := range app.Processes {
 		if m.running[app.ID] == nil {
@@ -47,7 +48,7 @@ func (m *FakeScheduler) Instances(ctx context.Context, appID string) ([]Instance
 	if a, ok := m.apps[appID]; ok {
 		for _, p := range a.Processes {
 			for i := uint(1); i <= m.running[a.ID][p.Type]; i++ {
-				p.Env = ProcessEnv(a, p)
+				p.Env = twelvefactor.ProcessEnv(a, p)
 				instances = append(instances, Instance{
 					ID:        fmt.Sprintf("%d", i),
 					State:     "running",
@@ -64,7 +65,7 @@ func (m *FakeScheduler) Stop(ctx context.Context, instanceID string) error {
 	return nil
 }
 
-func (m *FakeScheduler) Run(ctx context.Context, app App, p Process, in io.Reader, out io.Writer) error {
+func (m *FakeScheduler) Run(ctx context.Context, app twelvefactor.App, p twelvefactor.Process, in io.Reader, out io.Writer) error {
 	if out != nil {
 		fmt.Fprintf(out, "Fake output for `%s` on %s\n", p.Command, app.Name)
 	}

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -19,6 +19,10 @@ func NewFakeScheduler() *FakeScheduler {
 }
 
 func (m *FakeScheduler) Submit(ctx context.Context, app *App) error {
+	for _, p := range app.Processes {
+		p.Env = ProcessEnv(app, p)
+		p.Labels = ProcessLabels(app, p)
+	}
 	m.apps[app.ID] = app
 	return nil
 }

--- a/scheduler/runner.go
+++ b/scheduler/runner.go
@@ -20,7 +20,7 @@ func (m *AttachedRunner) Run(ctx context.Context, app *App, p *Process, in io.Re
 		return m.Runner.Run(ctx, runner.RunOpts{
 			Image:   app.Image,
 			Command: p.Command,
-			Env:     p.Env,
+			Env:     ProcessEnv(app, p),
 			Input:   in,
 			Output:  out,
 		})

--- a/scheduler/runner.go
+++ b/scheduler/runner.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"io"
 
+	"github.com/remind101/empire/12factor"
 	"github.com/remind101/empire/pkg/runner"
 	"golang.org/x/net/context"
 )
@@ -14,13 +15,13 @@ type AttachedRunner struct {
 	Runner *runner.Runner
 }
 
-func (m *AttachedRunner) Run(ctx context.Context, app App, p Process, in io.Reader, out io.Writer) error {
+func (m *AttachedRunner) Run(ctx context.Context, app twelvefactor.App, p twelvefactor.Process, in io.Reader, out io.Writer) error {
 	// If an output stream is provided, run using the docker runner.
 	if out != nil {
 		return m.Runner.Run(ctx, runner.RunOpts{
 			Image:   app.Image,
 			Command: p.Command,
-			Env:     ProcessEnv(app, p),
+			Env:     twelvefactor.ProcessEnv(app, p),
 			Input:   in,
 			Output:  out,
 		})

--- a/scheduler/runner.go
+++ b/scheduler/runner.go
@@ -18,7 +18,7 @@ func (m *AttachedRunner) Run(ctx context.Context, app *App, p *Process, in io.Re
 	// If an output stream is provided, run using the docker runner.
 	if out != nil {
 		return m.Runner.Run(ctx, runner.RunOpts{
-			Image:   p.Image,
+			Image:   app.Image,
 			Command: p.Command,
 			Env:     p.Env,
 			Input:   in,

--- a/scheduler/runner.go
+++ b/scheduler/runner.go
@@ -14,7 +14,7 @@ type AttachedRunner struct {
 	Runner *runner.Runner
 }
 
-func (m *AttachedRunner) Run(ctx context.Context, app *App, p *Process, in io.Reader, out io.Writer) error {
+func (m *AttachedRunner) Run(ctx context.Context, app App, p Process, in io.Reader, out io.Writer) error {
 	// If an output stream is provided, run using the docker runner.
 	if out != nil {
 		return m.Runner.Run(ctx, runner.RunOpts{

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -27,7 +27,7 @@ type App struct {
 	Labels map[string]string
 
 	// Process that belong to this app.
-	Processes []*Process
+	Processes []Process
 }
 
 type Process struct {
@@ -94,7 +94,7 @@ func (e *HTTPSExposure) Protocol() string { return "https" }
 
 // Instance represents an Instance of a Process.
 type Instance struct {
-	Process *Process
+	Process Process
 
 	// The instance ID.
 	ID string
@@ -108,12 +108,12 @@ type Instance struct {
 
 // ProcessEnv merges the App environment with any environment variables provided
 // in the process.
-func ProcessEnv(app *App, process *Process) map[string]string {
+func ProcessEnv(app App, process Process) map[string]string {
 	return merge(app.Env, process.Env)
 }
 
 // ProcessLabels merges the App labels with any labels provided in the process.
-func ProcessLabels(app *App, process *Process) map[string]string {
+func ProcessLabels(app App, process Process) map[string]string {
 	return merge(app.Labels, process.Labels)
 }
 
@@ -135,7 +135,7 @@ type Scaler interface {
 
 type Runner interface {
 	// Run runs a process.
-	Run(ctx context.Context, app *App, process *Process, in io.Reader, out io.Writer) error
+	Run(ctx context.Context, app App, process Process, in io.Reader, out io.Writer) error
 }
 
 // Scheduler is an interface for interfacing with Services.
@@ -144,13 +144,13 @@ type Scheduler interface {
 	Runner
 
 	// Submit submits an app, creating it or updating it as necessary.
-	Submit(context.Context, *App) error
+	Submit(context.Context, App) error
 
 	// Remove removes the App.
 	Remove(ctx context.Context, app string) error
 
 	// Instance lists the instances of a Process for an app.
-	Instances(ctx context.Context, app string) ([]*Instance, error)
+	Instances(ctx context.Context, app string) ([]Instance, error)
 
 	// Stop stops an instance. The scheduler will automatically start a new
 	// instance.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -32,6 +32,10 @@ type Scaler interface {
 
 type Runner interface {
 	// Run runs a process.
+	//
+	// TODO: In an ideal world, we'd only submit the app ID, since the
+	// scheduler should already know about the app description from a
+	// previous Submit.
 	Run(ctx context.Context, app twelvefactor.App, process twelvefactor.Process, in io.Reader, out io.Writer) error
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -20,6 +20,12 @@ type App struct {
 	// The Image to run.
 	Image image.Image
 
+	// The shared environment variables for the individual processes.
+	Env map[string]string
+
+	// The shared labels for the individual processes.
+	Labels map[string]string
+
 	// Process that belong to this app.
 	Processes []*Process
 }
@@ -31,10 +37,11 @@ type Process struct {
 	// The Command to run.
 	Command []string
 
-	// Environment variables to set.
+	// Additional environment variables to merge with the App's environment
+	// when running this process.
 	Env map[string]string
 
-	// Labels to set on the container.
+	// Free form labels to attach to this process.
 	Labels map[string]string
 
 	// Exposure is the level of exposure for this process.
@@ -97,6 +104,28 @@ type Instance struct {
 
 	// The time that this instance was last updated.
 	UpdatedAt time.Time
+}
+
+// ProcessEnv merges the App environment with any environment variables provided
+// in the process.
+func ProcessEnv(app *App, process *Process) map[string]string {
+	return merge(app.Env, process.Env)
+}
+
+// ProcessLabels merges the App labels with any labels provided in the process.
+func ProcessLabels(app *App, process *Process) map[string]string {
+	return merge(app.Labels, process.Labels)
+}
+
+// merges the maps together, favoring keys from the right to the left.
+func merge(envs ...map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for _, env := range envs {
+		for k, v := range env {
+			merged[k] = v
+		}
+	}
+	return merged
 }
 
 type Scaler interface {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -17,6 +17,9 @@ type App struct {
 	// The name of the app.
 	Name string
 
+	// The Image to run.
+	Image image.Image
+
 	// Process that belong to this app.
 	Processes []*Process
 }
@@ -24,9 +27,6 @@ type App struct {
 type Process struct {
 	// The type of process.
 	Type string
-
-	// The Image to run.
-	Image image.Image
 
 	// The Command to run.
 	Command []string

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -41,7 +41,7 @@ type Scheduler interface {
 	Runner
 
 	// Submit submits an app, creating it or updating it as necessary.
-	Submit(context.Context, twelvefactor.App) error
+	Submit(context.Context, twelvefactor.Manifest) error
 
 	// Remove removes the App.
 	Remove(ctx context.Context, app string) error

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -6,95 +6,14 @@ import (
 	"io"
 	"time"
 
-	"github.com/remind101/empire/pkg/image"
+	"github.com/remind101/empire/12factor"
+
 	"golang.org/x/net/context"
 )
 
-type App struct {
-	// The id of the app.
-	ID string
-
-	// The name of the app.
-	Name string
-
-	// The Image to run.
-	Image image.Image
-
-	// The shared environment variables for the individual processes.
-	Env map[string]string
-
-	// The shared labels for the individual processes.
-	Labels map[string]string
-
-	// Process that belong to this app.
-	Processes []Process
-}
-
-type Process struct {
-	// The type of process.
-	Type string
-
-	// The Command to run.
-	Command []string
-
-	// Additional environment variables to merge with the App's environment
-	// when running this process.
-	Env map[string]string
-
-	// Free form labels to attach to this process.
-	Labels map[string]string
-
-	// Exposure is the level of exposure for this process.
-	Exposure *Exposure
-
-	// Instances is the desired instances of this service to run.
-	Instances uint
-
-	// The amount of RAM to allocate to this process in bytes.
-	MemoryLimit uint
-
-	// The amount of CPU to allocate to this process, out of 1024. Maps to
-	// the --cpu-shares flag for docker.
-	CPUShares uint
-
-	// ulimit -u
-	Nproc uint
-}
-
-// Exposure controls the exposure settings for a process.
-type Exposure struct {
-	// External means that this process will be exposed to internet facing
-	// traffic, as opposed to being internal. How this is used is
-	// implementation specific. For ECS, this means that the attached ELB
-	// will be "internet-facing".
-	External bool
-
-	// The exposure type (e.g. HTTPExposure, HTTPSExposure, TCPExposure).
-	Type ExposureType
-}
-
-// Exposure represents a service that a process exposes, like HTTP/HTTPS/TCP or
-// SSL.
-type ExposureType interface {
-	Protocol() string
-}
-
-// HTTPExposure represents an HTTP exposure.
-type HTTPExposure struct{}
-
-func (e *HTTPExposure) Protocol() string { return "http" }
-
-// HTTPSExposure represents an HTTPS exposure
-type HTTPSExposure struct {
-	// The certificate to attach to the process.
-	Cert string
-}
-
-func (e *HTTPSExposure) Protocol() string { return "https" }
-
 // Instance represents an Instance of a Process.
 type Instance struct {
-	Process Process
+	Process twelvefactor.Process
 
 	// The instance ID.
 	ID string
@@ -106,28 +25,6 @@ type Instance struct {
 	UpdatedAt time.Time
 }
 
-// ProcessEnv merges the App environment with any environment variables provided
-// in the process.
-func ProcessEnv(app App, process Process) map[string]string {
-	return merge(app.Env, process.Env)
-}
-
-// ProcessLabels merges the App labels with any labels provided in the process.
-func ProcessLabels(app App, process Process) map[string]string {
-	return merge(app.Labels, process.Labels)
-}
-
-// merges the maps together, favoring keys from the right to the left.
-func merge(envs ...map[string]string) map[string]string {
-	merged := make(map[string]string)
-	for _, env := range envs {
-		for k, v := range env {
-			merged[k] = v
-		}
-	}
-	return merged
-}
-
 type Scaler interface {
 	// Scale scales an app process.
 	Scale(ctx context.Context, app string, process string, instances uint) error
@@ -135,7 +32,7 @@ type Scaler interface {
 
 type Runner interface {
 	// Run runs a process.
-	Run(ctx context.Context, app App, process Process, in io.Reader, out io.Writer) error
+	Run(ctx context.Context, app twelvefactor.App, process twelvefactor.Process, in io.Reader, out io.Writer) error
 }
 
 // Scheduler is an interface for interfacing with Services.
@@ -144,7 +41,7 @@ type Scheduler interface {
 	Runner
 
 	// Submit submits an app, creating it or updating it as necessary.
-	Submit(context.Context, App) error
+	Submit(context.Context, twelvefactor.App) error
 
 	// Remove removes the App.
 	Remove(ctx context.Context, app string) error

--- a/tasks.go
+++ b/tasks.go
@@ -41,7 +41,7 @@ func (s *tasksService) Tasks(ctx context.Context, app *App) ([]*Task, error) {
 // taskFromInstance converts a scheduler.Instance into a Task.
 // It pulls some of its data from empire specific environment variables if they have been set.
 // Once ECS supports this data natively, we can stop doing this.
-func taskFromInstance(i *scheduler.Instance) *Task {
+func taskFromInstance(i scheduler.Instance) *Task {
 	version := i.Process.Env["EMPIRE_RELEASE"]
 	if version == "" {
 		version = "v0"

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -98,12 +98,12 @@ func TestEmpire_Deploy(t *testing.T) {
 
 	img := image.Image{Repository: "remind101/acme-inc"}
 	s.On("Submit", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:    app.ID,
+		Name:  "acme-inc",
+		Image: img,
 		Processes: []*scheduler.Process{
 			{
 				Type:    "web",
-				Image:   img,
 				Command: []string{"./bin/web"},
 				Exposure: &scheduler.Exposure{
 					Type: &scheduler.HTTPExposure{},
@@ -255,12 +255,12 @@ func TestEmpire_Set(t *testing.T) {
 	// Deploy a new image to the app.
 	img := image.Image{Repository: "remind101/acme-inc"}
 	s.On("Submit", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:    app.ID,
+		Name:  "acme-inc",
+		Image: img,
 		Processes: []*scheduler.Process{
 			{
 				Type:    "web",
-				Image:   img,
 				Command: []string{"./bin/web"},
 				Exposure: &scheduler.Exposure{
 					Type: &scheduler.HTTPExposure{},
@@ -298,12 +298,12 @@ func TestEmpire_Set(t *testing.T) {
 
 	// Remove the environment variable
 	s.On("Submit", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:    app.ID,
+		Name:  "acme-inc",
+		Image: img,
 		Processes: []*scheduler.Process{
 			{
 				Type:    "web",
-				Image:   img,
 				Command: []string{"./bin/web"},
 				Exposure: &scheduler.Exposure{
 					Type: &scheduler.HTTPExposure{},

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -98,20 +98,22 @@ func TestEmpire_Deploy(t *testing.T) {
 	assert.NoError(t, err)
 
 	img := image.Image{Repository: "remind101/acme-inc"}
-	s.On("Submit", twelvefactor.App{
-		ID:    app.ID,
-		Name:  "acme-inc",
-		Image: img,
-		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v1",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
-		},
-		Labels: map[string]string{
-			"empire.app.name":    "acme-inc",
-			"empire.app.id":      app.ID,
-			"empire.app.release": "v1",
+	s.On("Submit", twelvefactor.Manifest{
+		App: twelvefactor.App{
+			ID:    app.ID,
+			Name:  "acme-inc",
+			Image: img,
+			Env: map[string]string{
+				"EMPIRE_APPID":      app.ID,
+				"EMPIRE_APPNAME":    "acme-inc",
+				"EMPIRE_RELEASE":    "v1",
+				"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+			},
+			Labels: map[string]string{
+				"empire.app.name":    "acme-inc",
+				"empire.app.id":      app.ID,
+				"empire.app.release": "v1",
+			},
 		},
 		Processes: []twelvefactor.Process{
 			{
@@ -259,21 +261,23 @@ func TestEmpire_Set(t *testing.T) {
 
 	// Deploy a new image to the app.
 	img := image.Image{Repository: "remind101/acme-inc"}
-	s.On("Submit", twelvefactor.App{
-		ID:    app.ID,
-		Name:  "acme-inc",
-		Image: img,
-		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v1",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
-			"RAILS_ENV":         "production",
-		},
-		Labels: map[string]string{
-			"empire.app.name":    "acme-inc",
-			"empire.app.id":      app.ID,
-			"empire.app.release": "v1",
+	s.On("Submit", twelvefactor.Manifest{
+		App: twelvefactor.App{
+			ID:    app.ID,
+			Name:  "acme-inc",
+			Image: img,
+			Env: map[string]string{
+				"EMPIRE_APPID":      app.ID,
+				"EMPIRE_APPNAME":    "acme-inc",
+				"EMPIRE_RELEASE":    "v1",
+				"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+				"RAILS_ENV":         "production",
+			},
+			Labels: map[string]string{
+				"empire.app.name":    "acme-inc",
+				"empire.app.id":      app.ID,
+				"empire.app.release": "v1",
+			},
 		},
 		Processes: []twelvefactor.Process{
 			{
@@ -306,20 +310,22 @@ func TestEmpire_Set(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Remove the environment variable
-	s.On("Submit", twelvefactor.App{
-		ID:    app.ID,
-		Name:  "acme-inc",
-		Image: img,
-		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v2",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
-		},
-		Labels: map[string]string{
-			"empire.app.name":    "acme-inc",
-			"empire.app.id":      app.ID,
-			"empire.app.release": "v2",
+	s.On("Submit", twelvefactor.Manifest{
+		App: twelvefactor.App{
+			ID:    app.ID,
+			Name:  "acme-inc",
+			Image: img,
+			Env: map[string]string{
+				"EMPIRE_APPID":      app.ID,
+				"EMPIRE_APPNAME":    "acme-inc",
+				"EMPIRE_RELEASE":    "v2",
+				"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+			},
+			Labels: map[string]string{
+				"empire.app.name":    "acme-inc",
+				"empire.app.id":      app.ID,
+				"empire.app.release": "v2",
+			},
 		},
 		Processes: []twelvefactor.Process{
 			{
@@ -360,7 +366,7 @@ type mockScheduler struct {
 	mock.Mock
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app twelvefactor.App) error {
-	args := m.Called(app)
+func (m *mockScheduler) Submit(_ context.Context, manifest twelvefactor.Manifest) error {
+	args := m.Called(manifest)
 	return args.Error(0)
 }

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/remind101/empire"
+	"github.com/remind101/empire/12factor"
 	"github.com/remind101/empire/empiretest"
 	"github.com/remind101/empire/pkg/image"
 	"github.com/remind101/empire/procfile"
@@ -97,7 +98,7 @@ func TestEmpire_Deploy(t *testing.T) {
 	assert.NoError(t, err)
 
 	img := image.Image{Repository: "remind101/acme-inc"}
-	s.On("Submit", scheduler.App{
+	s.On("Submit", twelvefactor.App{
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
@@ -112,12 +113,12 @@ func TestEmpire_Deploy(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v1",
 		},
-		Processes: []scheduler.Process{
+		Processes: []twelvefactor.Process{
 			{
 				Type:    "web",
 				Command: []string{"./bin/web"},
-				Exposure: &scheduler.Exposure{
-					Type: &scheduler.HTTPExposure{},
+				Exposure: &twelvefactor.Exposure{
+					Type: &twelvefactor.HTTPExposure{},
 				},
 				Instances:   1,
 				MemoryLimit: 536870912,
@@ -258,7 +259,7 @@ func TestEmpire_Set(t *testing.T) {
 
 	// Deploy a new image to the app.
 	img := image.Image{Repository: "remind101/acme-inc"}
-	s.On("Submit", scheduler.App{
+	s.On("Submit", twelvefactor.App{
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
@@ -274,12 +275,12 @@ func TestEmpire_Set(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v1",
 		},
-		Processes: []scheduler.Process{
+		Processes: []twelvefactor.Process{
 			{
 				Type:    "web",
 				Command: []string{"./bin/web"},
-				Exposure: &scheduler.Exposure{
-					Type: &scheduler.HTTPExposure{},
+				Exposure: &twelvefactor.Exposure{
+					Type: &twelvefactor.HTTPExposure{},
 				},
 				Instances:   1,
 				MemoryLimit: 536870912,
@@ -305,7 +306,7 @@ func TestEmpire_Set(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Remove the environment variable
-	s.On("Submit", scheduler.App{
+	s.On("Submit", twelvefactor.App{
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
@@ -320,12 +321,12 @@ func TestEmpire_Set(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v2",
 		},
-		Processes: []scheduler.Process{
+		Processes: []twelvefactor.Process{
 			{
 				Type:    "web",
 				Command: []string{"./bin/web"},
-				Exposure: &scheduler.Exposure{
-					Type: &scheduler.HTTPExposure{},
+				Exposure: &twelvefactor.Exposure{
+					Type: &twelvefactor.HTTPExposure{},
 				},
 				Instances:   1,
 				MemoryLimit: 536870912,
@@ -359,7 +360,7 @@ type mockScheduler struct {
 	mock.Mock
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app scheduler.App) error {
+func (m *mockScheduler) Submit(_ context.Context, app twelvefactor.App) error {
 	args := m.Called(app)
 	return args.Error(0)
 }

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -97,7 +97,7 @@ func TestEmpire_Deploy(t *testing.T) {
 	assert.NoError(t, err)
 
 	img := image.Image{Repository: "remind101/acme-inc"}
-	s.On("Submit", &scheduler.App{
+	s.On("Submit", scheduler.App{
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
@@ -112,7 +112,7 @@ func TestEmpire_Deploy(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v1",
 		},
-		Processes: []*scheduler.Process{
+		Processes: []scheduler.Process{
 			{
 				Type:    "web",
 				Command: []string{"./bin/web"},
@@ -258,7 +258,7 @@ func TestEmpire_Set(t *testing.T) {
 
 	// Deploy a new image to the app.
 	img := image.Image{Repository: "remind101/acme-inc"}
-	s.On("Submit", &scheduler.App{
+	s.On("Submit", scheduler.App{
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
@@ -274,7 +274,7 @@ func TestEmpire_Set(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v1",
 		},
-		Processes: []*scheduler.Process{
+		Processes: []scheduler.Process{
 			{
 				Type:    "web",
 				Command: []string{"./bin/web"},
@@ -305,7 +305,7 @@ func TestEmpire_Set(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Remove the environment variable
-	s.On("Submit", &scheduler.App{
+	s.On("Submit", scheduler.App{
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
@@ -320,7 +320,7 @@ func TestEmpire_Set(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v2",
 		},
-		Processes: []*scheduler.Process{
+		Processes: []scheduler.Process{
 			{
 				Type:    "web",
 				Command: []string{"./bin/web"},
@@ -359,7 +359,7 @@ type mockScheduler struct {
 	mock.Mock
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
+func (m *mockScheduler) Submit(_ context.Context, app scheduler.App) error {
 	args := m.Called(app)
 	return args.Error(0)
 }

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -101,6 +101,17 @@ func TestEmpire_Deploy(t *testing.T) {
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
+		Env: map[string]string{
+			"EMPIRE_APPID":      app.ID,
+			"EMPIRE_APPNAME":    "acme-inc",
+			"EMPIRE_RELEASE":    "v1",
+			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+		},
+		Labels: map[string]string{
+			"empire.app.name":    "acme-inc",
+			"empire.app.id":      app.ID,
+			"empire.app.release": "v1",
+		},
 		Processes: []*scheduler.Process{
 			{
 				Type:    "web",
@@ -113,18 +124,11 @@ func TestEmpire_Deploy(t *testing.T) {
 				CPUShares:   256,
 				Nproc:       256,
 				Env: map[string]string{
-					"EMPIRE_APPID":      app.ID,
-					"EMPIRE_APPNAME":    "acme-inc",
-					"EMPIRE_PROCESS":    "web",
-					"EMPIRE_RELEASE":    "v1",
-					"SOURCE":            "acme-inc.web.v1",
-					"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+					"EMPIRE_PROCESS": "web",
+					"SOURCE":         "acme-inc.web.v1",
 				},
 				Labels: map[string]string{
-					"empire.app.name":    "acme-inc",
-					"empire.app.id":      app.ID,
 					"empire.app.process": "web",
-					"empire.app.release": "v1",
 				},
 			},
 		},
@@ -258,6 +262,18 @@ func TestEmpire_Set(t *testing.T) {
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
+		Env: map[string]string{
+			"EMPIRE_APPID":      app.ID,
+			"EMPIRE_APPNAME":    "acme-inc",
+			"EMPIRE_RELEASE":    "v1",
+			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+			"RAILS_ENV":         "production",
+		},
+		Labels: map[string]string{
+			"empire.app.name":    "acme-inc",
+			"empire.app.id":      app.ID,
+			"empire.app.release": "v1",
+		},
 		Processes: []*scheduler.Process{
 			{
 				Type:    "web",
@@ -270,19 +286,11 @@ func TestEmpire_Set(t *testing.T) {
 				CPUShares:   256,
 				Nproc:       256,
 				Env: map[string]string{
-					"EMPIRE_APPID":      app.ID,
-					"EMPIRE_APPNAME":    "acme-inc",
-					"EMPIRE_PROCESS":    "web",
-					"EMPIRE_RELEASE":    "v1",
-					"SOURCE":            "acme-inc.web.v1",
-					"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
-					"RAILS_ENV":         "production",
+					"EMPIRE_PROCESS": "web",
+					"SOURCE":         "acme-inc.web.v1",
 				},
 				Labels: map[string]string{
-					"empire.app.name":    "acme-inc",
-					"empire.app.id":      app.ID,
 					"empire.app.process": "web",
-					"empire.app.release": "v1",
 				},
 			},
 		},
@@ -301,6 +309,17 @@ func TestEmpire_Set(t *testing.T) {
 		ID:    app.ID,
 		Name:  "acme-inc",
 		Image: img,
+		Env: map[string]string{
+			"EMPIRE_APPID":      app.ID,
+			"EMPIRE_APPNAME":    "acme-inc",
+			"EMPIRE_RELEASE":    "v2",
+			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+		},
+		Labels: map[string]string{
+			"empire.app.name":    "acme-inc",
+			"empire.app.id":      app.ID,
+			"empire.app.release": "v2",
+		},
 		Processes: []*scheduler.Process{
 			{
 				Type:    "web",
@@ -313,18 +332,11 @@ func TestEmpire_Set(t *testing.T) {
 				CPUShares:   256,
 				Nproc:       256,
 				Env: map[string]string{
-					"EMPIRE_APPID":      app.ID,
-					"EMPIRE_APPNAME":    "acme-inc",
-					"EMPIRE_PROCESS":    "web",
-					"EMPIRE_RELEASE":    "v2",
-					"SOURCE":            "acme-inc.web.v2",
-					"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+					"EMPIRE_PROCESS": "web",
+					"SOURCE":         "acme-inc.web.v2",
 				},
 				Labels: map[string]string{
-					"empire.app.name":    "acme-inc",
-					"empire.app.id":      app.ID,
 					"empire.app.process": "web",
-					"empire.app.release": "v2",
 				},
 			},
 		},

--- a/tests/github/github_test.go
+++ b/tests/github/github_test.go
@@ -78,7 +78,7 @@ type mockScheduler struct {
 	image chan string
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app twelvefactor.App) error {
-	m.image <- app.Image.String()
+func (m *mockScheduler) Submit(_ context.Context, manifest twelvefactor.Manifest) error {
+	m.image <- manifest.App.Image.String()
 	return nil
 }

--- a/tests/github/github_test.go
+++ b/tests/github/github_test.go
@@ -78,6 +78,6 @@ type mockScheduler struct {
 }
 
 func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
-	m.image <- app.Processes[0].Image.String()
+	m.image <- app.Image.String()
 	return nil
 }

--- a/tests/github/github_test.go
+++ b/tests/github/github_test.go
@@ -77,7 +77,7 @@ type mockScheduler struct {
 	image chan string
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
+func (m *mockScheduler) Submit(_ context.Context, app scheduler.App) error {
 	m.image <- app.Image.String()
 	return nil
 }

--- a/tests/github/github_test.go
+++ b/tests/github/github_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ejholmes/hookshot/events"
 	"github.com/ejholmes/hookshot/hooker"
 	"github.com/remind101/empire"
+	"github.com/remind101/empire/12factor"
 	"github.com/remind101/empire/empiretest"
 	"github.com/remind101/empire/scheduler"
 	"github.com/stretchr/testify/assert"
@@ -77,7 +78,7 @@ type mockScheduler struct {
 	image chan string
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app scheduler.App) error {
+func (m *mockScheduler) Submit(_ context.Context, app twelvefactor.App) error {
 	m.image <- app.Image.String()
 	return nil
 }


### PR DESCRIPTION
For part of Step 5/6 in https://github.com/remind101/empire/wiki/Extended-Procfile-Roadmap#step-5---refactor-how-we-store-process-configuration

This extracts just the new `App`, `Process` and `Manifest` types from https://github.com/remind101/empire/pull/696 and switches the current scheduler to use it.

The `twelvefactor` package just defines a more accurate Go representation of what we determine to be a twelve factor application.

The primary change is that the `Image` is now defined on the `App` and the shared environment/labels are defined on the `App` as well, which is a more accurate representation of a twelve factor app.