### PR TITLE
Custom::ECSTaskDefinition resource.

### DIFF
--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -96,7 +96,8 @@ func TestEmpireTemplate(t *testing.T) {
 				ID:   "1234",
 				Name: "acme-inc",
 				Env: map[string]string{
-					"ECS_UPDATES": "fast",
+					"ECS_SERVICE":         "custom",
+					"ECS_TASK_DEFINITION": "custom",
 				},
 				Processes: []*scheduler.Process{
 					{
@@ -171,6 +172,7 @@ func TestEmpireTemplate_Large(t *testing.T) {
 	buf := new(bytes.Buffer)
 
 	err := tmpl.Execute(buf, app)
+	t.Logf("Template size: %d bytes", buf.Len())
 	assert.NoError(t, err)
 	assert.Condition(t, func() bool {
 		return buf.Len() < MaxTemplateSize

--- a/scheduler/cloudformation/templates/fast.json
+++ b/scheduler/cloudformation/templates/fast.json
@@ -64,6 +64,16 @@
     }
   },
   "Resources": {
+    "AppEnv": {
+      "Properties": {
+        "Environment": {
+          "ECS_SERVICE": "custom",
+          "ECS_TASK_DEFINITION": "custom"
+        },
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::Environment"
+    },
     "CNAME": {
       "Condition": "DNSCondition",
       "Properties": {
@@ -88,6 +98,13 @@
       },
       "Type": "Custom::InstancePort",
       "Version": "1.0"
+    },
+    "webEnv": {
+      "Properties": {
+        "Environment": null,
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::Environment"
     },
     "webLoadBalancer": {
       "Properties": {
@@ -145,12 +162,12 @@
         "ServiceName": "acme-inc-web",
         "ServiceToken": "sns topic arn",
         "TaskDefinition": {
-          "Ref": "webTaskDefinition"
+          "Ref": "webTD"
         }
       },
       "Type": "Custom::ECSService"
     },
-    "webTaskDefinition": {
+    "webTD": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -176,12 +193,10 @@
             },
             "Environment": [
               {
-                "Name": "ECS_UPDATES",
-                "Value": "fast"
+                "Ref": "AppEnv"
               },
               {
-                "Name": "PORT",
-                "Value": "8080"
+                "Ref": "webEnv"
               }
             ],
             "Essential": true,
@@ -208,9 +223,20 @@
             ]
           }
         ],
+        "Family": "acme-inc-web",
+        "ServiceToken": "sns topic arn",
         "Volumes": []
       },
-      "Type": "AWS::ECS::TaskDefinition"
+      "Type": "Custom::ECSTaskDefinition"
+    },
+    "workerEnv": {
+      "Properties": {
+        "Environment": {
+          "FOO": "BAR"
+        },
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::Environment"
     },
     "workerService": {
       "Properties": {
@@ -222,12 +248,12 @@
         "ServiceName": "acme-inc-worker",
         "ServiceToken": "sns topic arn",
         "TaskDefinition": {
-          "Ref": "workerTaskDefinition"
+          "Ref": "workerTD"
         }
       },
       "Type": "Custom::ECSService"
     },
-    "workerTaskDefinition": {
+    "workerTD": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -253,12 +279,10 @@
             },
             "Environment": [
               {
-                "Name": "ECS_UPDATES",
-                "Value": "fast"
+                "Ref": "AppEnv"
               },
               {
-                "Name": "FOO",
-                "Value": "BAR"
+                "Ref": "workerEnv"
               }
             ],
             "Essential": true,
@@ -269,9 +293,11 @@
             "Ulimits": []
           }
         ],
+        "Family": "acme-inc-worker",
+        "ServiceToken": "sns topic arn",
         "Volumes": []
       },
-      "Type": "AWS::ECS::TaskDefinition"
+      "Type": "Custom::ECSTaskDefinition"
     }
   }
 }

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -199,6 +199,11 @@ func NewCustomResourceProvisioner(db *sql.DB, config client.ConfigProvider) *Cus
 				ecs:     ecs.New(config),
 				postfix: postfix,
 			},
+			"Custom::Environment": &EnvironmentResource{},
+			"Custom::ECSTaskDefinition": &ECSTaskDefinitionResource{
+				ecs:     ecs.New(config),
+				postfix: postfix,
+			},
 		},
 		client: http.DefaultClient,
 		sqs:    sqs.New(config),
@@ -255,26 +260,8 @@ func (c *CustomResourceProvisioner) Handle(message *sqs.Message) error {
 		return fmt.Errorf("error unmarshalling to cloudformation request: %v", err)
 	}
 
-	p, ok := c.Provisioners[req.ResourceType]
-	if !ok {
-		return fmt.Errorf("no provisioner for %v", req.ResourceType)
-	}
-
-	// If the provisioner defines a type for the properties, let's unmarhsal
-	// into that Go type.
-	if p, ok := p.(interface {
-		Properties() interface{}
-	}); ok {
-		req.ResourceProperties = p.Properties()
-		req.OldResourceProperties = p.Properties()
-		err = json.Unmarshal([]byte(m.Message), &req)
-		if err != nil {
-			return fmt.Errorf("error unmarshalling to cloudformation request: %v", err)
-		}
-	}
-
 	resp := NewResponseFromRequest(req)
-	resp.PhysicalResourceId, resp.Data, err = p.Provision(req)
+	resp.PhysicalResourceId, resp.Data, err = c.provision(m, req)
 	switch err {
 	case nil:
 		resp.Status = StatusSuccess
@@ -314,6 +301,27 @@ func (c *CustomResourceProvisioner) Handle(message *sqs.Message) error {
 	}
 
 	return nil
+}
+
+func (c *CustomResourceProvisioner) provision(m Message, req Request) (string, interface{}, error) {
+	p, ok := c.Provisioners[req.ResourceType]
+	if !ok {
+		return "", nil, fmt.Errorf("no provisioner for %v", req.ResourceType)
+	}
+
+	// If the provisioner defines a type for the properties, let's unmarhsal
+	// into that Go type.
+	if p, ok := p.(interface {
+		Properties() interface{}
+	}); ok {
+		req.ResourceProperties = p.Properties()
+		req.OldResourceProperties = p.Properties()
+		err := json.Unmarshal([]byte(m.Message), &req)
+		if err != nil {
+			return "", nil, fmt.Errorf("error unmarshalling to cloudformation request: %v", err)
+		}
+	}
+	return p.Provision(req)
 }
 
 // IntValue defines an int64 type that can parse integers as strings from json.

--- a/server/cloudformation/environment.go
+++ b/server/cloudformation/environment.go
@@ -1,0 +1,41 @@
+package cloudformation
+
+import "fmt"
+
+// EnvironmentProperties are the properties provided to the
+// Custom::Environment custom resource.
+type EnvironmentProperties struct {
+	Environment map[string]string
+}
+
+// EnvironmentResource is a custom resource that takes some encrypted
+// environment variables, stores them, then returns a unique identifier to
+// represent the environment.
+type EnvironmentResource struct {
+}
+
+func (p *EnvironmentResource) Properties() interface{} {
+	return &EnvironmentProperties{}
+}
+
+func (p *EnvironmentResource) Provision(req Request) (string, interface{}, error) {
+	properties := req.ResourceProperties.(*EnvironmentProperties)
+
+	switch req.RequestType {
+	case Create:
+		id, err := p.store(properties.Environment)
+		return id, nil, err
+	case Delete:
+		id := req.PhysicalResourceId
+		return id, nil, nil
+	case Update:
+		id, err := p.store(properties.Environment)
+		return id, nil, err
+	default:
+		return "", nil, fmt.Errorf("%s is not supported", req.RequestType)
+	}
+}
+
+func (p *EnvironmentResource) store(env map[string]string) (string, error) {
+	return "env", nil
+}


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/849

This is a spike into a fix for large templates for apps with lots of environment variables, and lots of processes defined in the Procfile. This drops the template size generated by the `TestEmpireTemplate_Large` test from 275kb, to 50kb.

Basically, we add two knew custom resources:

* **Custom::Environment**: A really simple resource that just takes some environment variables, and stores them, returning a physical id to reference that set of environment variables.
* **Custom::ECSTaskDefinition**: Pretty much identical to the AWS::ECS::TaskDefinition resource, but the `Environment` key takes a list of physical id's returned from a `Custom::Environment`.

Doing this means we don't have to duplicate the environment variables for each task definition. This also opens up the possibility of supporting encryption of environment variables, so that they aren't stored in plain text in the template.

**TODO**

* [ ] Storage? postgres? s3? dynamo? (Leaning towards postgres)
* [ ] Sort environment variables when using the custom task definition.
* [ ] Tests for new custom resources.
* [ ] Don't postfix the task definition?