### PR TITLE
Enable single transaction mode for migrations.

### DIFF
--- a/db.go
+++ b/db.go
@@ -36,10 +36,18 @@ func OpenDB(uri string) (*DB, error) {
 		return nil, err
 	}
 
+	m := migrate.NewPostgresMigrator(conn)
+	// Run all migrations in a single transaction, so they will be rolled
+	// back as one. This is almost always the behavior that users would want
+	// when upgrading Empire. If a new release has multiple migrations, and
+	// one of those fails, it's easier for them if the entire upgrade rolls
+	// back instead of getting stuck in failed state.
+	m.TransactionMode = migrate.SingleTransaction
+
 	return &DB{
 		DB:       &db,
 		uri:      uri,
-		migrator: migrate.NewPostgresMigrator(conn),
+		migrator: m,
 	}, nil
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -494,8 +494,8 @@
 		},
 		{
 			"path": "github.com/remind101/migrate",
-			"revision": "6a911e1904d23e8ad3de5b9fab2f6530241c6183",
-			"revisionTime": "2016-04-20T11:09:36+07:00"
+			"revision": "d22d647232c20dbea6d2aa1dda7f2737cccce614",
+			"revisionTime": "2016-04-23T08:09:09+07:00"
 		},
 		{
 			"path": "github.com/remind101/newrelic",


### PR DESCRIPTION
When we release the next version of Empire, it's going to contain at least 3 fairly large database migrations. When users are upgrading, it'd be more desirable if all of those migrations are treated atomically. If any of the migrations fail, it's better if the entire migration rolls back so that they can easily downgrade to the previous version instead of getting stuck in an inconsistent migration state.

Depends on https://github.com/remind101/migrate/pull/5. Once that is merged, I'll update the dep here.