### PR TITLE
Avoid DescribeStackResource call

### DIFF
--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -451,6 +451,17 @@ func TestScheduler_Scale_NoUpdates(t *testing.T) {
 	c.AssertExpectations(t)
 }
 
+func TestExtractServices(t *testing.T) {
+	output := "statuses=arn:aws:ecs:us-east-1:897883143566:service/stage-app-statuses-16NM105QFD6UO,statuses_retry=arn:aws:ecs:us-east-1:897883143566:service/stage-app-statusesretry-DKG2XMH75H5N"
+	services := extractServices(output)
+	expected := map[string]string{
+		"statuses":       "arn:aws:ecs:us-east-1:897883143566:service/stage-app-statuses-16NM105QFD6UO",
+		"statuses_retry": "arn:aws:ecs:us-east-1:897883143566:service/stage-app-statusesretry-DKG2XMH75H5N",
+	}
+
+	assert.Equal(t, expected, services)
+}
+
 func newDB(t testing.TB) *sql.DB {
 	db, err := sql.Open("postgres", "postgres://localhost/empire?sslmode=disable")
 	if err != nil {

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -250,22 +250,18 @@ func TestScheduler_Instances(t *testing.T) {
 	_, err := db.Exec(`INSERT INTO stacks (app_id, stack_name) VALUES ($1, $2)`, "c9366591-ab68-4d49-a333-95ce5a23df68", "acme-inc")
 	assert.NoError(t, err)
 
-	c.On("ListStackResourcesPages", &cloudformation.ListStackResourcesInput{
+	c.On("DescribeStacks", &cloudformation.DescribeStacksInput{
 		StackName: aws.String("acme-inc"),
-	}).Return(&cloudformation.ListStackResourcesOutput{
-		StackResourceSummaries: []*cloudformation.StackResourceSummary{
-			{ResourceType: aws.String("AWS::EC2::LoadBalancer")},
-			{ResourceType: aws.String("AWS::ECS::Service"), LogicalResourceId: aws.String("web")},
-		},
-	}, nil)
-
-	c.On("DescribeStackResource", &cloudformation.DescribeStackResourceInput{
-		LogicalResourceId: aws.String("web"),
-		StackName:         aws.String("acme-inc"),
-	}).Return(&cloudformation.DescribeStackResourceOutput{
-		StackResourceDetail: &cloudformation.StackResourceDetail{
-			Metadata:           aws.String(`{"name":"web"}`),
-			PhysicalResourceId: aws.String(`arn:aws:ecs:us-east-1:012345678910:service/acme-inc-web`),
+	}).Return(&cloudformation.DescribeStacksOutput{
+		Stacks: []*cloudformation.Stack{
+			{
+				Outputs: []*cloudformation.Output{
+					{
+						OutputKey:   aws.String("Services"),
+						OutputValue: aws.String("web=arn:aws:ecs:us-east-1:012345678910:service/acme-inc-web"),
+					},
+				},
+			},
 		},
 	}, nil)
 

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -9,7 +9,39 @@
       ]
     }
   },
-  "Outputs": {},
+  "Outputs": {
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Ref": "web"
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "worker",
+                  {
+                    "Ref": "worker"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
   "Parameters": {
     "DNS": {
       "Description": "When set to `true`, CNAME's will be altered",
@@ -42,9 +74,6 @@
       "Type": "AWS::Route53::RecordSet"
     },
     "web": {
-      "Metadata": {
-        "name": "web"
-      },
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {
@@ -156,9 +185,6 @@
       "Type": "AWS::ECS::TaskDefinition"
     },
     "worker": {
-      "Metadata": {
-        "name": "worker"
-      },
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -9,7 +9,28 @@
       ]
     }
   },
-  "Outputs": {},
+  "Outputs": {
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Ref": "web"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
   "Parameters": {
     "DNS": {
       "Description": "When set to `true`, CNAME's will be altered",
@@ -39,9 +60,6 @@
       "Type": "AWS::Route53::RecordSet"
     },
     "web": {
-      "Metadata": {
-        "name": "web"
-      },
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {


### PR DESCRIPTION
I discovered that for apps that have a lot of processes, you would almost always get throttled when calling DescribeStackResource (it's N+1 with the number processes). Previously, we used this call to map the process name, to the ARN of the ECS service.

To avoid hitting the rate limit, we can instead just use an output to do the mapping, which means better performance, and no rate limiting. The only downside is, you have to wait for the output to get populated before you can view the running tasks, but that's a minor annoyance.