### PR TITLE
Better restart with CloudFormation backend

### DIFF
--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -30,6 +30,9 @@ import (
 // values.
 const servicesOutput = "Services"
 
+// Parameter used to trigger a restart of the application.
+const restartParameter = "RestartKey"
+
 // CloudFormation limits
 //
 // See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"code.google.com/p/go-uuid/uuid"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -19,9 +18,6 @@ import (
 	"github.com/remind101/empire/pkg/bytesize"
 	"github.com/remind101/empire/scheduler"
 )
-
-// newUUID returns a new UUID. Set to a var so we can stub it out in tests.
-var newUUID = uuid.New
 
 const (
 	// For HTTP/HTTPS/TCP services, we allocate an ELB and map it's instance port to
@@ -134,8 +130,7 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 			"Description": "When set to `true`, CNAME's will be altered",
 		},
 		restartParameter: map[string]string{
-			"Type":    "String",
-			"Default": newUUID(),
+			"Type": "String",
 		},
 	}
 	conditions := map[string]interface{}{
@@ -173,8 +168,7 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 			"Type": "String",
 		}
 		parameters[restartProcessParameter(p.Type)] = map[string]string{
-			"Type":    "String",
-			"Default": newUUID(),
+			"Type": "String",
 		}
 
 		portMappings := []map[string]interface{}{}
@@ -307,7 +301,7 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 		for k, v := range cd.DockerLabels {
 			labels[k] = v
 		}
-		labels["empire.app.restart.key"] = map[string]interface{}{
+		labels["cloudformation.restart_key"] = map[string]interface{}{
 			"Fn::Join": []interface{}{"-", []interface{}{map[string]string{"Ref": restartParameter}, map[string]string{"Ref": restartProcessParameter(p.Type)}}},
 		}
 

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	newUUID = func() string { return "uuid" }
-}
-
 func TestEmpireTemplate(t *testing.T) {
 	tests := []struct {
 		file string
@@ -28,6 +24,13 @@ func TestEmpireTemplate(t *testing.T) {
 			&scheduler.App{
 				ID:   "1234",
 				Name: "acme-inc",
+				Env: map[string]string{
+					// These should get re-sorted in
+					// alphabetical order.
+					"C": "foo",
+					"A": "foobar",
+					"B": "bar",
+				},
 				Processes: []*scheduler.Process{
 					{
 						Type:    "web",

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	newUUID = func() string { return "uuid" }
+}
+
 func TestEmpireTemplate(t *testing.T) {
 	tests := []struct {
 		file string

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -48,18 +48,15 @@
       "Type": "String"
     },
     "RestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "webRestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "webScale": {
       "Type": "String"
     },
     "workerRestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "workerScale": {
@@ -160,8 +157,7 @@
             ],
             "Cpu": 256,
             "DockerLabels": {
-              "empire.app.process": "web",
-              "empire.app.restart.key": {
+              "cloudformation.restart_key": {
                 "Fn::Join": [
                   "-",
                   [
@@ -173,9 +169,22 @@
                     }
                   ]
                 ]
-              }
+              },
+              "empire.app.process": "web"
             },
             "Environment": [
+              {
+                "Name": "A",
+                "Value": "foobar"
+              },
+              {
+                "Name": "B",
+                "Value": "bar"
+              },
+              {
+                "Name": "C",
+                "Value": "foo"
+              },
               {
                 "Name": "PORT",
                 "Value": "8080"
@@ -231,8 +240,7 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
-              "empire.app.process": "worker",
-              "empire.app.restart.key": {
+              "cloudformation.restart_key": {
                 "Fn::Join": [
                   "-",
                   [
@@ -244,9 +252,22 @@
                     }
                   ]
                 ]
-              }
+              },
+              "empire.app.process": "worker"
             },
             "Environment": [
+              {
+                "Name": "A",
+                "Value": "foobar"
+              },
+              {
+                "Name": "B",
+                "Value": "bar"
+              },
+              {
+                "Name": "C",
+                "Value": "foo"
+              },
               {
                 "Name": "FOO",
                 "Value": "BAR"

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -47,7 +47,19 @@
       "Description": "When set to `true`, CNAME's will be altered",
       "Type": "String"
     },
+    "RestartKey": {
+      "Default": "uuid",
+      "Type": "String"
+    },
+    "webRestartKey": {
+      "Default": "uuid",
+      "Type": "String"
+    },
     "webScale": {
+      "Type": "String"
+    },
+    "workerRestartKey": {
+      "Default": "uuid",
       "Type": "String"
     },
     "workerScale": {
@@ -148,7 +160,20 @@
             ],
             "Cpu": 256,
             "DockerLabels": {
-              "empire.app.process": "web"
+              "empire.app.process": "web",
+              "empire.app.restart.key": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      "Ref": "RestartKey"
+                    },
+                    {
+                      "Ref": "webRestartKey"
+                    }
+                  ]
+                ]
+              }
             },
             "Environment": [
               {
@@ -206,7 +231,20 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
-              "empire.app.process": "worker"
+              "empire.app.process": "worker",
+              "empire.app.restart.key": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      "Ref": "RestartKey"
+                    },
+                    {
+                      "Ref": "workerRestartKey"
+                    }
+                  ]
+                ]
+              }
             },
             "Environment": [
               {

--- a/scheduler/cloudformation/templates/fast.json
+++ b/scheduler/cloudformation/templates/fast.json
@@ -48,18 +48,15 @@
       "Type": "String"
     },
     "RestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "webRestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "webScale": {
       "Type": "String"
     },
     "workerRestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "workerScale": {
@@ -162,8 +159,7 @@
             ],
             "Cpu": 256,
             "DockerLabels": {
-              "empire.app.process": "web",
-              "empire.app.restart.key": {
+              "cloudformation.restart_key": {
                 "Fn::Join": [
                   "-",
                   [
@@ -175,7 +171,8 @@
                     }
                   ]
                 ]
-              }
+              },
+              "empire.app.process": "web"
             },
             "Environment": [
               {
@@ -239,8 +236,7 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
-              "empire.app.process": "worker",
-              "empire.app.restart.key": {
+              "cloudformation.restart_key": {
                 "Fn::Join": [
                   "-",
                   [
@@ -252,7 +248,8 @@
                     }
                   ]
                 ]
-              }
+              },
+              "empire.app.process": "worker"
             },
             "Environment": [
               {

--- a/scheduler/cloudformation/templates/fast.json
+++ b/scheduler/cloudformation/templates/fast.json
@@ -47,7 +47,19 @@
       "Description": "When set to `true`, CNAME's will be altered",
       "Type": "String"
     },
+    "RestartKey": {
+      "Default": "uuid",
+      "Type": "String"
+    },
+    "webRestartKey": {
+      "Default": "uuid",
+      "Type": "String"
+    },
     "webScale": {
+      "Type": "String"
+    },
+    "workerRestartKey": {
+      "Default": "uuid",
       "Type": "String"
     },
     "workerScale": {
@@ -150,7 +162,20 @@
             ],
             "Cpu": 256,
             "DockerLabels": {
-              "empire.app.process": "web"
+              "empire.app.process": "web",
+              "empire.app.restart.key": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      "Ref": "RestartKey"
+                    },
+                    {
+                      "Ref": "webRestartKey"
+                    }
+                  ]
+                ]
+              }
             },
             "Environment": [
               {
@@ -214,7 +239,20 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
-              "empire.app.process": "worker"
+              "empire.app.process": "worker",
+              "empire.app.restart.key": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      "Ref": "RestartKey"
+                    },
+                    {
+                      "Ref": "workerRestartKey"
+                    }
+                  ]
+                ]
+              }
             },
             "Environment": [
               {

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -47,7 +47,19 @@
       "Description": "When set to `true`, CNAME's will be altered",
       "Type": "String"
     },
+    "RestartKey": {
+      "Default": "uuid",
+      "Type": "String"
+    },
+    "apiRestartKey": {
+      "Default": "uuid",
+      "Type": "String"
+    },
     "apiScale": {
+      "Type": "String"
+    },
+    "webRestartKey": {
+      "Default": "uuid",
       "Type": "String"
     },
     "webScale": {
@@ -171,7 +183,21 @@
               "./bin/api"
             ],
             "Cpu": 0,
-            "DockerLabels": {},
+            "DockerLabels": {
+              "empire.app.restart.key": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      "Ref": "RestartKey"
+                    },
+                    {
+                      "Ref": "apiRestartKey"
+                    }
+                  ]
+                ]
+              }
+            },
             "Environment": [
               {
                 "Name": "PORT",
@@ -286,7 +312,21 @@
               "./bin/web"
             ],
             "Cpu": 0,
-            "DockerLabels": {},
+            "DockerLabels": {
+              "empire.app.restart.key": {
+                "Fn::Join": [
+                  "-",
+                  [
+                    {
+                      "Ref": "RestartKey"
+                    },
+                    {
+                      "Ref": "webRestartKey"
+                    }
+                  ]
+                ]
+              }
+            },
             "Environment": [
               {
                 "Name": "PORT",

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -48,18 +48,15 @@
       "Type": "String"
     },
     "RestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "apiRestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "apiScale": {
       "Type": "String"
     },
     "webRestartKey": {
-      "Default": "uuid",
       "Type": "String"
     },
     "webScale": {
@@ -184,7 +181,7 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
-              "empire.app.restart.key": {
+              "cloudformation.restart_key": {
                 "Fn::Join": [
                   "-",
                   [
@@ -313,7 +310,7 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
-              "empire.app.restart.key": {
+              "cloudformation.restart_key": {
                 "Fn::Join": [
                   "-",
                   [


### PR DESCRIPTION
Step 1 of https://github.com/remind101/empire/issues/847#issue-156405642.

This makes it so we're not dependent on random sorting of environment variables to restart an application and preps the backend for an easy implementation of `Restart` and `RestartProcess` methods (which means we'll finally support `emp restart <process>`, hooray!).

Implementation wise, this works by setting an `cloudformation.restart_key` docker label on the task definition, with it's value as a composition of the app and process restart keys. If you change the global restart key, all task definitions are re-created. If you change a process restart key, the process task definition is updated (which ultimately causes a service restart).