### PR TITLE
Migrate apps to CloudFormation scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**
 
+* Empire now uses CloudFormation to provision resources for applications [#814](https://github.com/remind101/empire/pull/814), [#803](https://github.com/remind101/empire/pull/803).
 * Empire now supports requiring commit messages for all actions that emit an event via `--messages.required`. If a commit message is required for an action, emp will gracefully handle it and ask the user to input a value [#767](https://github.com/remind101/empire/issues/767).
 * You can now supply a commit message to any event that is published by Empire [#767](https://github.com/remind101/empire/issues/767).
 * Empire now supports deploying Docker images from the EC2 Container Registry [#730](https://github.com/remind101/empire/pull/730).

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -36,7 +36,6 @@ const (
 	FlagDockerCert   = "docker.cert"
 	FlagDockerAuth   = "docker.auth"
 
-	FlagScheduler            = "scheduler"
 	FlagAWSDebug             = "aws.debug"
 	FlagS3TemplateBucket     = "s3.templatebucket"
 	FlagCustomResourcesTopic = "customresources.topic"
@@ -186,12 +185,6 @@ var EmpireFlags = []cli.Flag{
 		Value:  path.Join(os.Getenv("HOME"), ".dockercfg"),
 		Usage:  "Path to a docker registry auth file (~/.dockercfg)",
 		EnvVar: "DOCKER_AUTH_PATH",
-	},
-	cli.StringFlag{
-		Name:   FlagScheduler,
-		Value:  "ecs",
-		Usage:  "The scheduler backend to use. Can be `ecs` or `cloudformation`.",
-		EnvVar: "EMPIRE_SCHEDULER",
 	},
 	cli.BoolFlag{
 		Name:   FlagAWSDebug,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ server:
   environment:
     EMPIRE_DATABASE_URL: postgres://postgres:postgres@postgres/postgres?sslmode=disable
     DOCKER_HOST: unix:///var/run/docker.sock
-    EMPIRE_SCHEDULER: ecs
 postgres:
   image: postgres
   ports:

--- a/migrations.go
+++ b/migrations.go
@@ -532,4 +532,17 @@ ALTER TABLE apps ADD COLUMN exposure TEXT NOT NULL default 'private'`,
 			`DROP TABLE stacks`,
 		}),
 	},
+
+	// This migration adds a table that gets used to migrate apps from the
+	// old ECS backend to the shiny new CloudFormation backend.
+	{
+		ID: 17,
+		Up: migrate.Queries([]string{
+			`CREATE TABLE scheduler_migration (app_id text NOT NULL, backend text NOT NULL)`,
+			`INSERT INTO scheduler_migration (app_id, backend) SELECT id, 'ecs' FROM apps`,
+		}),
+		Down: migrate.Queries([]string{
+			`DROP TABLE scheduler_migration`,
+		}),
+	},
 }

--- a/scheduler/cloudformation/migration.go
+++ b/scheduler/cloudformation/migration.go
@@ -1,0 +1,212 @@
+package cloudformation
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/net/context"
+
+	"github.com/remind101/empire/scheduler"
+	"github.com/remind101/empire/scheduler/ecs"
+)
+
+// This is the environment variable in the application that determines what step
+// of the migration we should transition to. A basic migration flow would look
+// like:
+//
+// 1. `emp set EMPIRE_SCHEDULER_MIGRATION=step1`: CloudFormation stack is
+//    created without any DNS changes.
+// 2. User removes the old CNAME manually in the AWS Console, then sets the
+//    `DNS` parameter in the CloudFormation stack to `true`.
+// 3. `emp set EMPIRE_SCHEDULER_MIGRATION=step2`: The old AWS resources are
+//    removed.
+// 4. `emp unset EMPIRE_SCHEDULER_MIGRATION`: All done.
+const MigrationEnvVar = "EMPIRE_SCHEDULER_MIGRATION"
+
+// ErrMigrating is returned when the application is being migrated.
+var ErrMigrating = errors.New("app is currently being migrated to a CloudFormation stack. Sit tight...")
+
+// This is a scheduler.Scheduler implementation that wraps the newer
+// cloudformation.Scheduler and the older ecs.Scheduler to migrate applications
+// over the the new CloudFormation based scheduler.
+//
+// It uses a sql table to determine what scheduling backend should be used. Apps
+// can be migrated from the ecs scheduler to the cloudformation scheduler by
+// using the Migrate function.
+type MigrationScheduler struct {
+	// The scheduler that we want to migrate to.
+	cloudformation interface {
+		scheduler.Scheduler
+		SubmitWithOptions(context.Context, *scheduler.App, SubmitOptions) error
+	}
+
+	// The scheduler we're migrating from.
+	ecs interface {
+		scheduler.Scheduler
+		RemoveWithOptions(context.Context, string, ecs.RemoveOptions) error
+	}
+
+	db *sql.DB
+}
+
+// NewMigrationScheduler returns a new MigrationSchedeuler instance.
+func NewMigrationScheduler(db *sql.DB, c *Scheduler, e *ecs.Scheduler) *MigrationScheduler {
+	return &MigrationScheduler{
+		db:             db,
+		cloudformation: c,
+		ecs:            e,
+	}
+}
+
+// Backend returns the scheduling backend to use for the given app.
+func (s *MigrationScheduler) Backend(appID string) (scheduler.Scheduler, error) {
+	backend, err := s.backend(appID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch backend {
+	case "ecs":
+		return s.ecs, nil
+	case "cloudformation":
+		return s.cloudformation, nil
+	default:
+		return nil, ErrMigrating
+	}
+}
+
+// backend returns the name of the backend to use for operations.
+func (s *MigrationScheduler) backend(appID string) (string, error) {
+	var backend string
+	err := s.db.QueryRow(`SELECT backend FROM scheduler_migration WHERE app_id = $1`, appID).Scan(&backend)
+
+	// For newly created apps.
+	if err == sql.ErrNoRows {
+		return "cloudformation", nil
+	}
+
+	return backend, err
+}
+
+func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App) error {
+	state, err := s.backend(app.ID)
+	if err != nil {
+		return err
+	}
+
+	desiredState := app.Processes[0].Env[MigrationEnvVar]
+	if desiredState != "" {
+		if err := s.Migrate(ctx, app, state, desiredState); err != nil {
+			return fmt.Errorf("error migrating app from %s to %s: %v", state, desiredState, err)
+		}
+		return nil
+	}
+
+	b, err := s.Backend(app.ID)
+	if err != nil {
+		return err
+	}
+	return b.Submit(ctx, app)
+}
+
+// Migrate submits the app to the CloudFormation scheduler, waits for the stack
+// to successfully create, then removes the old API managed resources using the
+// ECS scheduler.
+func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, state, desiredState string) error {
+	errTransition := fmt.Errorf("cannot transition from %s to %s", state, desiredState)
+
+	// Whether or not we're re-trying a state transition.
+	rerun := state == desiredState
+
+	switch desiredState {
+	case "step1":
+		if !rerun && state != "ecs" {
+			return errTransition
+		}
+
+		// Submit to cloudformation and wait for it to complete successfully.
+		// Don't make any DNS changes.
+		if err := s.cloudformation.SubmitWithOptions(ctx, app, SubmitOptions{
+			Wait:  false,
+			NoDNS: true,
+		}); err != nil {
+			return fmt.Errorf("error creating CloudFormation stack: %v", err)
+		}
+
+		// After this step, the user has a couple of options.
+		//
+		// 1. The user can proceed by migrating to step2
+		// 2. The user can remove the old CNAME, then update the DNS
+		//    parameter in the CloudFormation stack to `true`.
+
+		state = "step1"
+	case "step2":
+		if !rerun && state != "step1" {
+			return errTransition
+		}
+
+		// The user may have already manually enabled the DNS change,
+		// but let's make sure.
+		if err := s.cloudformation.Submit(ctx, app); err != nil {
+			return fmt.Errorf("error updating CloudFormation stack: %v", err)
+		}
+
+		// Remove the old AWS resources.
+		if err := s.ecs.RemoveWithOptions(ctx, app.ID, ecs.RemoveOptions{
+			NoDNS: true,
+		}); err != nil {
+			return fmt.Errorf("error removing existing ECS resources: %v", err)
+		}
+
+		state = "cloudformation"
+	default:
+		return fmt.Errorf("cannot transition to %s", desiredState)
+	}
+
+	_, err := s.db.Exec(`UPDATE scheduler_migration SET backend = $1 WHERE app_id = $2`, state, app.ID)
+	return err
+}
+
+func (s *MigrationScheduler) Remove(ctx context.Context, appID string) error {
+	b, err := s.Backend(appID)
+	if err != nil {
+		return err
+	}
+	if err := b.Remove(ctx, appID); err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`DELETE FROM scheduler_migration WHERE app_id = $1`, appID)
+	return err
+}
+
+func (s *MigrationScheduler) Instances(ctx context.Context, appID string) ([]*scheduler.Instance, error) {
+	b, err := s.Backend(appID)
+	if err != nil {
+		return nil, err
+	}
+	return b.Instances(ctx, appID)
+}
+
+func (s *MigrationScheduler) Run(ctx context.Context, app *scheduler.App, process *scheduler.Process, in io.Reader, out io.Writer) error {
+	b, err := s.Backend(app.ID)
+	if err != nil {
+		return err
+	}
+	return b.Run(ctx, app, process, in, out)
+}
+
+func (s *MigrationScheduler) Scale(ctx context.Context, appID, process string, instances uint) error {
+	b, err := s.Backend(appID)
+	if err != nil {
+		return err
+	}
+	return b.Scale(ctx, appID, process, instances)
+}
+
+func (s *MigrationScheduler) Stop(ctx context.Context, id string) error {
+	// These are identical between the old and new scheduler, so just using
+	// the new one is safe.
+	return s.cloudformation.Stop(ctx, id)
+}

--- a/scheduler/cloudformation/migration_test.go
+++ b/scheduler/cloudformation/migration_test.go
@@ -1,0 +1,257 @@
+package cloudformation
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/remind101/empire/scheduler"
+	"github.com/remind101/empire/scheduler/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// New apps don't need to be migrated, and should just be routed to the
+// CloudFormation scheduler.
+func TestMigrationScheduler_NewApp(t *testing.T) {
+	db := newDB(t)
+	defer db.Close()
+
+	e := new(mockECSScheduler)
+	c := new(mockCloudFormationScheduler)
+	s := &MigrationScheduler{
+		ecs:            e,
+		cloudformation: c,
+		db:             db,
+	}
+
+	app := &scheduler.App{
+		ID: "c9366591-ab68-4d49-a333-95ce5a23df68",
+		Processes: []*scheduler.Process{
+			{Type: "web"},
+		},
+	}
+
+	c.On("Submit", app).Return(nil)
+
+	err := s.Submit(context.Background(), app)
+	assert.NoError(t, err)
+
+	e.AssertExpectations(t)
+	c.AssertExpectations(t)
+}
+
+// Old apps that aren't being migrated should just be routed to the ECS
+// scheduler.
+func TestMigrationScheduler_OldApp(t *testing.T) {
+	db := newDB(t)
+	defer db.Close()
+
+	e := new(mockECSScheduler)
+	c := new(mockCloudFormationScheduler)
+	s := &MigrationScheduler{
+		ecs:            e,
+		cloudformation: c,
+		db:             db,
+	}
+
+	_, err := db.Exec(`INSERT INTO scheduler_migration (app_id, backend) VALUES ('c9366591-ab68-4d49-a333-95ce5a23df68', 'ecs')`)
+	assert.NoError(t, err)
+
+	app := &scheduler.App{
+		ID: "c9366591-ab68-4d49-a333-95ce5a23df68",
+		Processes: []*scheduler.Process{
+			{Type: "web"},
+		},
+	}
+
+	e.On("Submit", app).Return(nil)
+
+	err = s.Submit(context.Background(), app)
+	assert.NoError(t, err)
+
+	e.AssertExpectations(t)
+	c.AssertExpectations(t)
+}
+
+func TestMigrationScheduler_Migrate(t *testing.T) {
+	db := newDB(t)
+	defer db.Close()
+
+	e := new(mockECSScheduler)
+	c := new(mockCloudFormationScheduler)
+	s := &MigrationScheduler{
+		ecs:            e,
+		cloudformation: c,
+		db:             db,
+	}
+
+	_, err := db.Exec(`INSERT INTO scheduler_migration (app_id, backend) VALUES ('c9366591-ab68-4d49-a333-95ce5a23df68', 'ecs')`)
+	assert.NoError(t, err)
+
+	app := &scheduler.App{
+		ID: "c9366591-ab68-4d49-a333-95ce5a23df68",
+		Processes: []*scheduler.Process{
+			{
+				Type: "web",
+				Env: map[string]string{
+					MigrationEnvVar: "step1",
+				},
+			},
+		},
+	}
+
+	// Step1: Create the CloudFormation stack without making any DNS
+	// changes.
+	c.On("SubmitWithOptions", app, SubmitOptions{
+		NoDNS: true,
+	}).Return(nil)
+
+	err = s.Submit(context.Background(), app)
+	assert.NoError(t, err)
+
+	e.AssertExpectations(t)
+	c.AssertExpectations(t)
+
+	// Step2: Update the CloudFormation stack with the DNS changes, and
+	// remove the existing ECS resources.
+	app.Processes[0].Env[MigrationEnvVar] = "step2"
+
+	c.On("Submit", app).Return(nil)
+	e.On("RemoveWithOptions", app.ID, ecs.RemoveOptions{
+		NoDNS: true,
+	}).Return(nil)
+
+	err = s.Submit(context.Background(), app)
+	assert.NoError(t, err)
+
+	e.AssertExpectations(t)
+	c.AssertExpectations(t)
+
+	// Step3: Finalize the migration.
+	delete(app.Processes[0].Env, MigrationEnvVar)
+
+	c.On("Submit", app).Return(err)
+
+	err = s.Submit(context.Background(), app)
+	assert.NoError(t, err)
+
+	e.AssertExpectations(t)
+	c.AssertExpectations(t)
+}
+
+// It's not unlikely that the first couple of migrations will get rolled back,
+// because of Empire configuration issues (not having the correct permissions).
+//
+// To account for that, it should be possible to run step1 multiple times.
+func TestMigrationScheduler_Migrate_Rollback(t *testing.T) {
+	db := newDB(t)
+	defer db.Close()
+
+	e := new(mockECSScheduler)
+	c := new(mockCloudFormationScheduler)
+	s := &MigrationScheduler{
+		ecs:            e,
+		cloudformation: c,
+		db:             db,
+	}
+
+	_, err := db.Exec(`INSERT INTO scheduler_migration (app_id, backend) VALUES ('c9366591-ab68-4d49-a333-95ce5a23df68', 'ecs')`)
+	assert.NoError(t, err)
+
+	app := &scheduler.App{
+		ID: "c9366591-ab68-4d49-a333-95ce5a23df68",
+		Processes: []*scheduler.Process{
+			{
+				Type: "web",
+				Env: map[string]string{
+					MigrationEnvVar: "step1",
+				},
+			},
+		},
+	}
+
+	c.On("SubmitWithOptions", app, SubmitOptions{
+		NoDNS: true,
+	}).Return(nil).Twice()
+
+	err = s.Submit(context.Background(), app)
+	assert.NoError(t, err)
+
+	// Let's assume the the CloudFormation stack that was created got rolled
+	// back, so they manually delete the stack and try again.
+	err = s.Submit(context.Background(), app)
+	assert.NoError(t, err)
+
+	e.AssertExpectations(t)
+	c.AssertExpectations(t)
+}
+
+func TestMigrationScheduler_Migrate_InvalidStateTransitions(t *testing.T) {
+	db := newDB(t)
+	defer db.Close()
+
+	e := new(mockECSScheduler)
+	c := new(mockCloudFormationScheduler)
+	s := &MigrationScheduler{
+		ecs:            e,
+		cloudformation: c,
+		db:             db,
+	}
+
+	_, err := db.Exec(`INSERT INTO scheduler_migration (app_id, backend) VALUES ('c9366591-ab68-4d49-a333-95ce5a23df68', 'ecs')`)
+	assert.NoError(t, err)
+
+	app := &scheduler.App{
+		ID: "c9366591-ab68-4d49-a333-95ce5a23df68",
+		Processes: []*scheduler.Process{
+			{
+				Type: "web",
+				Env: map[string]string{
+					MigrationEnvVar: "step2",
+				},
+			},
+		},
+	}
+
+	err = s.Submit(context.Background(), app)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "error migrating app from ecs to step2: cannot transition from ecs to step2")
+
+	app.Processes[0].Env[MigrationEnvVar] = "step3"
+
+	err = s.Submit(context.Background(), app)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "error migrating app from ecs to step3: cannot transition to step3")
+
+	e.AssertExpectations(t)
+	c.AssertExpectations(t)
+}
+
+type mockScheduler struct {
+	scheduler.Scheduler
+	mock.Mock
+}
+
+func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
+	args := m.Called(app)
+	return args.Error(0)
+}
+
+type mockECSScheduler struct {
+	mockScheduler
+}
+
+func (m *mockECSScheduler) RemoveWithOptions(_ context.Context, appID string, opts ecs.RemoveOptions) error {
+	args := m.Called(appID, opts)
+	return args.Error(0)
+}
+
+type mockCloudFormationScheduler struct {
+	mockScheduler
+}
+
+func (m *mockCloudFormationScheduler) SubmitWithOptions(_ context.Context, app *scheduler.App, opts SubmitOptions) error {
+	args := m.Called(app, opts)
+	return args.Error(0)
+}

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -76,19 +76,8 @@ func TestEmpireTemplate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tmpl := &EmpireTemplate{
-			Cluster:                 "cluster",
-			ServiceRole:             "ecsServiceRole",
-			InternalSecurityGroupID: "sg-e7387381",
-			ExternalSecurityGroupID: "sg-1938737f",
-			InternalSubnetIDs:       []string{"subnet-bb01c4cd", "subnet-c85f4091"},
-			ExternalSubnetIDs:       []string{"subnet-ca96f4cd", "subnet-a13b909c"},
-			CustomResourcesTopic:    "sns topic arn",
-			HostedZone: &route53.HostedZone{
-				Id:   aws.String("Z3DG6IL3SJCGPX"),
-				Name: aws.String("empire"),
-			},
-		}
+		tmpl := newTemplate()
+		tmpl.NoCompress = true
 		buf := new(bytes.Buffer)
 
 		filename := fmt.Sprintf("templates/%s", tt.file)
@@ -100,5 +89,51 @@ func TestEmpireTemplate(t *testing.T) {
 
 		assert.Equal(t, string(expected), buf.String())
 		ioutil.WriteFile(filename, buf.Bytes(), 0660)
+	}
+}
+
+func TestEmpireTemplate_Large(t *testing.T) {
+	labels := make(map[string]string)
+	env := make(map[string]string)
+	for i := 0; i < 100; i++ {
+		env[fmt.Sprintf("ENV_VAR_%d", i)] = fmt.Sprintf("value%d", i)
+	}
+	app := &scheduler.App{
+		ID:   "",
+		Name: "bigappwithlotsofprocesses",
+	}
+
+	for i := 0; i < 60; i++ {
+		app.Processes = append(app.Processes, &scheduler.Process{
+			Type:    fmt.Sprintf("%d", i),
+			Command: []string{"./bin/web"},
+			Env:     env,
+			Labels:  labels,
+		})
+	}
+
+	tmpl := newTemplate()
+	buf := new(bytes.Buffer)
+
+	err := tmpl.Execute(buf, app)
+	assert.NoError(t, err)
+	assert.Condition(t, func() bool {
+		return buf.Len() < MaxTemplateSize
+	}, fmt.Sprintf("template must be smaller than %d, was %d", MaxTemplateSize, buf.Len()))
+}
+
+func newTemplate() *EmpireTemplate {
+	return &EmpireTemplate{
+		Cluster:                 "cluster",
+		ServiceRole:             "ecsServiceRole",
+		InternalSecurityGroupID: "sg-e7387381",
+		ExternalSecurityGroupID: "sg-1938737f",
+		InternalSubnetIDs:       []string{"subnet-bb01c4cd", "subnet-c85f4091"},
+		ExternalSubnetIDs:       []string{"subnet-ca96f4cd", "subnet-a13b909c"},
+		CustomResourcesTopic:    "sns topic arn",
+		HostedZone: &route53.HostedZone{
+			Id:   aws.String("Z3DG6IL3SJCGPX"),
+			Name: aws.String("empire"),
+		},
 	}
 }

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -1,6 +1,52 @@
 {
-  "Outputs": {},
+  "Conditions": {
+    "DNSCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "DNS"
+        },
+        "true"
+      ]
+    }
+  },
+  "Outputs": {
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Ref": "web"
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "worker",
+                  {
+                    "Ref": "worker"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
   "Parameters": {
+    "DNS": {
+      "Description": "When set to `true`, CNAME's will be altered",
+      "Type": "String"
+    },
     "webScale": {
       "Type": "String"
     },
@@ -10,12 +56,16 @@
   },
   "Resources": {
     "CNAME": {
+      "Condition": "DNSCondition",
       "Properties": {
         "HostedZoneId": "Z3DG6IL3SJCGPX",
         "Name": "acme-inc.empire",
         "ResourceRecords": [
           {
-            "Ref": "webLoadBalancer"
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
           }
         ],
         "TTL": 60,
@@ -24,9 +74,6 @@
       "Type": "AWS::Route53::RecordSet"
     },
     "web": {
-      "Metadata": {
-        "name": "web"
-      },
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {
@@ -138,9 +185,6 @@
       "Type": "AWS::ECS::TaskDefinition"
     },
     "worker": {
-      "Metadata": {
-        "name": "worker"
-      },
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -1,18 +1,57 @@
 {
-  "Outputs": {},
+  "Conditions": {
+    "DNSCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "DNS"
+        },
+        "true"
+      ]
+    }
+  },
+  "Outputs": {
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Ref": "web"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
   "Parameters": {
+    "DNS": {
+      "Description": "When set to `true`, CNAME's will be altered",
+      "Type": "String"
+    },
     "webScale": {
       "Type": "String"
     }
   },
   "Resources": {
     "CNAME": {
+      "Condition": "DNSCondition",
       "Properties": {
         "HostedZoneId": "Z3DG6IL3SJCGPX",
         "Name": "acme-inc.empire",
         "ResourceRecords": [
           {
-            "Ref": "webLoadBalancer"
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
           }
         ],
         "TTL": 60,
@@ -21,9 +60,6 @@
       "Type": "AWS::Route53::RecordSet"
     },
     "web": {
-      "Metadata": {
-        "name": "web"
-      },
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -29,6 +29,11 @@ const ContainerPort = 8080
 
 var DefaultDelimiter = "-"
 
+type lbManager interface {
+	lb.Manager
+	RemoveCNAMEs(context.Context, map[string]string) error
+}
+
 // Scheduler is an implementation of the ServiceManager interface that
 // is backed by Amazon ECS.
 type Scheduler struct {
@@ -36,7 +41,7 @@ type Scheduler struct {
 	serviceRole      string
 	ecs              *ecsutil.Client
 	logConfiguration *ecs.LogConfiguration
-	lb               lb.Manager
+	lb               lbManager
 }
 
 // Config holds configuration for generating a new ECS backed Scheduler
@@ -108,7 +113,7 @@ func NewLoadBalancedScheduler(db *sql.DB, config Config) (*Scheduler, error) {
 	return s, nil
 }
 
-func newLBManager(db *sql.DB, config Config) (lb.Manager, error) {
+func newLBManager(db *sql.DB, config Config) (lbManager, error) {
 	if err := validateLoadBalancedConfig(config); err != nil {
 		return nil, err
 	}
@@ -127,10 +132,9 @@ func newLBManager(db *sql.DB, config Config) (lb.Manager, error) {
 	n := lb.NewRoute53Nameserver(config.AWS)
 	n.ZoneID = config.ZoneID
 
-	lbm = lb.WithCNAME(lbm, n)
 	lbm = lb.WithLogging(lbm)
 
-	return lbm, nil
+	return lb.WithCNAME(lbm, n), nil
 }
 
 func validateLoadBalancedConfig(c Config) error {
@@ -161,6 +165,17 @@ func validateLoadBalancedConfig(c Config) error {
 	}
 
 	return nil
+}
+
+// This is purely used to migrate to the new CloudFormation scheduler. Simply
+// deletes the existing CNAME record for the app, so that the CloudFormation
+// stack can create it.
+func (m *Scheduler) RemoveCNAMEs(ctx context.Context, appID string) error {
+	tags := map[string]string{
+		"AppID": appID,
+	}
+
+	return m.lb.RemoveCNAMEs(ctx, tags)
 }
 
 // Submit will create an ECS service for each individual process in the App. New
@@ -195,6 +210,17 @@ func (m *Scheduler) Submit(ctx context.Context, app *scheduler.App) error {
 
 // Remove removes all of the AWS resources for this app.
 func (m *Scheduler) Remove(ctx context.Context, appID string) error {
+	return m.RemoveWithOptions(ctx, appID, RemoveOptions{})
+}
+
+// RemoveOptions are options that can be passed to RemoveWithOptions.
+type RemoveOptions struct {
+	// If set to true, DNS records will not be removed.
+	NoDNS bool
+}
+
+// RemoveWithOptions removes the application.
+func (m *Scheduler) RemoveWithOptions(ctx context.Context, appID string, opts RemoveOptions) error {
 	processes, err := m.Processes(ctx, appID)
 	if err != nil {
 		return err
@@ -206,7 +232,7 @@ func (m *Scheduler) Remove(ctx context.Context, appID string) error {
 		}
 	}
 
-	return m.removeLoadBalancers(ctx, appID)
+	return m.removeLoadBalancers(ctx, appID, opts.NoDNS)
 }
 
 // Instances returns all instances that are currently running, pending or
@@ -527,7 +553,7 @@ func (m *Scheduler) loadBalancer(ctx context.Context, app *scheduler.App, p *sch
 	return l, nil
 }
 
-func (m *Scheduler) removeLoadBalancers(ctx context.Context, app string) error {
+func (m *Scheduler) removeLoadBalancers(ctx context.Context, app string, noDNS bool) error {
 	tags := map[string]string{
 		"AppID": app,
 	}
@@ -537,9 +563,17 @@ func (m *Scheduler) removeLoadBalancers(ctx context.Context, app string) error {
 		return err
 	}
 
-	for _, lb := range lbs {
-		if err := m.lb.DestroyLoadBalancer(ctx, lb); err != nil {
-			return err
+	for _, l := range lbs {
+		if noDNS {
+			// Go around the CNAMEManager and destroy the load
+			// balancer directly.
+			if err := m.lb.(*lb.CNAMEManager).Manager.DestroyLoadBalancer(ctx, l); err != nil {
+				return err
+			}
+		} else {
+			if err := m.lb.DestroyLoadBalancer(ctx, l); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -663,6 +663,11 @@ func (m *mockLBManager) LoadBalancers(ctx context.Context, tags map[string]strin
 	return args.Get(0).([]*lb.LoadBalancer), args.Error(1)
 }
 
+func (m *mockLBManager) RemoveCNAMEs(ctx context.Context, tags map[string]string) error {
+	args := m.Called(tags)
+	return args.Error(0)
+}
+
 // fake app for testing.
 var fakeApp = &scheduler.App{
 	ID: "1234",


### PR DESCRIPTION
This is my initial thought on how we might migrate to the new CloudFormation based scheduler:

1. All existing apps will continue to use the old scheduler.
2. New apps will use the new scheduler.
3. When you want to migrate an app to the new scheduler, you set an environment variable.

**TODO**

* [x] Delete from `scheduler_migration` when destroyed.
* [x] Docs about upgrading Empire to the CloudFormation backend.
* [x] Add existing apps to scheduler_migration table.