### PR TITLE
Set explicit deadlines on operations

### DIFF
--- a/empire.go
+++ b/empire.go
@@ -26,6 +26,14 @@ var (
 	DefaultReporter = reporter.NewLogReporter()
 )
 
+// Timeouts for certain API actions.
+var (
+	TimeoutDeploy      = 20 * time.Minute
+	TimeoutSet         = 30 * time.Second
+	TimeoutRollback    = 30 * time.Second
+	TimeoutCertsAttach = 30 * time.Second
+)
+
 const (
 	// WebPort is the default PORT to set on web processes.
 	WebPort = 8080
@@ -273,6 +281,9 @@ func (opts SetOpts) Validate(e *Empire) error {
 // Config. If the app has a running release, a new release will be created and
 // run.
 func (e *Empire) Set(ctx context.Context, opts SetOpts) (*Config, error) {
+	ctx, cancel := context.WithTimeout(ctx, TimeoutSet)
+	defer cancel()
+
 	if err := opts.Validate(e); err != nil {
 		return nil, err
 	}
@@ -511,6 +522,9 @@ func (opts RollbackOpts) Validate(e *Empire) error {
 // Rollback rolls an app back to a specific release version. Returns a
 // new release.
 func (e *Empire) Rollback(ctx context.Context, opts RollbackOpts) (*Release, error) {
+	ctx, cancel := context.WithTimeout(ctx, TimeoutRollback)
+	defer cancel()
+
 	if err := opts.Validate(e); err != nil {
 		return nil, err
 	}
@@ -573,6 +587,9 @@ func (opts DeploymentsCreateOpts) Validate(e *Empire) error {
 
 // Deploy deploys an image and streams the output to w.
 func (e *Empire) Deploy(ctx context.Context, opts DeploymentsCreateOpts) (*Release, error) {
+	ctx, cancel := context.WithTimeout(ctx, TimeoutDeploy)
+	defer cancel()
+
 	if err := opts.Validate(e); err != nil {
 		return nil, err
 	}
@@ -671,6 +688,9 @@ func (e *Empire) StreamLogs(app *App, w io.Writer, duration time.Duration) error
 
 // CertsAttach attaches an SSL certificate to the app.
 func (e *Empire) CertsAttach(ctx context.Context, app *App, cert string) error {
+	ctx, cancel := context.WithTimeout(ctx, TimeoutCertsAttach)
+	defer cancel()
+
 	tx := e.db.Begin()
 
 	if err := e.certs.CertsAttach(ctx, tx, app, cert); err != nil {

--- a/empire.go
+++ b/empire.go
@@ -26,14 +26,6 @@ var (
 	DefaultReporter = reporter.NewLogReporter()
 )
 
-// Timeouts for certain API actions.
-var (
-	TimeoutDeploy      = 20 * time.Minute
-	TimeoutSet         = 30 * time.Second
-	TimeoutRollback    = 30 * time.Second
-	TimeoutCertsAttach = 30 * time.Second
-)
-
 const (
 	// WebPort is the default PORT to set on web processes.
 	WebPort = 8080
@@ -281,9 +273,6 @@ func (opts SetOpts) Validate(e *Empire) error {
 // Config. If the app has a running release, a new release will be created and
 // run.
 func (e *Empire) Set(ctx context.Context, opts SetOpts) (*Config, error) {
-	ctx, cancel := context.WithTimeout(ctx, TimeoutSet)
-	defer cancel()
-
 	if err := opts.Validate(e); err != nil {
 		return nil, err
 	}
@@ -522,9 +511,6 @@ func (opts RollbackOpts) Validate(e *Empire) error {
 // Rollback rolls an app back to a specific release version. Returns a
 // new release.
 func (e *Empire) Rollback(ctx context.Context, opts RollbackOpts) (*Release, error) {
-	ctx, cancel := context.WithTimeout(ctx, TimeoutRollback)
-	defer cancel()
-
 	if err := opts.Validate(e); err != nil {
 		return nil, err
 	}
@@ -587,9 +573,6 @@ func (opts DeploymentsCreateOpts) Validate(e *Empire) error {
 
 // Deploy deploys an image and streams the output to w.
 func (e *Empire) Deploy(ctx context.Context, opts DeploymentsCreateOpts) (*Release, error) {
-	ctx, cancel := context.WithTimeout(ctx, TimeoutDeploy)
-	defer cancel()
-
 	if err := opts.Validate(e); err != nil {
 		return nil, err
 	}
@@ -688,9 +671,6 @@ func (e *Empire) StreamLogs(app *App, w io.Writer, duration time.Duration) error
 
 // CertsAttach attaches an SSL certificate to the app.
 func (e *Empire) CertsAttach(ctx context.Context, app *App, cert string) error {
-	ctx, cancel := context.WithTimeout(ctx, TimeoutCertsAttach)
-	defer cancel()
-
 	tx := e.db.Begin()
 
 	if err := e.certs.CertsAttach(ctx, tx, app, cert); err != nil {

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -223,7 +223,7 @@ func TestScheduler_Submit_StackUpdateInProgress_Cancel(t *testing.T) {
 		Name: "acme-inc",
 	})
 	assert.Error(t, err)
-	assert.EqualError(t, err, "error waiting for stack to stabilize: context canceled")
+	assert.EqualError(t, err, "context canceled")
 
 	c.AssertExpectations(t)
 	x.AssertExpectations(t)


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/756
Slightly improves https://github.com/remind101/empire/issues/837

This sets explicit deadlines on `Deploy`, `Set`, `Rollback` and `CertsAttach` operations, which all use scheduler.Submit to submit a new release to the scheduler backend. The CloudFormation scheduler now will also use the deadline to cancel waiting for the stack to move to a stabilized state.

The effect of this is slightly better error messages. For example:

```console
$ emp deploy remind101/acme-inc:master
$ emp set FOO=bar -a acme-inc
error: stack did not stabilize from UPDATE_IN_PROGRESS after waiting 28 seconds
```

Instead of seeing an `EOF` error returned.

There's further changes we can make to improve the behavior so that actually hitting this error is rare (like queueing releases instead of performing them within the request/making rollbacks trigger a stack rollback first/etc), but I figure this is at least a good start.