### PR TITLE
Postgres 9.2 compat.

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -257,12 +257,12 @@ ALTER TABLE apps ADD COLUMN exposure TEXT NOT NULL default 'private'`,
 	{
 		ID: 14,
 		Up: func(tx *sql.Tx) error {
-			_, err := tx.Exec(`ALTER TABLE slugs ADD COLUMN process_types_json jsonb`)
+			_, err := tx.Exec(`ALTER TABLE slugs ADD COLUMN process_types_json json`)
 			if err != nil {
 				return err
 			}
 
-			_, err = tx.Exec(`ALTER TABLE processes ADD COLUMN command_json jsonb`)
+			_, err = tx.Exec(`ALTER TABLE processes ADD COLUMN command_json json`)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The `jsonb` datatype was added in Postgres 9.4 and some people (ourselves included) aren't on 9.4+ yet. For what we're using the json datatype for, there's really no advantage to using `jsonb` over `json`, since we're not querying, just storing.