### PR TITLE
Add support for creating TCP load balancers in ECS scheduler.

### DIFF
--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -533,6 +533,7 @@ func TestScheduler_LoadBalancer_NoExistingLoadBalancer(t *testing.T) {
 
 	l.On("LoadBalancers", map[string]string{"AppID": "appid", "ProcessType": "web"}).Return([]*lb.LoadBalancer{}, nil)
 	l.On("CreateLoadBalancer", lb.CreateLoadBalancerOpts{
+		Protocol: "http",
 		Tags:     map[string]string{"AppID": "appid", "ProcessType": "web", "App": "appname"},
 		External: false,
 	}).Return(&lb.LoadBalancer{

--- a/scheduler/ecs/lb/elb_test.go
+++ b/scheduler/ecs/lb/elb_test.go
@@ -46,6 +46,7 @@ func TestELB_CreateLoadBalancer(t *testing.T) {
 	}).Return(&elb.ModifyLoadBalancerAttributesOutput{}, nil)
 
 	lb, err := m.CreateLoadBalancer(context.Background(), CreateLoadBalancerOpts{
+		Protocol: "http",
 		External: true,
 	})
 	assert.NoError(t, err)

--- a/scheduler/ecs/lb/lb.go
+++ b/scheduler/ecs/lb/lb.go
@@ -8,6 +8,9 @@ const AppTag = "App"
 // CreateLoadBalancerOpts are options that can be provided when creating a
 // LoadBalancer.
 type CreateLoadBalancerOpts struct {
+	// The protocol to create the load balancer with.
+	Protocol string
+
 	// An arbitrary list of tags to assign to the load balancer.
 	Tags map[string]string
 
@@ -16,6 +19,9 @@ type CreateLoadBalancerOpts struct {
 
 	// The SSL Certificate
 	SSLCert string
+
+	// The port to listen on.
+	Port int64
 }
 
 // UpdateLoadBalancerOpts are options that can be provided when updating an

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -64,6 +64,10 @@ type Exposure struct {
 
 	// The exposure type (e.g. HTTPExposure, HTTPSExposure, TCPExposure).
 	Type ExposureType
+
+	// The port to expose. Implementors should provide sensible defaults for
+	// the zero value (e.g. port 80 for HTTP, port 443 for HTTPS).
+	Port int64
 }
 
 // Exposure represents a service that a process exposes, like HTTP/HTTPS/TCP or
@@ -84,6 +88,19 @@ type HTTPSExposure struct {
 }
 
 func (e *HTTPSExposure) Protocol() string { return "https" }
+
+// TCPExposure represents a raw TCP exposure.
+type TCPExposure struct{}
+
+func (e *TCPExposure) Protocol() string { return "tcp" }
+
+// SSLExposure represents a secure TCP exposure.
+type SSLExposure struct {
+	// The certificate to attach to the process.
+	Cert string
+}
+
+func (e *SSLExposure) Protocol() string { return "ssl" }
 
 // Instance represents an Instance of a Process.
 type Instance struct {


### PR DESCRIPTION
This should be a pre-req to https://github.com/remind101/empire/pull/800.

This adds support to the ECS scheduler for creating TCP/SSL load balancers for tcp/ssl exposures.