### PR TITLE
Store user and commit message with release description

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -145,7 +145,7 @@ func (s *configsService) Set(ctx context.Context, db *gorm.DB, opts SetOpts) (*C
 		App:         release.App,
 		Config:      c,
 		Slug:        release.Slug,
-		Description: configsApplyReleaseDesc(vars),
+		Description: configsApplyReleaseDesc(opts),
 	})
 	return c, err
 }
@@ -200,7 +200,8 @@ func mergeVars(old, new Vars) Vars {
 
 // configsApplyReleaseDesc formats a release description based on the config variables
 // being applied.
-func configsApplyReleaseDesc(vars Vars) string {
+func configsApplyReleaseDesc(opts SetOpts) string {
+	vars := opts.Vars
 	verb := "Set"
 	plural := ""
 	if len(vars) > 1 {
@@ -215,5 +216,6 @@ func configsApplyReleaseDesc(vars Vars) string {
 		}
 	}
 	keys.Sort()
-	return fmt.Sprintf("%s %s config var%s", verb, strings.Join(keys, ", "), plural)
+	desc := fmt.Sprintf("%s %s config var%s", verb, strings.Join(keys, ", "), plural)
+	return appendMessageToDescription(desc, opts.User, opts.Message)
 }

--- a/configs_test.go
+++ b/configs_test.go
@@ -82,24 +82,38 @@ func TestReleaseDesc(t *testing.T) {
 	configVal := "test"
 
 	tests := []struct {
-		in  Vars
+		in  SetOpts
 		out string
 	}{
 		{
-			Vars{"FOO": &configVal},
-			"Set FOO config var",
+			SetOpts{
+				User: &User{Name: "fake"},
+				Vars: Vars{"FOO": &configVal},
+			},
+			"Set FOO config var (fake)",
 		},
 		{
-			Vars{"FOO": &configVal, "BAR": &configVal},
-			"Set BAR, FOO config vars",
+			SetOpts{
+				User:    &User{Name: "fake"},
+				Vars:    Vars{"FOO": &configVal, "BAR": &configVal},
+				Message: "important things",
+			},
+			"Set BAR, FOO config vars (fake: 'important things')",
 		},
 		{
-			Vars{"FOO": nil},
-			"Unset FOO config var",
+			SetOpts{
+				User: &User{Name: "fake"},
+				Vars: Vars{"FOO": nil},
+			},
+			"Unset FOO config var (fake)",
 		},
 		{
-			Vars{"FOO": nil, "BAR": nil},
-			"Unset BAR, FOO config vars",
+			SetOpts{
+				User:    &User{Name: "fake"},
+				Vars:    Vars{"FOO": nil, "BAR": nil},
+				Message: "important things",
+			},
+			"Unset BAR, FOO config vars (fake: 'important things')",
 		},
 	}
 

--- a/deployments.go
+++ b/deployments.go
@@ -50,6 +50,7 @@ func (s *deployerService) deploy(ctx context.Context, db *gorm.DB, opts Deployme
 	// Create a new release for the Config
 	// and Slug.
 	desc := fmt.Sprintf("Deploy %s", img.String())
+	desc = appendMessageToDescription(desc, opts.User, opts.Message)
 
 	r, err := s.releases.Create(ctx, db, &Release{
 		App:         app,

--- a/releases.go
+++ b/releases.go
@@ -330,9 +330,9 @@ func processExposure(app *App, process string) *scheduler.Exposure {
 }
 
 func appendMessageToDescription(main string, user *User, message string) string {
-	formatted := message
-	if formatted != "" {
-		formatted = fmt.Sprintf(": '%s'", formatted)
+	var formatted string
+	if message != "" {
+		formatted = fmt.Sprintf(": '%s'", message)
 	}
 	return fmt.Sprintf("%s (%s%s)", main, user.Name, formatted)
 }

--- a/releases.go
+++ b/releases.go
@@ -123,6 +123,7 @@ func (s *releasesService) Rollback(ctx context.Context, db *gorm.DB, opts Rollba
 	}
 
 	desc := fmt.Sprintf("Rollback to v%d", version)
+	desc = appendMessageToDescription(desc, opts.User, opts.Message)
 	return s.Create(ctx, db, &Release{
 		App:         app,
 		Config:      r.Config,
@@ -326,4 +327,12 @@ func processExposure(app *App, process string) *scheduler.Exposure {
 	}
 
 	return exposure
+}
+
+func appendMessageToDescription(main string, user *User, message string) string {
+	formatted := message
+	if formatted != "" {
+		formatted = fmt.Sprintf(": '%s'", formatted)
+	}
+	return fmt.Sprintf("%s (%s%s)", main, user.Name, formatted)
 }

--- a/tests/cli/deploy_test.go
+++ b/tests/cli/deploy_test.go
@@ -16,10 +16,10 @@ Status: Created new release v1 for acme-inc`,
 		},
 		{
 			"releases -a acme-inc",
-			"v1    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"v1    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2 (fake)",
 		},
 		{
-			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2 -m important",
 			`Pulling repository remind101/acme-inc
 345c7524bc96: Pulling image (9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2) from remind101/acme-inc
 345c7524bc96: Pulling image (9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2) from remind101/acme-inc, endpoint: https://registry-1.docker.io/v1/
@@ -30,7 +30,7 @@ Status: Created new release v2 for acme-inc`,
 		},
 		{
 			"releases -a acme-inc",
-			"v1    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2\nv2    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"v1    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2 (fake)\nv2    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2 (fake: 'important')",
 		},
 		{
 			"create my-app",
@@ -48,7 +48,7 @@ Status: Created new release v1 for my-app`,
 		},
 		{
 			"releases -a my-app",
-			"v1    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2",
+			"v1    Dec 31  2014  Deploy remind101/acme-inc:9ea71ea5abe676f117b2c969a6ea3c1be8ed4098d2118b1fd9ea5a5e59aa24f2 (fake)",
 		},
 	})
 }
@@ -67,7 +67,7 @@ Status: Created new release v1 for acme-inc`,
 		},
 		{
 			"releases -a acme-inc",
-			"v1    Dec 31  2014  Deploy remind101/acme-inc:latest",
+			"v1    Dec 31  2014  Deploy remind101/acme-inc:latest (fake)",
 		},
 	})
 }

--- a/tests/cli/rollback_test.go
+++ b/tests/cli/rollback_test.go
@@ -16,10 +16,10 @@ func TestRollback(t *testing.T) {
 		},
 		{
 			"releases -a acme-inc",
-			`v1    Dec 31  2014  Deploy remind101/acme-inc:latest
-v2    Dec 31  2014  Deploy remind101/acme-inc:latest
-v3    Dec 31  2014  Set FOO config var
-v4    Dec 31  2014  Rollback to v1`,
+			`v1    Dec 31  2014  Deploy remind101/acme-inc:latest (fake)
+v2    Dec 31  2014  Deploy remind101/acme-inc:latest (fake)
+v3    Dec 31  2014  Set FOO config var (fake)
+v4    Dec 31  2014  Rollback to v1 (fake)`,
 		},
 		{
 			"env -a acme-inc",


### PR DESCRIPTION
Fixes: https://github.com/remind101/empire/issues/822

Sample output:
```
$ ./build/emp releases -a acme-inc
v1    May 10 11:59  Deploy remind101/acme-inc:master (fake)
v2    May 10 14:26  Set ELSE, TEST config vars (fake: 'important commit message')
v3    May 10 14:29  Set TEST config var (fake: 'other thing')
v4    May 10 14:35  Rollback to v2 (fake: 'bad variable')
v5    May 10 14:41  Deploy remind101/acme-inc:master (fake: 'deploying new version')
```