### PR TITLE
Don't set EMPIRE_CREATED_AT env var.

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -264,7 +264,6 @@ func newSchedulerApp(release *Release) *scheduler.App {
 	env["EMPIRE_APPID"] = release.App.ID
 	env["EMPIRE_APPNAME"] = release.App.Name
 	env["EMPIRE_RELEASE"] = fmt.Sprintf("v%d", release.Version)
-	env["EMPIRE_CREATED_AT"] = timex.Now().Format(time.RFC3339)
 
 	labels := map[string]string{
 		"empire.app.id":      release.App.ID,

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -101,10 +101,9 @@ func TestEmpire_Deploy(t *testing.T) {
 		ID:   app.ID,
 		Name: "acme-inc",
 		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v1",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+			"EMPIRE_APPID":   app.ID,
+			"EMPIRE_APPNAME": "acme-inc",
+			"EMPIRE_RELEASE": "v1",
 		},
 		Labels: map[string]string{
 			"empire.app.name":    "acme-inc",
@@ -266,10 +265,9 @@ func TestEmpire_Run(t *testing.T) {
 		ID:   app.ID,
 		Name: "acme-inc",
 		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v1",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+			"EMPIRE_APPID":   app.ID,
+			"EMPIRE_APPNAME": "acme-inc",
+			"EMPIRE_RELEASE": "v1",
 		},
 		Labels: map[string]string{
 			"empire.app.name":    "acme-inc",
@@ -340,10 +338,9 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 		ID:   app.ID,
 		Name: "acme-inc",
 		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v1",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+			"EMPIRE_APPID":   app.ID,
+			"EMPIRE_APPNAME": "acme-inc",
+			"EMPIRE_RELEASE": "v1",
 		},
 		Labels: map[string]string{
 			"empire.app.name":    "acme-inc",
@@ -421,11 +418,10 @@ func TestEmpire_Set(t *testing.T) {
 		ID:   app.ID,
 		Name: "acme-inc",
 		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v1",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
-			"RAILS_ENV":         "production",
+			"EMPIRE_APPID":   app.ID,
+			"EMPIRE_APPNAME": "acme-inc",
+			"EMPIRE_RELEASE": "v1",
+			"RAILS_ENV":      "production",
 		},
 		Labels: map[string]string{
 			"empire.app.name":    "acme-inc",
@@ -468,10 +464,9 @@ func TestEmpire_Set(t *testing.T) {
 		ID:   app.ID,
 		Name: "acme-inc",
 		Env: map[string]string{
-			"EMPIRE_APPID":      app.ID,
-			"EMPIRE_APPNAME":    "acme-inc",
-			"EMPIRE_RELEASE":    "v2",
-			"EMPIRE_CREATED_AT": "2015-01-01T01:01:01Z",
+			"EMPIRE_APPID":   app.ID,
+			"EMPIRE_APPNAME": "acme-inc",
+			"EMPIRE_RELEASE": "v2",
 		},
 		Labels: map[string]string{
 			"empire.app.name":    "acme-inc",


### PR DESCRIPTION
Empire used to use this env var internally to determine when a task was started, but we've since implemented that using the native [StartedAt, CreatedAt, StoppedAt attributes](https://github.com/remind101/empire/blob/master/scheduler/ecs/ecs.go#L276-L284) in https://github.com/remind101/empire/pull/683 (released in 0.10.0).

This should be safe to remove since it was only used internally, and wasn't documented anywhere, but it shouldn't be merged until https://github.com/remind101/empire/pull/850 is merged (restarts would always set a new value for this).