### PR TITLE
Handle errors when trying to do an interactive emp run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * ECR authentication now supports multiple regions, and works independently of ECS region [#784](https://github.com/remind101/empire/pull/784)
 * Provisioned ELB's are only destroyed when the entire app is removed [#801](https://github.com/remind101/empire/pull/801)
 * Docker containers started by attached runs now have labels, cpu and memory constraints applied to them [#809](https://github.com/remind101/empire/pull/809)
+* Fixed a bug where interactive `emp run` would get stuck attempting to read bytes after an error from the initial request [#795](https://github.com/remind101/empire/issues/795)
 
 **Performance**
 

--- a/cmd/emp/run.go
+++ b/cmd/emp/run.go
@@ -149,7 +149,11 @@ func runRun(cmd *Command, args []string) {
 
 	clientconn := httputil.NewClientConn(dial, nil)
 	defer clientconn.Close()
-	_, err = clientconn.Do(req)
+	res, err := clientconn.Do(req)
+	defer res.Body.Close()
+	if err = heroku.CheckResp(res); err != nil {
+		printFatal(err.Error())
+	}
 	if err != nil && err != httputil.ErrPersistEOF {
 		printFatal(err.Error())
 	}

--- a/pkg/heroku/heroku.go
+++ b/pkg/heroku/heroku.go
@@ -224,7 +224,7 @@ func (c *Client) DoReq(req *http.Request, v interface{}) error {
 			os.Stderr.Write([]byte{'\n'})
 		}
 	}
-	if err = checkResp(res); err != nil {
+	if err = CheckResp(res); err != nil {
 		return err
 	}
 	switch t := v.(type) {
@@ -250,7 +250,7 @@ type errorResp struct {
 	URL     string `json:"url"`
 }
 
-func checkResp(res *http.Response) error {
+func CheckResp(res *http.Response) error {
 	if res.StatusCode/100 != 2 { // 200, 201, 202, etc
 		var e errorResp
 		err := json.NewDecoder(res.Body).Decode(&e)

--- a/pkg/heroku/heroku_test.go
+++ b/pkg/heroku/heroku_test.go
@@ -168,9 +168,9 @@ var respTests = []respTest{
 
 func TestCheckResp(t *testing.T) {
 	for i, rt := range respTests {
-		resp := checkResp(&rt.Response)
+		resp := CheckResp(&rt.Response)
 		if !reflect.DeepEqual(rt.Expected, resp) {
-			t.Errorf("checkResp respTests[%d] expected %v, got %v", i, rt.Expected, resp)
+			t.Errorf("CheckResp respTests[%d] expected %v, got %v", i, rt.Expected, resp)
 		}
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/remind101/empire/issues/795

The headers that come back from the request are:
```
map[Date:[Tue, 03 May 2016 21:04:53 GMT] Content-Length:[67] Content-Type:[text/plain; charset=utf-8]]
```

Since this is still a "heroku" request, it seemed fitting to just export the `CheckResp` method and call that here.