### PR TITLE
Annotate log streaming errors.

### DIFF
--- a/empire.go
+++ b/empire.go
@@ -666,7 +666,11 @@ func (e *Empire) ListScale(ctx context.Context, app *App) (Formation, error) {
 
 // Streamlogs streams logs from an app.
 func (e *Empire) StreamLogs(app *App, w io.Writer, duration time.Duration) error {
-	return e.LogsStreamer.StreamLogs(app, w, duration)
+	if err := e.LogsStreamer.StreamLogs(app, w, duration); err != nil {
+		return fmt.Errorf("error streaming logs: %v", err)
+	}
+
+	return nil
 }
 
 // CertsAttach attaches an SSL certificate to the app.

--- a/logs.go
+++ b/logs.go
@@ -1,6 +1,7 @@
 package empire
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -29,12 +30,12 @@ func NewKinesisLogsStreamer() *KinesisLogsStreamer {
 func (s *KinesisLogsStreamer) StreamLogs(app *App, w io.Writer, duration time.Duration) error {
 	k, err := kinesumer.NewDefault(app.ID, duration)
 	if err != nil {
-		return err
+		return fmt.Errorf("error initializing kinesumer: %v", err)
 	}
 
 	_, err = k.Begin()
 	if err != nil {
-		return err
+		return fmt.Errorf("error starting kinesumer: %v", err)
 	}
 	defer k.End()
 
@@ -42,7 +43,7 @@ func (s *KinesisLogsStreamer) StreamLogs(app *App, w io.Writer, duration time.Du
 		rec := <-k.Records()
 		msg := append(rec.Data(), '\n')
 		if _, err := w.Write(msg); err != nil {
-			return err
+			return fmt.Errorf("error writing kinesis record to log stream: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Added this while debugging issues with #863 and #864, which were ultimately caused elsewhere, but we should still be doing more of this to make errors more useful. `error: io.EOF` makes me sad.