### PR TITLE
Backwards compatability with the old emp cli

### DIFF
--- a/server/heroku/logs.go
+++ b/server/heroku/logs.go
@@ -26,7 +26,7 @@ func (h *PostLogs) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 
 	var form PostLogsForm
 	if err := Decode(r, &form); err != nil {
-		if err != "EOF" {
+		if err.Error() != "EOF" {
 			return fmt.Errorf("error decoding request: %v", err)
 		}
 	}

--- a/server/heroku/logs.go
+++ b/server/heroku/logs.go
@@ -2,6 +2,7 @@ package heroku
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -26,7 +27,9 @@ func (h *PostLogs) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 
 	var form PostLogsForm
 	if err := Decode(r, &form); err != nil {
-		if err.Error() != "EOF" {
+		// We ignore the EOF error for backwards compatability with the "emp"
+		// command that doesn't support providing a duration.
+		if err != io.EOF {
 			return fmt.Errorf("error decoding request: %v", err)
 		}
 	}

--- a/server/heroku/logs.go
+++ b/server/heroku/logs.go
@@ -1,8 +1,6 @@
 package heroku
 
 import (
-	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -26,12 +24,11 @@ func (h *PostLogs) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	var form PostLogsForm
-	if err := Decode(r, &form); err != nil {
-		// We ignore the EOF error for backwards compatability with the "emp"
-		// command that doesn't support providing a duration.
-		if err != io.EOF {
-			return fmt.Errorf("error decoding request: %v", err)
-		}
+	// We ignore the EOF error for backwards compatability with the "emp"
+	// command that doesn't support providing a duration.
+	ignoreEOF := true
+	if err := DecodeRequest(r, &form, ignoreEOF); err != nil {
+		return err
 	}
 
 	rw := streamhttp.StreamingResponseWriter(w)

--- a/server/heroku/logs.go
+++ b/server/heroku/logs.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -20,13 +21,14 @@ type PostLogsForm struct {
 func (h *PostLogs) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	a, err := findApp(ctx, h)
 	if err != nil {
-		return err
+		return fmt.Errorf("error finding app: %v", err)
 	}
 
 	var form PostLogsForm
-
 	if err := Decode(r, &form); err != nil {
-		return err
+		if err != "EOF" {
+			return fmt.Errorf("error decoding request: %v", err)
+		}
 	}
 
 	rw := streamhttp.StreamingResponseWriter(w)

--- a/server/heroku/logs.go
+++ b/server/heroku/logs.go
@@ -21,7 +21,7 @@ type PostLogsForm struct {
 func (h *PostLogs) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	a, err := findApp(ctx, h)
 	if err != nil {
-		return fmt.Errorf("error finding app: %v", err)
+		return err
 	}
 
 	var form PostLogsForm


### PR DESCRIPTION
If we get an empty body (from the old emp cli) just use the default form
values.

Fixes: https://github.com/remind101/empire/issues/863