### PR TITLE
Add the app release as a stack output.

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -253,7 +253,6 @@ func releasesCreate(db *gorm.DB, release *Release) (*Release, error) {
 }
 
 func newSchedulerApp(release *Release) *scheduler.App {
-
 	var processes []*scheduler.Process
 
 	for name, p := range release.Formation {
@@ -274,6 +273,7 @@ func newSchedulerApp(release *Release) *scheduler.App {
 	return &scheduler.App{
 		ID:        release.App.ID,
 		Name:      release.App.Name,
+		Release:   fmt.Sprintf("v%d", release.Version),
 		Processes: processes,
 		Env:       env,
 		Labels:    labels,

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/remind101/empire"
 	"github.com/remind101/empire/pkg/arn"
 	"github.com/remind101/empire/pkg/bytesize"
 	"github.com/remind101/empire/scheduler"
@@ -144,7 +145,14 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 		},
 	}
 	resources := map[string]interface{}{}
-	outputs := map[string]interface{}{}
+	outputs := map[string]interface{}{
+		"Release": map[string]interface{}{
+			"Value": app.Release,
+		},
+		"EmpireVersion": map[string]interface{}{
+			"Value": empire.Version,
+		},
+	}
 
 	serviceMappings := []map[string]interface{}{}
 

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -22,8 +22,9 @@ func TestEmpireTemplate(t *testing.T) {
 		{
 			"basic.json",
 			&scheduler.App{
-				ID:   "1234",
-				Name: "acme-inc",
+				ID:      "1234",
+				Release: "v1",
+				Name:    "acme-inc",
 				Env: map[string]string{
 					// These should get re-sorted in
 					// alphabetical order.
@@ -65,8 +66,9 @@ func TestEmpireTemplate(t *testing.T) {
 		{
 			"https.json",
 			&scheduler.App{
-				ID:   "1234",
-				Name: "acme-inc",
+				ID:      "1234",
+				Release: "v1",
+				Name:    "acme-inc",
 				Processes: []*scheduler.Process{
 					{
 						Type:    "web",
@@ -93,8 +95,9 @@ func TestEmpireTemplate(t *testing.T) {
 		{
 			"fast.json",
 			&scheduler.App{
-				ID:   "1234",
-				Name: "acme-inc",
+				ID:      "1234",
+				Release: "v1",
+				Name:    "acme-inc",
 				Env: map[string]string{
 					"ECS_UPDATES": "fast",
 				},
@@ -154,10 +157,11 @@ func TestEmpireTemplate_Large(t *testing.T) {
 		env[fmt.Sprintf("ENV_VAR_%d", i)] = fmt.Sprintf("value%d", i)
 	}
 	app := &scheduler.App{
-		ID:     "",
-		Name:   "bigappwithlotsofprocesses",
-		Env:    env,
-		Labels: labels,
+		ID:      "",
+		Release: "v1",
+		Name:    "bigappwithlotsofprocesses",
+		Env:     env,
+		Labels:  labels,
 	}
 
 	for i := 0; i < 60; i++ {

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -10,6 +10,12 @@
     }
   },
   "Outputs": {
+    "EmpireVersion": {
+      "Value": "0.10.0"
+    },
+    "Release": {
+      "Value": "v1"
+    },
     "Services": {
       "Value": {
         "Fn::Join": [

--- a/scheduler/cloudformation/templates/fast.json
+++ b/scheduler/cloudformation/templates/fast.json
@@ -10,6 +10,12 @@
     }
   },
   "Outputs": {
+    "EmpireVersion": {
+      "Value": "0.10.0"
+    },
+    "Release": {
+      "Value": "v1"
+    },
     "Services": {
       "Value": {
         "Fn::Join": [

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -10,6 +10,12 @@
     }
   },
   "Outputs": {
+    "EmpireVersion": {
+      "Value": "0.10.0"
+    },
+    "Release": {
+      "Value": "v1"
+    },
     "Services": {
       "Value": {
         "Fn::Join": [

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -14,6 +14,9 @@ type App struct {
 	// The id of the app.
 	ID string
 
+	// An identifier that represents the version of this release.
+	Release string
+
 	// The name of the app.
 	Name string
 

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -98,8 +98,9 @@ func TestEmpire_Deploy(t *testing.T) {
 
 	img := image.Image{Repository: "remind101/acme-inc"}
 	s.On("Submit", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:      app.ID,
+		Name:    "acme-inc",
+		Release: "v1",
 		Env: map[string]string{
 			"EMPIRE_APPID":   app.ID,
 			"EMPIRE_APPNAME": "acme-inc",
@@ -262,8 +263,9 @@ func TestEmpire_Run(t *testing.T) {
 	e.Scheduler = s
 
 	s.On("Run", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:      app.ID,
+		Name:    "acme-inc",
+		Release: "v1",
 		Env: map[string]string{
 			"EMPIRE_APPID":   app.ID,
 			"EMPIRE_APPNAME": "acme-inc",
@@ -335,8 +337,9 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 	e.Scheduler = s
 
 	s.On("Run", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:      app.ID,
+		Name:    "acme-inc",
+		Release: "v1",
 		Env: map[string]string{
 			"EMPIRE_APPID":   app.ID,
 			"EMPIRE_APPNAME": "acme-inc",
@@ -415,8 +418,9 @@ func TestEmpire_Set(t *testing.T) {
 	// Deploy a new image to the app.
 	img := image.Image{Repository: "remind101/acme-inc"}
 	s.On("Submit", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:      app.ID,
+		Name:    "acme-inc",
+		Release: "v1",
 		Env: map[string]string{
 			"EMPIRE_APPID":   app.ID,
 			"EMPIRE_APPNAME": "acme-inc",
@@ -461,8 +465,9 @@ func TestEmpire_Set(t *testing.T) {
 
 	// Remove the environment variable
 	s.On("Submit", &scheduler.App{
-		ID:   app.ID,
-		Name: "acme-inc",
+		ID:      app.ID,
+		Name:    "acme-inc",
+		Release: "v2",
 		Env: map[string]string{
 			"EMPIRE_APPID":   app.ID,
 			"EMPIRE_APPNAME": "acme-inc",


### PR DESCRIPTION
This just makes it easier to see what release of an app the cloudformation stack is on.

Also adds the empire version that was used to submit the cloudformation stack.