### PR TITLE
Don't wait for ECS services to stabilize

### DIFF
--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -82,6 +82,45 @@ func TestEmpireTemplate(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"fast.json",
+			&scheduler.App{
+				ID:   "1234",
+				Name: "acme-inc",
+				Env: map[string]string{
+					"ECS_UPDATES": "fast",
+				},
+				Processes: []*scheduler.Process{
+					{
+						Type:    "web",
+						Image:   image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
+						Command: []string{"./bin/web"},
+						Exposure: &scheduler.Exposure{
+							Type: &scheduler.HTTPExposure{},
+						},
+						Labels: map[string]string{
+							"empire.app.process": "web",
+						},
+						MemoryLimit: 128 * bytesize.MB,
+						CPUShares:   256,
+						Instances:   1,
+						Nproc:       256,
+					},
+					{
+						Type:    "worker",
+						Image:   image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
+						Command: []string{"./bin/worker"},
+						Labels: map[string]string{
+							"empire.app.process": "worker",
+						},
+						Env: map[string]string{
+							"FOO": "BAR",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/scheduler/cloudformation/templates/fast.json
+++ b/scheduler/cloudformation/templates/fast.json
@@ -1,0 +1,242 @@
+{
+  "Conditions": {
+    "DNSCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "DNS"
+        },
+        "true"
+      ]
+    }
+  },
+  "Outputs": {
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Ref": "webService"
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "worker",
+                  {
+                    "Ref": "workerService"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "DNS": {
+      "Description": "When set to `true`, CNAME's will be altered",
+      "Type": "String"
+    },
+    "webScale": {
+      "Type": "String"
+    },
+    "workerScale": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "CNAME": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "acme-inc.empire",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
+          }
+        ],
+        "TTL": 60,
+        "Type": "CNAME"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
+    "web8080InstancePort": {
+      "Properties": {
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::InstancePort",
+      "Version": "1.0"
+    },
+    "webLoadBalancer": {
+      "Properties": {
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 30
+        },
+        "CrossZone": true,
+        "Listeners": [
+          {
+            "InstancePort": {
+              "Fn::GetAtt": [
+                "web8080InstancePort",
+                "InstancePort"
+              ]
+            },
+            "InstanceProtocol": "http",
+            "LoadBalancerPort": 80,
+            "Protocol": "http"
+          }
+        ],
+        "Scheme": "internal",
+        "SecurityGroups": [
+          "sg-e7387381"
+        ],
+        "Subnets": [
+          "subnet-bb01c4cd",
+          "subnet-c85f4091"
+        ],
+        "Tags": [
+          {
+            "Key": "empire.app.process",
+            "Value": "web"
+          }
+        ]
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+    },
+    "webService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "webScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "webLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "ServiceName": "acme-inc-web",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "webTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService"
+    },
+    "webTaskDefinition": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/web"
+            ],
+            "Cpu": 256,
+            "DockerLabels": {
+              "empire.app.process": "web"
+            },
+            "Environment": [
+              {
+                "Name": "ECS_UPDATES",
+                "Value": "fast"
+              },
+              {
+                "Name": "PORT",
+                "Value": "8080"
+              }
+            ],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 128,
+            "Name": "web",
+            "PortMappings": [
+              {
+                "ContainerPort": 8080,
+                "HostPort": {
+                  "Fn::GetAtt": [
+                    "web8080InstancePort",
+                    "InstancePort"
+                  ]
+                }
+              }
+            ],
+            "Ulimits": [
+              {
+                "HardLimit": 256,
+                "Name": "nproc",
+                "SoftLimit": 256
+              }
+            ]
+          }
+        ],
+        "Volumes": []
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    },
+    "workerService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "workerScale"
+        },
+        "LoadBalancers": [],
+        "ServiceName": "acme-inc-worker",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "workerTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService"
+    },
+    "workerTaskDefinition": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/worker"
+            ],
+            "Cpu": 0,
+            "DockerLabels": {
+              "empire.app.process": "worker"
+            },
+            "Environment": [
+              {
+                "Name": "ECS_UPDATES",
+                "Value": "fast"
+              },
+              {
+                "Name": "FOO",
+                "Value": "BAR"
+              }
+            ],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 0,
+            "Name": "worker",
+            "PortMappings": [],
+            "Ulimits": []
+          }
+        ],
+        "Volumes": []
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -196,7 +196,8 @@ func NewCustomResourceProvisioner(db *sql.DB, config client.ConfigProvider) *Cus
 				ports: lb.NewDBPortAllocator(db),
 			},
 			"Custom::ECSService": &ECSServiceResource{
-				ecs: ecs.New(config),
+				ecs:     ecs.New(config),
+				postfix: postfix,
 			},
 		},
 		client: http.DefaultClient,

--- a/server/cloudformation/cloudformation_test.go
+++ b/server/cloudformation/cloudformation_test.go
@@ -41,15 +41,13 @@ func TestCustomResourceProvisioner_Handle(t *testing.T) {
 	}
 
 	p.On("Provision", Request{
-		RequestType:       Create,
-		ResponseURL:       "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
-		StackId:           "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
-		RequestId:         "daf3f3f9-79a1-4049-823e-09544e582b06",
-		LogicalResourceId: "webInstancePort",
-		ResourceType:      "Custom::InstancePort",
-		ResourceProperties: map[string]interface{}{
-			"ServiceToken": "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
-		},
+		RequestType:        Create,
+		ResponseURL:        "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
+		StackId:            "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:          "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId:  "webInstancePort",
+		ResourceType:       "Custom::InstancePort",
+		ResourceProperties: json.RawMessage(`{"ServiceToken":"arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD"}`),
 	}).Return("9001", map[string]int64{"InstancePort": 9001}, nil)
 
 	raw, err := json.Marshal(Response{
@@ -69,6 +67,27 @@ func TestCustomResourceProvisioner_Handle(t *testing.T) {
 
 	err = c.Handle(message)
 	assert.NoError(t, err)
+}
+
+func TestIntValue(t *testing.T) {
+	type foo struct {
+		I IntValue `json:"I"`
+	}
+
+	tests := []struct {
+		in  []byte
+		out foo
+	}{
+		{[]byte(`{"I": 1}`), foo{I: 1}},
+		{[]byte(`{"I": "1"}`), foo{I: 1}},
+	}
+
+	for _, tt := range tests {
+		var i foo
+		err := json.Unmarshal(tt.in, &i)
+		assert.NoError(t, err)
+		assert.Equal(t, tt.out, i)
+	}
 }
 
 type mockProvisioner struct {

--- a/server/cloudformation/cloudformation_test.go
+++ b/server/cloudformation/cloudformation_test.go
@@ -41,13 +41,15 @@ func TestCustomResourceProvisioner_Handle(t *testing.T) {
 	}
 
 	p.On("Provision", Request{
-		RequestType:        Create,
-		ResponseURL:        "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
-		StackId:            "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
-		RequestId:          "daf3f3f9-79a1-4049-823e-09544e582b06",
-		LogicalResourceId:  "webInstancePort",
-		ResourceType:       "Custom::InstancePort",
-		ResourceProperties: json.RawMessage(`{"ServiceToken":"arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD"}`),
+		RequestType:       Create,
+		ResponseURL:       "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
+		StackId:           "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:         "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId: "webInstancePort",
+		ResourceType:      "Custom::InstancePort",
+		ResourceProperties: map[string]interface{}{
+			"ServiceToken": "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
+		},
 	}).Return("9001", map[string]int64{"InstancePort": 9001}, nil)
 
 	raw, err := json.Marshal(Response{

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -1,0 +1,122 @@
+package cloudformation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+type ecsClient interface {
+	CreateService(*ecs.CreateServiceInput) (*ecs.CreateServiceOutput, error)
+	DeleteService(*ecs.DeleteServiceInput) (*ecs.DeleteServiceOutput, error)
+	UpdateService(*ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error)
+}
+
+type ECSServiceProperties struct {
+	ServiceName   *string
+	Cluster       *string
+	DesiredCount  *IntValue
+	LoadBalancers []struct {
+		ContainerName    *string
+		ContainerPort    *IntValue
+		LoadBalancerName *string
+	}
+	Role           *string
+	TaskDefinition *string
+}
+
+// ECSServiceResource is a Provisioner that creates and updates ECS services.
+type ECSServiceResource struct {
+	ecs ecsClient
+}
+
+func (p *ECSServiceResource) Provision(req Request) (string, interface{}, error) {
+	var properties, oldProperties ECSServiceProperties
+
+	if req.ResourceProperties != nil {
+		if err := json.Unmarshal(req.ResourceProperties, &properties); err != nil {
+			return "", nil, fmt.Errorf("error unmarshaling properties: %v", err)
+		}
+	}
+
+	if req.OldResourceProperties != nil {
+		if err := json.Unmarshal(req.OldResourceProperties, &oldProperties); err != nil {
+			return "", nil, fmt.Errorf("error unmarshaling properties: %v", err)
+		}
+	}
+
+	switch req.RequestType {
+	case Create:
+		var loadBalancers []*ecs.LoadBalancer
+		for _, v := range properties.LoadBalancers {
+			loadBalancers = append(loadBalancers, &ecs.LoadBalancer{
+				ContainerName:    v.ContainerName,
+				ContainerPort:    v.ContainerPort.Value(),
+				LoadBalancerName: v.LoadBalancerName,
+			})
+		}
+
+		resp, err := p.ecs.CreateService(&ecs.CreateServiceInput{
+			ServiceName:    properties.ServiceName,
+			Cluster:        properties.Cluster,
+			DesiredCount:   properties.DesiredCount.Value(),
+			Role:           properties.Role,
+			TaskDefinition: properties.TaskDefinition,
+			LoadBalancers:  loadBalancers,
+		})
+		if err != nil {
+			return "", nil, err
+		}
+
+		return *resp.Service.ServiceArn, nil, nil
+	case Delete:
+		id := req.PhysicalResourceId
+		_, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
+			Service:      aws.String(id),
+			Cluster:      properties.Cluster,
+			DesiredCount: aws.Int64(0),
+		})
+		if err != nil {
+			return id, nil, err
+		}
+
+		_, err = p.ecs.DeleteService(&ecs.DeleteServiceInput{
+			Service: aws.String(id),
+			Cluster: properties.Cluster,
+		})
+
+		return id, nil, err
+	case Update:
+		id := req.PhysicalResourceId
+
+		if !reflect.DeepEqual(properties.Cluster, oldProperties.Cluster) {
+			return id, nil, errors.New("cannot update cluster")
+		}
+
+		if !reflect.DeepEqual(properties.Role, oldProperties.Role) {
+			return id, nil, errors.New("cannot update role")
+		}
+
+		if !reflect.DeepEqual(properties.ServiceName, oldProperties.ServiceName) {
+			return id, nil, errors.New("cannot update service name")
+		}
+
+		if !reflect.DeepEqual(properties.LoadBalancers, oldProperties.LoadBalancers) {
+			return id, nil, errors.New("cannot update load balancers")
+		}
+
+		_, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
+			Service:      aws.String(id),
+			Cluster:      properties.Cluster,
+			DesiredCount: properties.DesiredCount.Value(),
+		})
+
+		return id, nil, err
+	default:
+		return "", nil, fmt.Errorf("%s is not supported", req.RequestType)
+	}
+}

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -15,15 +15,19 @@ type ecsClient interface {
 	UpdateService(*ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error)
 }
 
+type LoadBalancer struct {
+	ContainerName    *string
+	ContainerPort    *IntValue
+	LoadBalancerName *string
+}
+
+// ECSServiceProperties represents the properties for the Custom::ECSService
+// resource.
 type ECSServiceProperties struct {
-	ServiceName   *string
-	Cluster       *string
-	DesiredCount  *IntValue
-	LoadBalancers []struct {
-		ContainerName    *string
-		ContainerPort    *IntValue
-		LoadBalancerName *string
-	}
+	ServiceName    *string
+	Cluster        *string
+	DesiredCount   *IntValue
+	LoadBalancers  []LoadBalancer
 	Role           *string
 	TaskDefinition *string
 }
@@ -67,6 +71,9 @@ func (p *ECSServiceResource) Provision(req Request) (string, interface{}, error)
 		return *resp.Service.ServiceArn, nil, nil
 	case Delete:
 		id := req.PhysicalResourceId
+
+		// We have to scale the service down to 0, before we're able to
+		// destroy it.
 		_, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
 			Service:      aws.String(id),
 			Cluster:      properties.Cluster,
@@ -85,30 +92,42 @@ func (p *ECSServiceResource) Provision(req Request) (string, interface{}, error)
 	case Update:
 		id := req.PhysicalResourceId
 
-		if !reflect.DeepEqual(properties.Cluster, oldProperties.Cluster) {
-			return id, nil, errors.New("cannot update cluster")
-		}
-
-		if !reflect.DeepEqual(properties.Role, oldProperties.Role) {
-			return id, nil, errors.New("cannot update role")
-		}
-
-		if !reflect.DeepEqual(properties.ServiceName, oldProperties.ServiceName) {
-			return id, nil, errors.New("cannot update service name")
-		}
-
-		if !reflect.DeepEqual(properties.LoadBalancers, oldProperties.LoadBalancers) {
-			return id, nil, errors.New("cannot update load balancers")
+		if err := canUpdateService(properties, oldProperties); err != nil {
+			return id, nil, err
 		}
 
 		_, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
-			Service:      aws.String(id),
-			Cluster:      properties.Cluster,
-			DesiredCount: properties.DesiredCount.Value(),
+			Service:        aws.String(id),
+			Cluster:        properties.Cluster,
+			DesiredCount:   properties.DesiredCount.Value(),
+			TaskDefinition: properties.TaskDefinition,
 		})
 
 		return id, nil, err
 	default:
 		return "", nil, fmt.Errorf("%s is not supported", req.RequestType)
 	}
+}
+
+// We currently only support updating the task definition and desired count.
+func canUpdateService(new, old *ECSServiceProperties) error {
+	eq := reflect.DeepEqual
+
+	if !eq(new.Cluster, old.Cluster) {
+		return errors.New("cannot update cluster")
+	}
+
+	if !eq(new.Role, old.Role) {
+		return errors.New("cannot update role")
+	}
+
+	if !eq(new.ServiceName, old.ServiceName) {
+		return errors.New("cannot update service name")
+	}
+
+	if !eq(new.LoadBalancers, old.LoadBalancers) {
+		return errors.New("cannot update load balancers")
+	}
+
+	return nil
 }

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -1,7 +1,6 @@
 package cloudformation
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -34,20 +33,13 @@ type ECSServiceResource struct {
 	ecs ecsClient
 }
 
+func (p *ECSServiceResource) Properties() interface{} {
+	return &ECSServiceProperties{}
+}
+
 func (p *ECSServiceResource) Provision(req Request) (string, interface{}, error) {
-	var properties, oldProperties ECSServiceProperties
-
-	if req.ResourceProperties != nil {
-		if err := json.Unmarshal(req.ResourceProperties, &properties); err != nil {
-			return "", nil, fmt.Errorf("error unmarshaling properties: %v", err)
-		}
-	}
-
-	if req.OldResourceProperties != nil {
-		if err := json.Unmarshal(req.OldResourceProperties, &oldProperties); err != nil {
-			return "", nil, fmt.Errorf("error unmarshaling properties: %v", err)
-		}
-	}
+	properties := req.ResourceProperties.(*ECSServiceProperties)
+	oldProperties := req.OldResourceProperties.(*ECSServiceProperties)
 
 	switch req.RequestType {
 	case Create:

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -1,7 +1,6 @@
 package cloudformation
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,8 +26,13 @@ func TestECSServiceResource_Create(t *testing.T) {
 	}, nil)
 
 	id, data, err := p.Provision(Request{
-		RequestType:        Create,
-		ResourceProperties: json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
+		RequestType: Create,
+		ResourceProperties: &ECSServiceProperties{
+			Cluster:      aws.String("cluster"),
+			ServiceName:  aws.String("acme-inc-web"),
+			DesiredCount: intValue(1),
+		},
+		OldResourceProperties: &ECSServiceProperties{},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
@@ -48,10 +52,18 @@ func TestECSServiceResource_Update(t *testing.T) {
 	}).Return(&ecs.UpdateServiceOutput{}, nil)
 
 	id, data, err := p.Provision(Request{
-		RequestType:           Update,
-		PhysicalResourceId:    "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
-		ResourceProperties:    json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 2}`),
-		OldResourceProperties: json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
+		RequestType:        Update,
+		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
+		ResourceProperties: &ECSServiceProperties{
+			Cluster:      aws.String("cluster"),
+			ServiceName:  aws.String("acme-inc-web"),
+			DesiredCount: intValue(2),
+		},
+		OldResourceProperties: &ECSServiceProperties{
+			Cluster:      aws.String("cluster"),
+			ServiceName:  aws.String("acme-inc-web"),
+			DesiredCount: intValue(1),
+		},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
@@ -76,10 +88,18 @@ func TestECSServiceResource_Delete(t *testing.T) {
 	}).Return(&ecs.DeleteServiceOutput{}, nil)
 
 	id, data, err := p.Provision(Request{
-		RequestType:           Delete,
-		PhysicalResourceId:    "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
-		ResourceProperties:    json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
-		OldResourceProperties: json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
+		RequestType:        Delete,
+		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
+		ResourceProperties: &ECSServiceProperties{
+			Cluster:      aws.String("cluster"),
+			ServiceName:  aws.String("acme-inc-web"),
+			DesiredCount: intValue(1),
+		},
+		OldResourceProperties: &ECSServiceProperties{
+			Cluster:      aws.String("cluster"),
+			ServiceName:  aws.String("acme-inc-web"),
+			DesiredCount: intValue(1),
+		},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -1,0 +1,107 @@
+package cloudformation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestECSServiceResource_Create(t *testing.T) {
+	e := new(mockECS)
+	p := &ECSServiceResource{
+		ecs: e,
+	}
+
+	e.On("CreateService", &ecs.CreateServiceInput{
+		ServiceName:  aws.String("acme-inc-web"),
+		Cluster:      aws.String("cluster"),
+		DesiredCount: aws.Int64(1),
+	}).Return(&ecs.CreateServiceOutput{
+		Service: &ecs.Service{
+			ServiceArn: aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
+		},
+	}, nil)
+
+	id, data, err := p.Provision(Request{
+		RequestType:        Create,
+		ResourceProperties: json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
+	assert.Nil(t, data)
+}
+
+func TestECSServiceResource_Update(t *testing.T) {
+	e := new(mockECS)
+	p := &ECSServiceResource{
+		ecs: e,
+	}
+
+	e.On("UpdateService", &ecs.UpdateServiceInput{
+		Service:      aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
+		Cluster:      aws.String("cluster"),
+		DesiredCount: aws.Int64(2),
+	}).Return(&ecs.UpdateServiceOutput{}, nil)
+
+	id, data, err := p.Provision(Request{
+		RequestType:           Update,
+		PhysicalResourceId:    "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
+		ResourceProperties:    json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 2}`),
+		OldResourceProperties: json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
+	assert.Nil(t, data)
+}
+
+func TestECSServiceResource_Delete(t *testing.T) {
+	e := new(mockECS)
+	p := &ECSServiceResource{
+		ecs: e,
+	}
+
+	e.On("UpdateService", &ecs.UpdateServiceInput{
+		Service:      aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
+		Cluster:      aws.String("cluster"),
+		DesiredCount: aws.Int64(0),
+	}).Return(&ecs.UpdateServiceOutput{}, nil)
+
+	e.On("DeleteService", &ecs.DeleteServiceInput{
+		Service: aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
+		Cluster: aws.String("cluster"),
+	}).Return(&ecs.DeleteServiceOutput{}, nil)
+
+	id, data, err := p.Provision(Request{
+		RequestType:           Delete,
+		PhysicalResourceId:    "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
+		ResourceProperties:    json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
+		OldResourceProperties: json.RawMessage(`{"Cluster": "cluster", "ServiceName": "acme-inc-web", "DesiredCount": 1}`),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
+	assert.Nil(t, data)
+}
+
+type mockECS struct {
+	ecsClient
+	mock.Mock
+}
+
+func (m *mockECS) CreateService(input *ecs.CreateServiceInput) (*ecs.CreateServiceOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*ecs.CreateServiceOutput), args.Error(1)
+}
+
+func (m *mockECS) UpdateService(input *ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*ecs.UpdateServiceOutput), args.Error(1)
+}
+
+func (m *mockECS) DeleteService(input *ecs.DeleteServiceInput) (*ecs.DeleteServiceOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*ecs.DeleteServiceOutput), args.Error(1)
+}

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -46,26 +46,64 @@ func TestECSServiceResource_Update(t *testing.T) {
 	}
 
 	e.On("UpdateService", &ecs.UpdateServiceInput{
-		Service:      aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
-		Cluster:      aws.String("cluster"),
-		DesiredCount: aws.Int64(2),
+		Service:        aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
+		Cluster:        aws.String("cluster"),
+		DesiredCount:   aws.Int64(2),
+		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
 	}).Return(&ecs.UpdateServiceOutput{}, nil)
 
 	id, data, err := p.Provision(Request{
 		RequestType:        Update,
 		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
 		ResourceProperties: &ECSServiceProperties{
-			Cluster:      aws.String("cluster"),
-			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(2),
+			Cluster:        aws.String("cluster"),
+			ServiceName:    aws.String("acme-inc-web"),
+			DesiredCount:   intValue(2),
+			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
 		},
 		OldResourceProperties: &ECSServiceProperties{
-			Cluster:      aws.String("cluster"),
-			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(1),
+			Cluster:        aws.String("cluster"),
+			ServiceName:    aws.String("acme-inc-web"),
+			DesiredCount:   intValue(1),
+			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
 		},
 	})
 	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
+	assert.Nil(t, data)
+}
+
+func TestECSServiceResource_Update_Cluster(t *testing.T) {
+	e := new(mockECS)
+	p := &ECSServiceResource{
+		ecs: e,
+	}
+
+	e.On("UpdateService", &ecs.UpdateServiceInput{
+		Service:        aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
+		Cluster:        aws.String("cluster"),
+		DesiredCount:   aws.Int64(2),
+		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+	}).Return(&ecs.UpdateServiceOutput{}, nil)
+
+	id, data, err := p.Provision(Request{
+		RequestType:        Update,
+		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
+		ResourceProperties: &ECSServiceProperties{
+			Cluster:        aws.String("clusterB"),
+			ServiceName:    aws.String("acme-inc-web"),
+			DesiredCount:   intValue(2),
+			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+		},
+		OldResourceProperties: &ECSServiceProperties{
+			Cluster:        aws.String("clusterA"),
+			ServiceName:    aws.String("acme-inc-web"),
+			DesiredCount:   intValue(1),
+			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
+		},
+	})
+	assert.Error(t, err)
+	assert.EqualError(t, err, "cannot update cluster")
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
 	assert.Nil(t, data)
 }
@@ -104,6 +142,62 @@ func TestECSServiceResource_Delete(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
 	assert.Nil(t, data)
+}
+
+func TestCanUpdateService(t *testing.T) {
+	tests := []struct {
+		new, old ECSServiceProperties
+		out      bool
+	}{
+		{
+			ECSServiceProperties{Cluster: aws.String("cluster"), TaskDefinition: aws.String("td:2"), DesiredCount: intValue(1)},
+			ECSServiceProperties{Cluster: aws.String("cluster"), TaskDefinition: aws.String("td:1"), DesiredCount: intValue(0)},
+			true,
+		},
+
+		{
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elb")}}},
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elb")}}},
+			true,
+		},
+
+		// Can't change clusters.
+		{
+			ECSServiceProperties{Cluster: aws.String("clusterB")},
+			ECSServiceProperties{Cluster: aws.String("clusterA")},
+			false,
+		},
+
+		// Can't change name.
+		{
+			ECSServiceProperties{ServiceName: aws.String("acme-inc-B")},
+			ECSServiceProperties{ServiceName: aws.String("acme-inc-A")},
+			false,
+		},
+
+		// Can't change role.
+		{
+			ECSServiceProperties{Role: aws.String("roleB")},
+			ECSServiceProperties{Role: aws.String("roleA")},
+			false,
+		},
+
+		// Can't change load balancers
+		{
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elbB")}}},
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elbA")}}},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		out := canUpdateService(&tt.new, &tt.old)
+		if tt.out {
+			assert.Nil(t, out)
+		} else {
+			assert.Error(t, out)
+		}
+	}
 }
 
 type mockECS struct {


### PR DESCRIPTION
Switching to CloudFormation has some less than optimal behavior with the way ECS services are updated; CloudFormation will wait for the ECS service to stabilize, when updating. This has some negative consequences:

1. The stack is locked during the entire duration, making it impossible to submit a new stack template until all of the services have stabilized.
2. If the cluster has insufficient resources, the stack could potentially stay in an UPDATE_IN_PROGRESS state for a very long time, or eventually rollback.

From Empire's perspective, we'd like CloudFormation to simply submit the updates to ECS, then complete, which would mimic the behavior of the old non-cloudformation scheduler.

This PR adds a `Custom::ECSService` resource to our custom resource handlers. This operates similarly to `AWS::EC2::Service`, except it does not wait for the service to stabilize. Doing this should allow us to submit changes to CloudFormation faster, and should resolve most of https://github.com/remind101/empire/issues/837.

For the time being, this can be enabled on a per app basis by setting `ECS_UPDATES=fast` in the apps environment. You can switch back and forth between the two without any apparent downtime. This may become the default before the next release.