### PR TITLE
Allow processes to be removed with CloudFormation backend.

### DIFF
--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -128,6 +128,69 @@ func TestScheduler_Submit_ExistingStack(t *testing.T) {
 	x.AssertExpectations(t)
 }
 
+func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
+	db := newDB(t)
+	defer db.Close()
+
+	x := new(mockS3Client)
+	c := new(mockCloudFormationClient)
+	s := &Scheduler{
+		Template:       template.Must(template.New("t").Parse("{}")),
+		Wait:           true,
+		Bucket:         "bucket",
+		cloudformation: c,
+		s3:             x,
+		db:             db,
+	}
+
+	x.On("PutObject", &s3.PutObjectInput{
+		Bucket:      aws.String("bucket"),
+		Body:        bytes.NewReader([]byte("{}")),
+		Key:         aws.String("/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
+		ContentType: aws.String("application/json"),
+	}).Return(&s3.PutObjectOutput{}, nil)
+
+	c.On("DescribeStacks", &cloudformation.DescribeStacksInput{
+		StackName: aws.String("acme-inc"),
+	}).Return(&cloudformation.DescribeStacksOutput{
+		Stacks: []*cloudformation.Stack{
+			{
+				StackStatus: aws.String("CREATE_COMPLETE"),
+				Parameters: []*cloudformation.Parameter{
+					{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
+					{ParameterKey: aws.String("workerScale"), ParameterValue: aws.String("0")},
+					{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
+				},
+			},
+		},
+	}, nil)
+
+	c.On("UpdateStack", &cloudformation.UpdateStackInput{
+		StackName:   aws.String("acme-inc"),
+		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
+		Parameters: []*cloudformation.Parameter{
+			{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
+			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
+		},
+	}).Return(&cloudformation.UpdateStackOutput{}, nil)
+
+	c.On("WaitUntilStackUpdateComplete", &cloudformation.DescribeStacksInput{
+		StackName: aws.String("acme-inc"),
+	}).Return(nil)
+
+	err := s.Submit(context.Background(), &scheduler.App{
+		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
+		Name: "acme-inc",
+		Processes: []*scheduler.Process{
+			{Type: "web", Instances: 1},
+		},
+	})
+	assert.NoError(t, err)
+
+	c.AssertExpectations(t)
+	x.AssertExpectations(t)
+}
+
 func TestScheduler_Submit_StackUpdateInProgress(t *testing.T) {
 	db := newDB(t)
 	defer db.Close()
@@ -201,7 +264,6 @@ func TestScheduler_Remove(t *testing.T) {
 	c.On("DeleteStack", &cloudformation.DeleteStackInput{
 		StackName: aws.String("acme-inc"),
 	}).Return(&cloudformation.DeleteStackOutput{}, nil)
-
 
 	c.On("DescribeStacks", &cloudformation.DescribeStacksInput{
 		StackName: aws.String("acme-inc"),


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/846

Previously, we'd merge in all the parameters from the existing stack even if we were submitting a new stack template that had different parameters. Now, we only merge in existing parameters if we using the same template (UsePreviousTemplate).