### PR TITLE
Simplify cert attaching.

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -477,6 +477,8 @@
                 "elasticloadbalancing:ConfigureHealthCheck",
                 "elasticloadbalancing:ModifyLoadBalancerAttributes",
                 "elasticloadbalancing:SetLoadBalancerListenerSSLCertificate",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
+                "elasticloadbalancing:DeleteLoadBalancerListeners",
                 "elasticloadbalancing:SetLoadBalancerPoliciesOfListener"
               ],
               "Resource": ["*"]

--- a/docs/ssl_certs.md
+++ b/docs/ssl_certs.md
@@ -11,5 +11,5 @@ $ aws iam upload-server-certificate --server-certificate-name myServerCertificat
 Then attach it to the application:
 
 ```console
-$ emp certs-attach arn:aws:iam::<accountId>:server-certificate/myServerCertificate -a <app>
+$ emp certs-attach myServerCertificate -a <app>
 ```

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -66,7 +66,16 @@ func TestEmpireTemplate(t *testing.T) {
 						Command: []string{"./bin/web"},
 						Exposure: &scheduler.Exposure{
 							Type: &scheduler.HTTPSExposure{
-								Cert: "iamcert",
+								Cert: "arn:aws:iam::012345678901:server-certificate/AcmeIncDotCom",
+							},
+						},
+					},
+					{
+						Type:    "api",
+						Command: []string{"./bin/api"},
+						Exposure: &scheduler.Exposure{
+							Type: &scheduler.HTTPSExposure{
+								Cert: "AcmeIncDotCom", // Simple cert format.
 							},
 						},
 					},

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -25,6 +25,17 @@
                   }
                 ]
               ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "api",
+                  {
+                    "Ref": "api"
+                  }
+                ]
+              ]
             }
           ]
         ]
@@ -34,6 +45,9 @@
   "Parameters": {
     "DNS": {
       "Description": "When set to `true`, CNAME's will be altered",
+      "Type": "String"
+    },
+    "apiScale": {
       "Type": "String"
     },
     "webScale": {
@@ -58,6 +72,133 @@
         "Type": "CNAME"
       },
       "Type": "AWS::Route53::RecordSet"
+    },
+    "api": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "apiScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "api",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "apiLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "TaskDefinition": {
+          "Ref": "apiTaskDefinition"
+        }
+      },
+      "Type": "AWS::ECS::Service"
+    },
+    "api8080InstancePort": {
+      "Properties": {
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::InstancePort",
+      "Version": "1.0"
+    },
+    "apiLoadBalancer": {
+      "Properties": {
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 30
+        },
+        "CrossZone": true,
+        "Listeners": [
+          {
+            "InstancePort": {
+              "Fn::GetAtt": [
+                "api8080InstancePort",
+                "InstancePort"
+              ]
+            },
+            "InstanceProtocol": "http",
+            "LoadBalancerPort": 80,
+            "Protocol": "http"
+          },
+          {
+            "InstancePort": {
+              "Fn::GetAtt": [
+                "api8080InstancePort",
+                "InstancePort"
+              ]
+            },
+            "InstanceProtocol": "http",
+            "LoadBalancerPort": 443,
+            "Protocol": "https",
+            "SSLCertificateId": {
+              "Fn::Join": [
+                "",
+                [
+                  "arn:aws:iam::",
+                  {
+                    "Ref": "AWS::AccountId"
+                  },
+                  ":server-certificate/",
+                  "AcmeIncDotCom"
+                ]
+              ]
+            }
+          }
+        ],
+        "Scheme": "internal",
+        "SecurityGroups": [
+          "sg-e7387381"
+        ],
+        "Subnets": [
+          "subnet-bb01c4cd",
+          "subnet-c85f4091"
+        ],
+        "Tags": [
+          {
+            "Key": "empire.app.process",
+            "Value": "api"
+          }
+        ]
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+    },
+    "apiTaskDefinition": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/api"
+            ],
+            "Cpu": 0,
+            "DockerLabels": {},
+            "Environment": [
+              {
+                "Name": "PORT",
+                "Value": "8080"
+              }
+            ],
+            "Essential": true,
+            "Image": "",
+            "Memory": 0,
+            "Name": "api",
+            "PortMappings": [
+              {
+                "ContainerPort": 8080,
+                "HostPort": {
+                  "Fn::GetAtt": [
+                    "api8080InstancePort",
+                    "InstancePort"
+                  ]
+                }
+              }
+            ],
+            "Ulimits": []
+          }
+        ],
+        "Volumes": []
+      },
+      "Type": "AWS::ECS::TaskDefinition"
     },
     "web": {
       "Properties": {
@@ -117,7 +258,7 @@
             "InstanceProtocol": "http",
             "LoadBalancerPort": 443,
             "Protocol": "https",
-            "SSLCertificateId": "iamcert"
+            "SSLCertificateId": "arn:aws:iam::012345678901:server-certificate/AcmeIncDotCom"
           }
         ],
         "Scheme": "internal",


### PR DESCRIPTION
This just simplifies attaching SSL certs, so that you can provide just the name instead of the full cert ARN.