### PR TITLE
Only destroy load balancers when the app is destroyed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * `emp scale -l` now lists configured scale, not the running processes [#769](https://github.com/remind101/empire/pull/769)
 * Fixed a bug where it was previously possible to create a signed access token with an empty username [#780](https://github.com/remind101/empire/pull/780)
 * ECR authentication now supports multiple regions, and works independently of ECS region [#784](https://github.com/remind101/empire/pull/784)
+* Provisioned ELB's are only destroyed when the entire app is removed [#801](https://github.com/remind101/empire/pull/801)
 
 **Performance**
 

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -277,8 +277,7 @@ func TestScheduler_Remove(t *testing.T) {
 	defer s.Close()
 
 	m.lb.(*mockLBManager).On("LoadBalancers", map[string]string{
-		"AppID":       "1234",
-		"ProcessType": "web",
+		"AppID": "1234",
 	}).Return([]*lb.LoadBalancer{}, nil)
 
 	if err := m.Remove(context.Background(), "1234"); err != nil {


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/798

I think it's a lot safer if we only ever destroy a load balancer when the entire app is destroyed, rather than per process. With the existing behavior, it would be possible to deploy a Procfile without the `web` process and the load balancer would be destroyed, making it more difficult to recover from (if you have CNAME's pointed at it).

With the new behavior, it does mean that you could potentially accumulate unused load balancers, but those can always be destroyed manually if it's a real problem.