### PR TITLE
Remove per process restart keys

### DIFF
--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -257,12 +257,6 @@ func (s *Scheduler) submit(ctx context.Context, tx *sql.Tx, app *scheduler.App, 
 			ParameterKey:   aws.String(scaleParameter(p.Type)),
 			ParameterValue: aws.String(fmt.Sprintf("%d", p.Instances)),
 		})
-
-		// FIXME: Remove this in favor of a RestartProcess method.
-		parameters = append(parameters, &cloudformation.Parameter{
-			ParameterKey:   aws.String(restartProcessParameter(p.Type)),
-			ParameterValue: aws.String(newUUID()),
-		})
 	}
 
 	_, err = s.cloudformation.DescribeStacks(&cloudformation.DescribeStacksInput{

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -64,7 +64,6 @@ func TestScheduler_Submit_NewStack(t *testing.T) {
 			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
 			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 			{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
-			{ParameterKey: aws.String("webRestartKey"), ParameterValue: aws.String("uuid")},
 		},
 		Tags: []*cloudformation.Tag{
 			{Key: aws.String("empire.app.id"), Value: aws.String("c9366591-ab68-4d49-a333-95ce5a23df68")},
@@ -192,9 +191,7 @@ func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
 					{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
 					{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 					{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
-					{ParameterKey: aws.String("webRestartKey"), ParameterValue: aws.String("uuid")},
 					{ParameterKey: aws.String("workerScale"), ParameterValue: aws.String("0")},
-					{ParameterKey: aws.String("workerRestartKey"), ParameterValue: aws.String("uuid")},
 				},
 			},
 		},
@@ -207,7 +204,6 @@ func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
 			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
 			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 			{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
-			{ParameterKey: aws.String("webRestartKey"), ParameterValue: aws.String("uuid")},
 		},
 	}).Return(&cloudformation.UpdateStackOutput{}, nil)
 

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -175,9 +175,6 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 		parameters[scaleParameter(p.Type)] = map[string]string{
 			"Type": "String",
 		}
-		parameters[restartProcessParameter(p.Type)] = map[string]string{
-			"Type": "String",
-		}
 
 		portMappings := []map[string]interface{}{}
 
@@ -309,9 +306,7 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 		for k, v := range cd.DockerLabels {
 			labels[k] = v
 		}
-		labels["cloudformation.restart-key"] = map[string]interface{}{
-			"Fn::Join": []interface{}{"-", []interface{}{map[string]string{"Ref": restartParameter}, map[string]string{"Ref": restartProcessParameter(p.Type)}}},
-		}
+		labels["cloudformation.restart-key"] = map[string]string{"Ref": restartParameter}
 
 		taskDefinition := fmt.Sprintf("%sTaskDefinition", key)
 		containerDefinition := map[string]interface{}{
@@ -484,10 +479,4 @@ func processResourceName(process string) string {
 // scale of a process.
 func scaleParameter(process string) string {
 	return fmt.Sprintf("%sScale", processResourceName(process))
-}
-
-// restartProcessParameter returns the name of the parameter used to control
-// restarting a single process.
-func restartProcessParameter(process string) string {
-	return fmt.Sprintf("%sRestartKey", processResourceName(process))
 }

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -56,13 +56,7 @@
     "RestartKey": {
       "Type": "String"
     },
-    "webRestartKey": {
-      "Type": "String"
-    },
     "webScale": {
-      "Type": "String"
-    },
-    "workerRestartKey": {
       "Type": "String"
     },
     "workerScale": {
@@ -164,17 +158,7 @@
             "Cpu": 256,
             "DockerLabels": {
               "cloudformation.restart-key": {
-                "Fn::Join": [
-                  "-",
-                  [
-                    {
-                      "Ref": "RestartKey"
-                    },
-                    {
-                      "Ref": "webRestartKey"
-                    }
-                  ]
-                ]
+                "Ref": "RestartKey"
               },
               "empire.app.process": "web"
             },
@@ -247,17 +231,7 @@
             "Cpu": 0,
             "DockerLabels": {
               "cloudformation.restart-key": {
-                "Fn::Join": [
-                  "-",
-                  [
-                    {
-                      "Ref": "RestartKey"
-                    },
-                    {
-                      "Ref": "workerRestartKey"
-                    }
-                  ]
-                ]
+                "Ref": "RestartKey"
               },
               "empire.app.process": "worker"
             },

--- a/scheduler/cloudformation/templates/fast.json
+++ b/scheduler/cloudformation/templates/fast.json
@@ -56,13 +56,7 @@
     "RestartKey": {
       "Type": "String"
     },
-    "webRestartKey": {
-      "Type": "String"
-    },
     "webScale": {
-      "Type": "String"
-    },
-    "workerRestartKey": {
       "Type": "String"
     },
     "workerScale": {
@@ -166,17 +160,7 @@
             "Cpu": 256,
             "DockerLabels": {
               "cloudformation.restart-key": {
-                "Fn::Join": [
-                  "-",
-                  [
-                    {
-                      "Ref": "RestartKey"
-                    },
-                    {
-                      "Ref": "webRestartKey"
-                    }
-                  ]
-                ]
+                "Ref": "RestartKey"
               },
               "empire.app.process": "web"
             },
@@ -243,17 +227,7 @@
             "Cpu": 0,
             "DockerLabels": {
               "cloudformation.restart-key": {
-                "Fn::Join": [
-                  "-",
-                  [
-                    {
-                      "Ref": "RestartKey"
-                    },
-                    {
-                      "Ref": "workerRestartKey"
-                    }
-                  ]
-                ]
+                "Ref": "RestartKey"
               },
               "empire.app.process": "worker"
             },

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -56,13 +56,7 @@
     "RestartKey": {
       "Type": "String"
     },
-    "apiRestartKey": {
-      "Type": "String"
-    },
     "apiScale": {
-      "Type": "String"
-    },
-    "webRestartKey": {
       "Type": "String"
     },
     "webScale": {
@@ -188,17 +182,7 @@
             "Cpu": 0,
             "DockerLabels": {
               "cloudformation.restart-key": {
-                "Fn::Join": [
-                  "-",
-                  [
-                    {
-                      "Ref": "RestartKey"
-                    },
-                    {
-                      "Ref": "apiRestartKey"
-                    }
-                  ]
-                ]
+                "Ref": "RestartKey"
               }
             },
             "Environment": [
@@ -317,17 +301,7 @@
             "Cpu": 0,
             "DockerLabels": {
               "cloudformation.restart-key": {
-                "Fn::Join": [
-                  "-",
-                  [
-                    {
-                      "Ref": "RestartKey"
-                    },
-                    {
-                      "Ref": "webRestartKey"
-                    }
-                  ]
-                ]
+                "Ref": "RestartKey"
               }
             },
             "Environment": [


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/861

We only added the per process restart keys with the idea of supporting `emp restart <process>`, but this creates too many parameters for some applications that have a lot of processes.