### PR TITLE
Add Custom::App CloudFormation resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * You can now specify the CPU and memory constraints for attached one-off tasks with the `-s` flag to `emp run` [#809](https://github.com/remind101/empire/pull/809)
 * You can now provide a duration to `emp log` with the `-d` flag to start streaming logs from a specific point in time ie (5m, 10m, 1h) [#829](https://github.com/remind101/empire/issues/829)
 * If log streaming is enabled, Empire will attempt to write events to the kinesis stream for the application [#832](https://github.com/remind101/empire/issues/832)
+* You can now provision Empire applications and set environment variables from CloudFormation stacks using a `Custom::App` resource [#819](https://github.com/remind101/empire/pull/819)
 
 **Bugs**
 

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -37,7 +37,7 @@ func runServer(c *cli.Context) {
 	}
 
 	if c.String(FlagCustomResourcesQueue) != "" {
-		p, err := newCloudFormationCustomResourceProvisioner(db, c)
+		p, err := newCloudFormationCustomResourceProvisioner(e, c)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -61,13 +61,13 @@ func newServer(c *cli.Context, e *empire.Empire) http.Handler {
 	return server.New(e, opts)
 }
 
-func newCloudFormationCustomResourceProvisioner(db *empire.DB, c *cli.Context) (*cloudformation.CustomResourceProvisioner, error) {
+func newCloudFormationCustomResourceProvisioner(e *empire.Empire, c *cli.Context) (*cloudformation.CustomResourceProvisioner, error) {
 	r, err := newReporter(c)
 	if err != nil {
 		return nil, err
 	}
 
-	p := cloudformation.NewCustomResourceProvisioner(db.DB.DB(), newConfigProvider(c))
+	p := cloudformation.NewCustomResourceProvisioner(e, newConfigProvider(c))
 	p.Logger = newLogger()
 	p.Reporter = r
 	p.QueueURL = c.String(FlagCustomResourcesQueue)

--- a/server/cloudformation/apps.go
+++ b/server/cloudformation/apps.go
@@ -1,0 +1,116 @@
+package cloudformation
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/remind101/empire"
+	"golang.org/x/net/context"
+)
+
+type AppsProvisioner struct {
+	empire *empire.Empire
+}
+
+func (p *AppsProvisioner) Provision(req Request) (id string, data interface{}, err error) {
+	ctx := context.Background()
+	user := &empire.User{Name: "cloudformation"}
+
+	switch req.RequestType {
+	case Create:
+		name := req.ResourceProperties["Name"].(string)
+		app, err := p.empire.AppsFind(empire.AppsQuery{
+			Name: &name,
+		})
+		if err != nil && err != gorm.RecordNotFound {
+			return "", nil, err
+		}
+
+		app, err = p.empire.Create(ctx, empire.CreateOpts{
+			User: user,
+			Name: name,
+		})
+		if err != nil {
+			return "", nil, err
+		}
+
+		if err := p.setEnvironment(ctx, user, app, req); err != nil {
+			return "", nil, err
+		}
+
+		return app.ID, map[string]string{"Id": app.ID}, nil
+	case Delete:
+		id := req.PhysicalResourceId
+		app, err := p.empire.AppsFind(empire.AppsQuery{
+			ID: &id,
+		})
+		if err != nil {
+			return id, nil, err
+		}
+
+		// TODO: Handle error
+		_ = p.empire.Destroy(ctx, empire.DestroyOpts{
+			User: user,
+			App:  app,
+		})
+
+		return id, nil, nil
+	case Update:
+		id := req.PhysicalResourceId
+
+		app, err := p.empire.AppsFind(empire.AppsQuery{
+			ID: &id,
+		})
+		if err != nil {
+			return id, nil, err
+		}
+
+		if err := p.setEnvironment(ctx, user, app, req); err != nil {
+			return id, nil, err
+		}
+
+		return id, map[string]string{"Id": app.ID}, nil
+	}
+
+	return
+}
+
+func (p *AppsProvisioner) setEnvironment(ctx context.Context, user *empire.User, app *empire.App, req Request) error {
+	vars := varsFromRequest(req)
+
+	_, err := p.empire.Set(ctx, empire.SetOpts{
+		User: user,
+		App:  app,
+		Vars: vars,
+	})
+
+	return err
+}
+
+func varsFromRequest(req Request) empire.Vars {
+	vars := make(empire.Vars)
+
+	if env, ok := req.ResourceProperties["Environment"].(map[string]interface{}); ok {
+		for k, v := range env {
+			var val *string
+			switch v := v.(type) {
+			case string:
+				vv := v
+				val = &vv
+			default:
+			}
+			vars[empire.Variable(k)] = val
+		}
+	}
+
+	if req.RequestType == Update {
+		if env, ok := req.OldResourceProperties["Environment"].(map[string]interface{}); ok {
+			// Find any environment variables that were removed.
+			for k := range env {
+				if _, ok := vars[empire.Variable(k)]; !ok {
+					vars[empire.Variable(k)] = nil
+				}
+			}
+		}
+	}
+
+	return vars
+}

--- a/server/cloudformation/apps_test.go
+++ b/server/cloudformation/apps_test.go
@@ -1,0 +1,36 @@
+package cloudformation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/remind101/empire"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVarsFromRequest(t *testing.T) {
+	var req Request
+	err := json.Unmarshal([]byte(`{"ResourceProperties": {"Environment": {"FOO": "bar", "BAR": null}}}`), &req)
+	assert.NoError(t, err)
+
+	bar := "bar"
+	vars := varsFromRequest(req)
+	assert.Equal(t, empire.Vars{
+		"FOO": &bar,
+		"BAR": nil,
+	}, vars)
+}
+
+func TestVarsFromRequest_DeletedVars(t *testing.T) {
+	var req Request
+	err := json.Unmarshal([]byte(`{"RequestType": "Update", "ResourceProperties": {"Environment": {"FOO": "bar", "BAR": null}}, "OldResourceProperties": {"Environment": {"FOOBAR": "foobar"}}}`), &req)
+	assert.NoError(t, err)
+
+	bar := "bar"
+	vars := varsFromRequest(req)
+	assert.Equal(t, empire.Vars{
+		"FOO":    &bar,
+		"BAR":    nil,
+		"FOOBAR": nil,
+	}, vars)
+}


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/810

This adds a `Custom::App` resource, so you can provision Empire applications, and set environment variables from CloudFormation stacks. This allows you to provision your entire infrastructure, including Empire apps, and link it all together.

Not quite ready, because I think there's some UX things to address first, but I'm pretty excited about what this enables.

**TODO**

* [ ] Environment variables set by CloudFormation probably shouldn't be editable (or visible) from `emp set`.
* [ ] Docs
* [ ] Can we use `Custom::Empire::App`?