### PR TITLE
Improvements to demo/dev CloudFormation stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ If you want to contribute to Empire, you may end up wanting to run a local insta
 4. Run the bootstrap script, which will create a cloudformation stack, ecs cluster and populate a .env file:
 
    ```console
-   $ DEMOMODE=0 ./bin/bootstrap
+   $ ./bin/bootstrap
    ```
 5. Run Empire with [docker-compose](https://docs.docker.com/compose/):
 
    ```console
+   $ docker-compose up db # Only need to do this the first time, so that the db can initialize.
    $ docker-compose up
    ```
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -2,14 +2,14 @@
 
 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
-echo '!! This script produces an insecure demo or dev environment and is   !!'
+echo '!! This script produces an insecure dev environment and is           !!'
 echo '!! not meant to be ran in production. As well it is exposed to the   !!'
 echo '!! internet and as such should not be left running without further   !!'
 echo '!! locking down of the security groups.                              !!'
 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
 echo '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
 
-read -p "Do you want to continue? (y/N)" SECCHECK
+read -p "Do you want to continue? (y/N) " SECCHECK
 
 SECCHECK=$(echo $SECCHECK | tr '[:upper:]' '[:lower:]')
 
@@ -21,10 +21,6 @@ fi
 
 set -e
 set -o pipefail
-
-# Set to anything other than 1 to skip launching Empire/Postgres as a service
-# in ECS (meant for development)
-DEMOMODE=${DEMOMODE:-true}
 
 # Check for dependent commands
 check_dep() {
@@ -73,7 +69,7 @@ DEFAULT_DOCKER_REGISTRY="https://index.docker.io/v1/"
 AWSCMD="aws cloudformation create-stack --stack-name "$STACK" --template-body file://$PWD/docs/cloudformation.json --capabilities CAPABILITY_IAM"
 
 
-PARAMETERS="ParameterKey=DesiredCapacity,ParameterValue=5 ParameterKey=MaxCapacity,ParameterValue=10 ParameterKey=AvailabilityZones,ParameterValue=\"$SAFEZONES\" ParameterKey=KeyName,ParameterValue=\"$keyname\" ParameterKey=LaunchEmpire,ParameterValue=$DEMOMODE"
+PARAMETERS="ParameterKey=DesiredCapacity,ParameterValue=5 ParameterKey=DesiredCapacity,ParameterValue=10 ParameterKey=AvailabilityZones,ParameterValue=\"$SAFEZONES\" ParameterKey=KeyName,ParameterValue=\"$keyname\" ParameterKey=LaunchEmpire,ParameterValue=false"
 
 if [ "$private_docker" == "Y" ]
 then
@@ -111,31 +107,23 @@ done
 echo
 echo "==> Stack $STACK complete."
 
-# Give additional info if in DEMOMODE
-if [ "$DEMOMODE" -eq 1 ]
-then
-  echo "==> Now run the following commands - when asked for a username, enter 'fake'. The password is blank:"
-  echo "$ export EMPIRE_API_URL=http://$(output ELBDNSName)/"
-  echo "$ emp login"
-else
-  if [ ! -e ~/.dockercfg ]; then
-    echo "==> ~/.dockercfg not found. Creating."
-    echo '{}' > ~/.dockercfg
-  fi
-
-  echo "==> Dumping stack info into .env for devmode."
-  echo "AWS_REGION=$AWS_DEFAULT_REGION" > .env
-  echo "AWS_ACCESS_KEY_ID=$(output AccessKeyId)" >> .env
-  echo "AWS_SECRET_ACCESS_KEY=$(output SecretAccessKey)" >> .env
-  echo "EMPIRE_S3_TEMPLATE_BUCKET=$(output TemplateBucket)" >> .env
-  echo "EMPIRE_ELB_VPC_ID=$(output VPC)" >> .env
-  echo "EMPIRE_ELB_SG_PRIVATE=$(output InternalELBSG)" >> .env
-  echo "EMPIRE_ELB_SG_PUBLIC=$(output ExternalELBSG)" >> .env
-  echo "EMPIRE_ECS_CLUSTER=$(output Cluster)" >> .env
-  echo "EMPIRE_ECS_SERVICE_ROLE=$(output ServiceRole)" >> .env
-  echo "EMPIRE_EC2_SUBNETS_PRIVATE=$(output Subnets)" >> .env
-  echo "EMPIRE_EC2_SUBNETS_PUBLIC=$(output Subnets)" >> .env
-  echo "EMPIRE_ROUTE53_INTERNAL_ZONE_ID=$(output InternalZoneID)" >> .env
-  echo "EMPIRE_CUSTOM_RESOURCES_TOPIC=$(output CustomResourcesTopic)" >> .env
-  echo "EMPIRE_CUSTOM_RESOURCES_QUEUE=$(output CustomResourcesQueue)" >> .env
+if [ ! -e ~/.dockercfg ]; then
+  echo "==> ~/.dockercfg not found. Creating."
+  echo '{}' > ~/.dockercfg
 fi
+
+echo "==> Dumping stack info into .env"
+echo "AWS_REGION=$AWS_DEFAULT_REGION" > .env
+echo "AWS_ACCESS_KEY_ID=$(output AccessKeyId)" >> .env
+echo "AWS_SECRET_ACCESS_KEY=$(output SecretAccessKey)" >> .env
+echo "EMPIRE_S3_TEMPLATE_BUCKET=$(output TemplateBucket)" >> .env
+echo "EMPIRE_ELB_VPC_ID=$(output VPC)" >> .env
+echo "EMPIRE_ELB_SG_PRIVATE=$(output InternalELBSG)" >> .env
+echo "EMPIRE_ELB_SG_PUBLIC=$(output ExternalELBSG)" >> .env
+echo "EMPIRE_ECS_CLUSTER=$(output Cluster)" >> .env
+echo "EMPIRE_ECS_SERVICE_ROLE=$(output ServiceRole)" >> .env
+echo "EMPIRE_EC2_SUBNETS_PRIVATE=$(output Subnets)" >> .env
+echo "EMPIRE_EC2_SUBNETS_PUBLIC=$(output Subnets)" >> .env
+echo "EMPIRE_ROUTE53_INTERNAL_ZONE_ID=$(output InternalZoneID)" >> .env
+echo "EMPIRE_CUSTOM_RESOURCES_TOPIC=$(output CustomResourcesTopic)" >> .env
+echo "EMPIRE_CUSTOM_RESOURCES_QUEUE=$(output CustomResourcesQueue)" >> .env

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -24,7 +24,7 @@ set -o pipefail
 
 # Set to anything other than 1 to skip launching Empire/Postgres as a service
 # in ECS (meant for development)
-DEMOMODE=${DEMOMODE:-1}
+DEMOMODE=${DEMOMODE:-true}
 
 # Check for dependent commands
 check_dep() {

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -292,7 +292,7 @@ var EmpireFlags = []cli.Flag{
 	},
 	cli.StringFlag{
 		Name:   FlagRunLogsBackend,
-		Value:  "",
+		Value:  "stdout",
 		Usage:  "The backend implementation to use to record the logs from interactive runs. Current supports `cloudwatch` and `stdout`",
 		EnvVar: "EMPIRE_RUN_LOGS_BACKEND",
 	},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 server:
   build: .
-  command: server -automigrate=true --messages.required
+  command: server -automigrate=true
   links:
-    - postgres:postgres
+    - db:db
   ports:
     - "8080:8080"
   volumes:
@@ -11,9 +11,9 @@ server:
   env_file: .env
   user: root
   environment:
-    EMPIRE_DATABASE_URL: postgres://postgres:postgres@postgres/postgres?sslmode=disable
+    EMPIRE_DATABASE_URL: postgres://postgres:postgres@db/postgres?sslmode=disable
     DOCKER_HOST: unix:///var/run/docker.sock
-postgres:
+db:
   image: postgres
   ports:
     - "5432:5432"

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -2,6 +2,48 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "Example ECS cluster for Empire",
 
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": { "default": "Empire" },
+          "Parameters": ["LaunchEmpire", "EmpireVersion", "EventsBackend", "RunLogsBackend"]
+        },
+        {
+          "Label": { "default": "GitHub Authentication" },
+          "Parameters": ["GitHubClientId", "GitHubClientSecret", "GitHubOrganization", "GitHubTeamId"]
+        },
+        {
+          "Label": { "default": "Docker" },
+          "Parameters": ["DockerUser", "DockerPass", "DockerEmail", "DockerRegistry"]
+        },
+        {
+          "Label": { "default": "Cluster" },
+          "Parameters": ["DesiredCapacity", "AmiId", "AvailabilityZones", "InstanceType", "KeyName"]
+        }
+      ],
+      "ParameterLabels": {
+        "KeyName": { "default": "Key name" },
+        "LaunchEmpire": { "default": "Launch" },
+        "EmpireVersion": { "default": "Version" },
+        "EventsBackend": { "default": "Send events to" },
+        "RunLogsBackend": { "default": "Send interactive run logs to" },
+        "GitHubClientId": { "default": "Client ID" },
+        "GitHubClientSecret": { "default": "Client Secret" },
+        "GitHubOrganization": { "default": "Organization" },
+        "GitHubTeamId": { "default": "Team ID" },
+        "DockerUser": { "default": "Username" },
+        "DockerPass": { "default": "Password" },
+        "DockerEmail": { "default": "Email" },
+        "DockerRegistry": { "default": "Registry" },
+        "DesiredCapacity": { "default": "Cluster size" },
+        "AmiId": { "default": "ECS optimized AMI id" },
+        "AvailabilityZones": { "default": "Availability zones" },
+        "InstanceType": { "default": "Instance type" }
+      }
+    }
+  },
+
   "Parameters": {
     "InstanceType": {
       "Type": "String",
@@ -12,56 +54,53 @@
     "EmpireVersion": {
       "Type": "String",
       "Default": "master",
-      "Description": "Docker tag to specify the version of Empire to run."
+      "Description": "Docker tag to specify the version of Empire to run. This can be any git branch or sha."
     },
     "AmiId" : {
       "Type": "AWS::EC2::Image::Id",
-      "Description": "AMI Id. Defaults to the official ECS Optimized Linux.",
+      "Description": "The AMI id of the AMI to run the instances with. This defaults to the official ECS ami.",
       "Default": "ami-67a3a90d"
     },
     "KeyName": {
-      "Type": "AWS::EC2::KeyPair::KeyName",
-      "Description": "The name of the key pair to use to allow SSH access."
+      "Type": "String",
+      "Description": "The name of the key pair to use if you want to allow SSH access to hosts."
     },
     "EventsBackend": {
       "Type": "String",
+      "AllowedValues": ["sns", "none"],
       "Description": "The backend to use to publish Empire events to. Set this to SNS to create an SNS topic and publish events there.",
       "Default": "sns"
     },
     "RunLogsBackend": {
       "Type": "String",
+      "AllowedValues": ["cloudwatch", "stdout"],
       "Description": "The backend used to store logs from interactive runs.",
       "Default": "cloudwatch"
     },
     "DockerRegistry": {
       "Type": "String",
-      "Description": "Docker private registry url",
+      "Description": "The URL of the Docker registry to pull private images from.",
       "Default": "https://index.docker.io/v1/"
     },
     "DockerUser": {
       "Type": "String",
-      "Description": "Docker username for private registry",
+      "Description": "Username of a Docker registry user to pull images from private repositories.",
       "Default": ""
     },
     "DockerPass": {
       "Type": "String",
-      "Description": "Docker password for private registry",
+      "Description": "Password of a Docker registry user to pull images from private repositories.",
       "Default": "",
       "NoEcho": true
     },
     "DockerEmail": {
       "Type": "String",
-      "Description": "Docker registry email",
+      "Description": "Email of a Docker registry user to pull images from private repositories.",
       "Default": ""
-    },
-    "MaxCapacity": {
-      "Type": "String",
-      "Description": "Maximum number of EC2 instances in the auto scaling group",
-      "Default": "5"
     },
     "DesiredCapacity": {
       "Type": "String",
-      "Description": "Desired number of EC2 instances in the auto scaling group",
+      "Description": "The number of EC2 instances to run in the ECS cluster.",
       "Default": "3"
     },
     "AvailabilityZones": {
@@ -70,14 +109,36 @@
       "Default": "us-east-1a,us-east-1b"
     },
     "LaunchEmpire": {
-      "Type": "Number",
-      "Default": "1",
-      "Description": "If 1, then launch Empire & Postgres as ECS tasks. If anything else, skip launching Empire (intended for dev use when Empire is ran locally)"
+      "Type": "String",
+      "Default": "true",
+      "AllowedValues": ["false", "true"],
+      "Description": "If true, then launch Empire & Postgres as ECS tasks. If anything else, skip launching Empire (intended for dev use when Empire is ran locally)."
+    },
+    "GitHubClientId": {
+      "Type": "String",
+      "Default": "",
+      "Description": "The oauth client id to use with the GitHub authentication backend."
+    },
+    "GitHubClientSecret": {
+      "Type": "String",
+      "Default": "",
+      "Description": "The oauth client secret to use with the GitHub authentication backend."
+    },
+    "GitHubOrganization": {
+      "Type": "String",
+      "Default": "",
+      "Description": "If set, this will ensure that all users are a member of this GitHub organization."
+    },
+    "GitHubTeamId": {
+      "Type": "String",
+      "Default": "",
+      "Description": "If set, this will ensure that all users are a member of this GitHub team."
     }
   },
 
   "Conditions": {
-    "DemoMode": {"Fn::Equals": [{"Ref": "LaunchEmpire"}, "1"]},
+    "HasKeyName": {"Fn::Not": [{"Fn::Equals": ["", { "Ref": "KeyName" }]}]},
+    "DemoMode": {"Fn::Equals": [{"Ref": "LaunchEmpire"}, "true"]},
     "DevMode": {"Fn::Not": [{"Condition": "DemoMode"}]},
     "SNSEvents": {"Fn::Equals": [{"Ref": "EventsBackend"}, "sns"]},
     "CloudWatchLogs": {"Fn::Equals": [{"Ref": "RunLogsBackend"}, "cloudwatch"]}
@@ -414,7 +475,7 @@
         "InstanceType": { "Ref": "InstanceType" },
         "AssociatePublicIpAddress": true,
         "IamInstanceProfile": { "Ref": "InstanceProfile" },
-        "KeyName": { "Ref": "KeyName" },
+        "KeyName": { "Fn::If": ["HasKeyName", { "Ref": "KeyName" }, { "Ref": "AWS::NoValue" }] },
         "SecurityGroups": [
           { "Ref": "InstanceSecurityGroup" }
         ],
@@ -442,7 +503,7 @@
         "VPCZoneIdentifier": [{ "Fn::Join" : [",", [ { "Ref" : "PubSubnetAz1" }, { "Ref" : "PubSubnetAz2" } ] ] }],
         "LaunchConfigurationName": { "Ref": "LaunchConfiguration" },
         "MinSize": "1",
-        "MaxSize": { "Ref": "MaxCapacity" },
+        "MaxSize": { "Ref": "DesiredCapacity" },
         "DesiredCapacity": { "Ref": "DesiredCapacity" },
         "Tags": [
           {
@@ -573,6 +634,22 @@
               {
                 "Name": "EMPIRE_CUSTOM_RESOURCES_QUEUE",
                 "Value": { "Ref": "CustomResourcesQueue" }
+              },
+              {
+                "Name": "EMPIRE_GITHUB_CLIENT_ID",
+                "Value": { "Ref": "GitHubClientId" }
+              },
+              {
+                "Name": "EMPIRE_GITHUB_CLIENT_SECRET",
+                "Value": { "Ref": "GitHubClientSecret" }
+              },
+              {
+                "Name": "EMPIRE_GITHUB_ORGANIZATION",
+                "Value": { "Ref": "GitHubOrganization" }
+              },
+              {
+                "Name": "EMPIRE_GITHUB_TEAM_ID",
+                "Value": { "Ref": "GitHubTeamId" }
               }
             ],
             "Command": ["server", "-automigrate=true"],
@@ -641,8 +718,7 @@
       "Type": "AWS::SNS::Topic",
       "Condition": "SNSEvents",
       "Properties": {
-        "DisplayName": "Empire Events",
-        "TopicName" : "events"
+        "DisplayName": "Empire Events"
       }
     },
 

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -112,7 +112,7 @@
       "Type": "String",
       "Default": "true",
       "AllowedValues": ["false", "true"],
-      "Description": "If true, then launch Empire & Postgres as ECS tasks. If anything else, skip launching Empire (intended for dev use when Empire is ran locally)."
+      "Description": "If true, then launch Empire & Postgres as ECS services. Note that this is NOT a production grade stack, this is only meant to serve as an easy way to try out Empire. If you want to take Empire into production, read the docs on Production Best Practices http://empire.readthedocs.io/en/latest/production_best_practices/."
     },
     "GitHubClientId": {
       "Type": "String",
@@ -357,10 +357,39 @@
       }
     },
 
-    "InstancePolicies": {
+    "ECSAgentPolicy": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyName": "ecs",
+        "Roles": [ { "Ref": "InstanceRole" } ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ecs:DeregisterContainerInstance",
+                "ecs:DiscoverPollEndpoint",
+                "ecs:Poll",
+                "ecs:RegisterContainerInstance",
+                "ecs:StartTelemetrySession",
+                "ecs:Submit*",
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage"
+              ],
+              "Resource": ["*"]
+            }
+          ]
+        }
+      }
+    },
+
+    "EmpirePolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "empire",
         "Roles": [ { "Ref": "InstanceRole" } ],
         "Users": [ { "Ref": "User" } ],
         "PolicyDocument": {
@@ -384,28 +413,102 @@
             {
               "Effect": "Allow",
               "Action": [
-                "cloudformation:*",
-                "s3:*",
-                "ec2:Describe*",
-                "elasticloadbalancing:*",
-                "ecs:*",
+                "sns:Publish"
+              ],
+              "Resource": { "Ref": "EventsTopic" }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:PutObjectVersionAcl",
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersionAcl"
+              ],
+              "Resource": { "Fn::Join": ["", ["arn:aws:s3:::", { "Ref": "TemplateBucket" }, "/*"]] }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "cloudformation:CreateStack",
+                "cloudformation:UpdateStack",
+                "cloudformation:DeleteStack",
+                "cloudformation:ListStackResources",
+                "cloudformation:DescribeStackResource",
+                "cloudformation:DescribeStacks"
+              ],
+              "Resource": ["*"]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ecs:CreateService",
+                "ecs:DeleteService",
+                "ecs:DeregisterTaskDefinition",
+                "ecs:Describe*",
+                "ecs:List*",
+                "ecs:RegisterTaskDefinition",
+                "ecs:RunTask",
+                "ecs:StartTask",
+                "ecs:StopTask",
+                "ecs:SubmitTaskStateChange",
+                "ecs:UpdateService"
+              ],
+              "Resource": ["*"]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:ConfigureHealthCheck",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetLoadBalancerListenerSSLCertificate",
+                "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
+              ],
+              "Resource": ["*"]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
                 "ecr:GetAuthorizationToken",
                 "ecr:BatchCheckLayerAvailability",
                 "ecr:GetDownloadUrlForLayer",
-                "ecr:BatchGetImage",
-                "iam:ListInstanceProfiles",
-                "iam:ListRoles",
-                "iam:PassRole",
-                "iam:UploadServerCertificate",
-                "iam:DeleteServerCertificate",
-                "route53:*",
-                "sns:*",
+                "ecr:BatchGetImage"
+              ],
+              "Resource": ["*"]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups"
+              ],
+              "Resource": ["*"]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "route53:ListHostedZonesByName",
+                "route53:ChangeResourceRecordSets",
+                "route53:ListHostedZones",
+                "route53:GetHostedZone",
+                "route53:GetChange"
+              ],
+              "Resource": { "Fn::Join": ["", ["arn:aws:route53:::hostedzone/", { "Ref": "InternalDomain" }]] }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents"
               ],
-              "Resource": [
-                "*"
-              ]
+              "Resource": { "Fn::Join": ["", ["arn:aws:logs:*:*:log-group:", { "Ref": "LogGroup" }, ":log-stream:*"]] }
             }
           ]
         }

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -23,9 +23,9 @@
         }
       ],
       "ParameterLabels": {
-        "KeyName": { "default": "Key name" },
+        "KeyName": { "default": "SSH key name" },
         "LaunchEmpire": { "default": "Launch" },
-        "EmpireVersion": { "default": "Version" },
+        "EmpireVersion": { "default": "Daemon version" },
         "EventsBackend": { "default": "Send events to" },
         "RunLogsBackend": { "default": "Send interactive run logs to" },
         "GitHubClientId": { "default": "Client ID" },

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -352,6 +352,7 @@
 
     "TemplateBucket": {
       "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Delete",
       "Properties": {
         "AccessControl": "Private"
       }
@@ -395,6 +396,13 @@
         "PolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "iam:PassRole"
+              ],
+              "Resource": { "Fn::GetAtt": ["ServiceRole", "Arn"] }
+            },
             {
               "Effect": "Allow",
               "Action": [
@@ -497,10 +505,16 @@
                 "route53:ListHostedZonesByName",
                 "route53:ChangeResourceRecordSets",
                 "route53:ListHostedZones",
-                "route53:GetHostedZone",
-                "route53:GetChange"
+                "route53:GetHostedZone"
               ],
               "Resource": { "Fn::Join": ["", ["arn:aws:route53:::hostedzone/", { "Ref": "InternalDomain" }]] }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "route53:GetChange*"
+              ],
+              "Resource": "arn:aws:route53:::change/*"
             },
             {
               "Effect": "Allow",

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -391,7 +391,7 @@
       "Properties": {
         "PolicyName": "empire",
         "Roles": [ { "Ref": "InstanceRole" } ],
-        "Users": [ { "Ref": "User" } ],
+        "Groups": [ { "Ref": "Group" } ],
         "PolicyDocument": {
           "Version": "2012-10-17",
           "Statement": [
@@ -618,9 +618,15 @@
       }
     },
 
+    "Group": {
+      "Type": "AWS::IAM::Group"
+    },
+
     "User": {
       "Type": "AWS::IAM::User",
-      "Properties": { }
+      "Properties": {
+        "Groups": [ { "Ref": "Group" } ]
+      }
     },
 
     "AccessKey": {

--- a/docs/quickstart_installing.md
+++ b/docs/quickstart_installing.md
@@ -9,14 +9,6 @@ production environments.
 
 This guide assumes that you have the following installed:
 
-* **AWS CLI**: You can find the instructions at
-  [http://aws.amazon.com/cli/][awscli]. You'll need a fairly recent version of the
-  CLI that has support for ECS.
-
-```console
-$ pip install --upgrade awscli
-```
-
 * **Amazon EC2 Key Pair**: Make sure you've created an Amazon EC2 Key Pair. See
   [creating or importing a keypair][keypair] for more information.
 
@@ -37,32 +29,9 @@ group that our CloudFormation stack creates.
 Also, check that the offical ECS AMI ID for US East matches with the one in
 [cloudformation.json][democloud].
 
-## Step 2 - Clone the empire repo
+## Step 2 - Create CloudFormation stack
 
-In order to run the script and cloudformation template for this guide, you'll
-need to clone this repository.
-
-```console
-$ git clone https://github.com/remind101/empire.git
-$ cd empire
-```
-
-## Step 3 - Create CloudFormation stack
-
-Create a new CloudFormation stack using the [bootstrap](../bin/bootstrap)
-script.
-
-```console
-$ ./bin/bootstrap
-AWS SSH KeyName: default
-Do you have a docker account & want to use it for private repo access? [y/N] n
-==> Launching empire in AZs: us-east-1a us-east-1b, Cloudformation Stack empire-1a96c6f3
-==> Waiting for stack to complete
-==> Status: CREATE_IN_PROGRESS
-==> Stack empire-1a96c6f3 complete. Now run the following commands - when asked for a username, enter 'fake'. The password is blank:
-$ export EMPIRE_API_URL=http://empire-1a-LoadBala-EC3V01X8GHOO-1318261069.us-east-1.elb.amazonaws.com/
-$ emp login
-```
+[![Install](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#cstack=sn%7Eempire%7Cturl%7Ehttps://s3.amazonaws.com/empirepaas/cloudformation.json)
 
 This is a very simple stack that will:
 
@@ -75,7 +44,7 @@ This is a very simple stack that will:
 * Configure the instances to be able to pull from a private registry. (If
   docker credentials were provided).
 
-## Step 4 - Get the emp client
+## Step 3 - Get the emp client
 
 The last thing you need to do is download the Empire client, **emp**. Refer to the [README][empclient] for instructions on how to install it.
 

--- a/docs/quickstart_using.md
+++ b/docs/quickstart_using.md
@@ -3,6 +3,7 @@
 Going forward from the [installing](quickstart_installing.md) guide, the first thing we'll need to do is tell the empire client where it can find the empire API. The *bootstrap* command should have printed that out for you, so make sure you've set it in your environment like so:
 
 ```
+$ # This value is obtained from the ELBDNSName stack output from the CloudFormation stack you created.
 $ export EMPIRE_API_URL=http://empire-60-LoadBala-1M8NAQ24SPGMP-770037928.us-east-1.elb.amazonaws.com/
 ```
 
@@ -31,7 +32,7 @@ $ emp apps
 Good - we haven't deployed any apps, so we shouldn't see any. Lets deploy our first app - the [acme-inc](https://github.com/remind101/acme-inc) app. It's a simple app that was written by Remind for simple testing of Empire. It has two 'processes' in the [Procfile](https://github.com/remind101/acme-inc/blob/master/Procfile) - a web and worker process.
 
 ```console
-$ emp deploy remind101/acme-inc:latest
+$ emp deploy remind101/acme-inc:master
 Pulling repository remind101/acme-inc
 345c7524bc96: Download complete
 a1dd7097a8e8: Download complete
@@ -40,11 +41,11 @@ a1dd7097a8e8: Download complete
 c7388ff7ab91: Download complete
 78fb106ed050: Download complete
 133fcef559c4: Download complete
-Status: Downloaded newer image for remind101/acme-inc:latest
+Status: Downloaded newer image for remind101/acme-inc:master
 Status: Created new release v1 for acme-inc
 ```
 
-So what just happened? We just told the Empire API to go out and get the 'latest' tagged image from the remind101/acme-inc repository. The Empire daemon then pulled that image down from [hub.docker.com](http://hub.docker.com/), then extracted the *Procfile* from it to analyze what processes were available. Now lets see what apps we're running:
+So what just happened? We just told the Empire API to go out and get the 'master' tagged image from the remind101/acme-inc repository. The Empire daemon then pulled that image down from [hub.docker.com](http://hub.docker.com/), then extracted the *Procfile* from it to analyze what processes were available. Now lets see what apps we're running:
 
 ```console
 $ emp apps
@@ -68,7 +69,7 @@ Next lets take a look at this release and see what we can find out about it. Fir
 
 ```console
 $ emp releases -a acme-inc
-v1    Jun 15 20:42  Deploy remind101/acme-inc:latest
+v1    Jun 15 20:42  Deploy remind101/acme-inc:master
 ```
 
 As you can see we only have a single release, the initial release that was created when we deployed the app.
@@ -98,7 +99,7 @@ As well we should see a new release created for acme-inc:
 
 ```console
 $ emp releases -a acme-inc
-v1    Jun 15 20:42  Deploy remind101/acme-inc:latest
+v1    Jun 15 20:42  Deploy remind101/acme-inc:master
 v2    Jun 15 20:44  Set BAT,FOO config vars
 ```
 
@@ -128,7 +129,7 @@ Rollback creates a new release that copies all the environment variables, as wel
 
 ```console
 $ emp releases -a acme-inc
-v1    Jun 15 20:42  Deploy remind101/acme-inc:latest
+v1    Jun 15 20:42  Deploy remind101/acme-inc:master
 v2    Jun 15 20:44  Set BAT,FOO config vars
 v3    Jun 15 20:45  Rollback to v1
 ```


### PR DESCRIPTION
https://github.com/remind101/empire/issues/820 brought up some good pain points. While I wasn't able to find any functional issue with the current CloudFormation stack, there's definitely some improvements that can be made.

1. This now groups and re-labels the parameters when creating a new stack in the CloudFormation ui to make things that are related, more clear: ![](https://dl.dropboxusercontent.com/u/1906634/GitHub/empire-stack.png)
2. I added parameters for enabling GitHub authentication.
3. It's no longer required to provide a KeyName parameter, which means you can click through the entire stack creation without changing anything. This used to be annoying if you don't select a KeyName, because the stack would rollback.
4. Changes the quickstart install docs to use the CloudFormation UI, instead of cloning and running `./bin/bootstrap`. `./bin/bootstrap` is mostly meant for devs working on Empire, so it's usually easier to just clickthrough cloudformation if you just want to try it.
5. The IAM permissions that Empire needs are now explicitly defined, which people can use as a reference when productionizing Empire.