### PR TITLE
Fix HTTPS listener in CloudFormation backend.

### DIFF
--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -191,8 +191,8 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 
 			if e, ok := p.Exposure.Type.(*scheduler.HTTPSExposure); ok {
 				listeners = append(listeners, map[string]interface{}{
-					"LoadBalancerPort": 80,
-					"Protocol":         "http",
+					"LoadBalancerPort": 443,
+					"Protocol":         "https",
 					"InstancePort": map[string][]string{
 						"Fn::GetAtt": []string{
 							instancePort,

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -115,8 +115,8 @@
               ]
             },
             "InstanceProtocol": "http",
-            "LoadBalancerPort": 80,
-            "Protocol": "http",
+            "LoadBalancerPort": 443,
+            "Protocol": "https",
             "SSLCertificateId": "iamcert"
           }
         ],


### PR DESCRIPTION
When adding the HTTPS listener, we want to actually use https. Doh!