### PR TITLE
Middleware cleanup.

### DIFF
--- a/empire.go
+++ b/empire.go
@@ -3,17 +3,14 @@ package empire // import "github.com/remind101/empire"
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"time"
 
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/fsouza/go-dockerclient"
-	"github.com/inconshreveable/log15"
 	"github.com/jinzhu/gorm"
 	"github.com/remind101/empire/pkg/dockerutil"
 	"github.com/remind101/empire/pkg/image"
 	"github.com/remind101/empire/scheduler"
-	"github.com/remind101/pkg/reporter"
 	"golang.org/x/net/context"
 )
 
@@ -21,9 +18,6 @@ var (
 	// DefaultOptions is a default Options instance that can be passed when
 	// intializing a new Empire.
 	DefaultOptions = Options{}
-
-	// DefaultReporter is the default reporter.Reporter to use.
-	DefaultReporter = reporter.NewLogReporter()
 )
 
 const (
@@ -41,13 +35,6 @@ type Options struct {
 
 // Empire is a context object that contains a collection of services.
 type Empire struct {
-	// Reporter is an reporter.Reporter that will be used to report errors to
-	// an external system.
-	reporter.Reporter
-
-	// Logger is a log15 logger that will be used for logging.
-	Logger log15.Logger
-
 	DB *DB
 	db *gorm.DB
 
@@ -88,7 +75,6 @@ type Empire struct {
 // New returns a new Empire instance.
 func New(db *DB, options Options) *Empire {
 	e := &Empire{
-		Logger:       nullLogger(),
 		LogsStreamer: logsDisabled,
 		EventStream:  NullEventStream,
 
@@ -718,13 +704,6 @@ func newJSONMessageError(err error) jsonmessage.JSONMessage {
 			Message: err.Error(),
 		},
 	}
-}
-
-func nullLogger() log15.Logger {
-	l := log15.New()
-	h := log15.StreamHandler(ioutil.Discard, log15.LogfmtFormat())
-	l.SetHandler(h)
-	return l
 }
 
 // PullAndExtract returns a ProcfileExtractor that will pull the image using the

--- a/server/cloudformation/cloudformation_test.go
+++ b/server/cloudformation/cloudformation_test.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/inconshreveable/log15"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,7 +19,6 @@ func TestCustomResourceProvisioner_Handle(t *testing.T) {
 	p := new(mockProvisioner)
 	h := new(mockHTTPClient)
 	c := &CustomResourceProvisioner{
-		Logger: nullLogger(),
 		Provisioners: map[string]Provisioner{
 			"Custom::InstancePort": p,
 		},
@@ -67,7 +67,7 @@ func TestCustomResourceProvisioner_Handle(t *testing.T) {
 
 	h.On("Do", req).Return(&http.Response{StatusCode: 200, Body: ioutil.NopCloser(new(bytes.Buffer))}, nil)
 
-	err = c.Handle(message)
+	err = c.Handle(context.Background(), message)
 	assert.NoError(t, err)
 }
 
@@ -122,11 +122,4 @@ func (m *mockSQSClient) ReceiveMessage(input *sqs.ReceiveMessageInput) (*sqs.Rec
 func (m *mockSQSClient) DeleteMessage(input *sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error) {
 	args := m.Called(input)
 	return args.Get(0).(*sqs.DeleteMessageOutput), args.Error(1)
-}
-
-func nullLogger() log15.Logger {
-	l := log15.New()
-	h := log15.StreamHandler(ioutil.Discard, log15.LogfmtFormat())
-	l.SetHandler(h)
-	return l
 }

--- a/server/heroku/heroku.go
+++ b/server/heroku/heroku.go
@@ -13,7 +13,6 @@ import (
 	"github.com/remind101/empire/pkg/heroku"
 	"github.com/remind101/empire/server/auth"
 	"github.com/remind101/pkg/httpx"
-	"github.com/remind101/pkg/httpx/middleware"
 )
 
 // The Accept header that controls the api version. See
@@ -80,7 +79,13 @@ func New(e *empire.Empire, authenticator auth.Authenticator) httpx.Handler {
 
 	api := Authenticate(r, authenticator)
 
-	return middleware.HandleError(api, errorHandler)
+	return httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		err := api.ServeHTTPContext(ctx, w, r)
+		if err != nil {
+			errorHandler(err, w, r)
+		}
+		return nil
+	})
 }
 
 // Encode json encodes v into w.

--- a/server/heroku/heroku.go
+++ b/server/heroku/heroku.go
@@ -13,6 +13,7 @@ import (
 	"github.com/remind101/empire/pkg/heroku"
 	"github.com/remind101/empire/server/auth"
 	"github.com/remind101/pkg/httpx"
+	"github.com/remind101/pkg/reporter"
 )
 
 // The Accept header that controls the api version. See
@@ -73,16 +74,13 @@ func New(e *empire.Empire, authenticator auth.Authenticator) httpx.Handler {
 	// Logs
 	r.Handle("/apps/{app}/log-sessions", &PostLogs{e}).Methods("POST") // hk log
 
-	errorHandler := func(err error, w http.ResponseWriter, r *http.Request) {
-		Error(w, err, http.StatusInternalServerError)
-	}
-
 	api := Authenticate(r, authenticator)
 
 	return httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 		err := api.ServeHTTPContext(ctx, w, r)
 		if err != nil {
-			errorHandler(err, w, r)
+			Error(w, err, http.StatusInternalServerError)
+			reporter.Report(ctx, err)
 		}
 		return nil
 	})

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -3,42 +3,65 @@ package middleware
 import (
 	"net/http"
 
+	"golang.org/x/net/context"
+
 	"github.com/inconshreveable/log15"
 	"github.com/remind101/pkg/httpx"
-	"github.com/remind101/pkg/httpx/middleware"
 	"github.com/remind101/pkg/logger"
-	"github.com/remind101/pkg/reporter"
-	"golang.org/x/net/context"
 )
 
-type CommonOpts struct {
-	// A Reporter to use to report errors and panics.
-	Reporter reporter.Reporter
-
-	// A logger to log requests to.
-	Logger log15.Logger
-}
-
-type log struct {
-	log15.Logger
-}
-
-func (l *log) New(pairs ...interface{}) logger.Logger {
-	return &log{l.Logger.New(pairs...)}
-}
-
-// Common wraps the httpx.Handler with some common middleware.
-func Common(h httpx.Handler, opts CommonOpts) http.Handler {
-	l := &log{opts.Logger}
-
-	// Recover from panics.
-	h = middleware.Recover(h, opts.Reporter)
-
-	// Add a logger to the context.
-	h = middleware.LogTo(h, func(ctx context.Context, r *http.Request) logger.Logger {
-		return l.New("request_id", httpx.RequestID(ctx))
+// Handler adapts an httpx.Handler to an http.Handler using the provided root
+// context.
+func Handler(root context.Context, h httpx.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.ServeHTTPContext(root, w, r)
 	})
+}
 
-	// Wrap the route in middleware to add a context.Context.
-	return middleware.BackgroundContext(h)
+// Common wraps the handler with common middleware to:
+//
+// * Log requests
+// * Recover from panics.
+// * Add the request id to the context.
+func Common(h httpx.Handler) httpx.Handler {
+	// Log requests to the embedded logger.
+	h = LogRequests(h)
+
+	// Prefix log messages with the request id.
+	h = PrefixRequestID(h)
+
+	// Recover from panics by reporting them to the reporter.
+	h = WithRecovery(h)
+
+	// Add information about the request to reported errors.
+	return WithRequest(h)
+}
+
+// LogRequests logs the requests to the embedded logger.
+func LogRequests(h httpx.Handler) httpx.Handler {
+	return httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		logger.Info(ctx, "request.start",
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+
+		err := h.ServeHTTPContext(ctx, w, r)
+
+		logger.Info(ctx, "request.complete")
+
+		return err
+	})
+}
+
+// PrefixRequestID adds the request as a prefix to the log15.Logger.
+func PrefixRequestID(h httpx.Handler) httpx.Handler {
+	return httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		if l, ok := logger.FromContext(ctx); ok {
+			if l, ok := l.(log15.Logger); ok {
+				ctx = logger.WithLogger(ctx, l.New("request_id", httpx.RequestID(ctx)))
+			}
+		}
+
+		return h.ServeHTTPContext(ctx, w, r)
+	})
 }

--- a/server/middleware/recovery.go
+++ b/server/middleware/recovery.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/remind101/pkg/httpx"
+	"github.com/remind101/pkg/reporter"
+	"golang.org/x/net/context"
+)
+
+// Recovery is a middleware that will recover from panics and return the error.
+type Recovery struct {
+	// handler is the wrapped httpx.Handler.
+	handler httpx.Handler
+}
+
+func WithRecovery(h httpx.Handler) *Recovery {
+	return &Recovery{
+		handler: h,
+	}
+}
+
+// ServeHTTPContext implements the httpx.Handler interface. It recovers from
+// panics and returns an error for upstream middleware to handle.
+func (h *Recovery) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
+	if _, ok := reporter.FromContext(ctx); ok {
+		defer func() {
+			if v := recover(); v != nil {
+				err = fmt.Errorf("%v", v)
+
+				if v, ok := v.(error); ok {
+					err = v
+				}
+
+				reporter.Report(ctx, err)
+
+				return
+			}
+		}()
+	}
+
+	err = h.handler.ServeHTTPContext(ctx, w, r)
+
+	return
+}

--- a/server/middleware/recovery_test.go
+++ b/server/middleware/recovery_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/remind101/pkg/httpx"
+	"github.com/remind101/pkg/reporter"
+	"golang.org/x/net/context"
+)
+
+func TestRecovery(t *testing.T) {
+	var (
+		called  bool
+		errBoom = errors.New("boom")
+	)
+
+	ctx := reporter.WithReporter(context.Background(), reporter.ReporterFunc(func(ctx context.Context, err error) error {
+		called = true
+
+		e := err.(*reporter.Error)
+
+		if e.Err != errBoom {
+			t.Fatalf("err => %v; want %v", err, errBoom)
+		}
+
+		return nil
+	}))
+
+	h := &Recovery{
+		handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			panic(errBoom)
+		}),
+	}
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", "1234")
+	resp := httptest.NewRecorder()
+
+	ctx = httpx.WithRequest(ctx, req)
+
+	defer func() {
+		if err := recover(); err != nil {
+			t.Fatal("Expected the panic to be handled.")
+		}
+	}()
+
+	err := h.ServeHTTPContext(ctx, resp, req)
+
+	if err != errBoom {
+		t.Fatalf("err => %v; want %v", err, errBoom)
+	}
+}
+
+func TestRecoveryPanicString(t *testing.T) {
+	ctx := reporter.WithReporter(context.Background(), reporter.ReporterFunc(func(ctx context.Context, err error) error {
+		return nil
+	}))
+
+	h := &Recovery{
+		handler: httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+			panic("boom")
+		}),
+	}
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	resp := httptest.NewRecorder()
+
+	defer func() {
+		if err := recover(); err != nil {
+			t.Fatal("Expected the panic to be handled.")
+		}
+	}()
+
+	err := h.ServeHTTPContext(ctx, resp, req)
+
+	if got, want := err.Error(), "boom"; got != want {
+		t.Fatalf("err => %v; want %v", got, want)
+	}
+}

--- a/server/middleware/request.go
+++ b/server/middleware/request.go
@@ -1,0 +1,25 @@
+package middleware
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+
+	"github.com/remind101/pkg/httpx"
+	"github.com/remind101/pkg/reporter"
+)
+
+// WithRequest adds information about the http.Request to reported errors.
+func WithRequest(h httpx.Handler) httpx.Handler {
+	return httpx.HandlerFunc(func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		ctx = httpx.WithRequest(ctx, r)
+
+		// Add the request to the context.
+		reporter.AddRequest(ctx, r)
+
+		// Add the request id
+		reporter.AddContext(ctx, "request_id", httpx.RequestID(ctx))
+
+		return h.ServeHTTPContext(ctx, w, r)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,6 @@ import (
 	"github.com/remind101/empire/server/auth"
 	"github.com/remind101/empire/server/github"
 	"github.com/remind101/empire/server/heroku"
-	"github.com/remind101/empire/server/middleware"
 	"github.com/remind101/pkg/httpx"
 	"golang.org/x/net/context"
 )
@@ -32,7 +31,7 @@ type Options struct {
 	}
 }
 
-func New(e *empire.Empire, options Options) http.Handler {
+func New(e *empire.Empire, options Options) httpx.Handler {
 	r := httpx.NewRouter()
 
 	if options.GitHub.Webhooks.Secret != "" {
@@ -46,16 +45,13 @@ func New(e *empire.Empire, options Options) http.Handler {
 	}
 
 	// Mount the heroku api
-	h := heroku.New(e, options.Authenticator)
-	r.Headers("Accept", heroku.AcceptHeader).Handler(h)
+	hk := heroku.New(e, options.Authenticator)
+	r.Headers("Accept", heroku.AcceptHeader).Handler(hk)
 
 	// Mount health endpoint
 	r.Handle("/health", NewHealthHandler(e))
 
-	return middleware.Common(r, middleware.CommonOpts{
-		Reporter: e.Reporter,
-		Logger:   e.Logger,
-	})
+	return r
 }
 
 // githubWebhook is a MatcherFunc that matches requests that have an

--- a/tests/cli/login_test.go
+++ b/tests/cli/login_test.go
@@ -1,7 +1,6 @@
 package cli_test
 
 import (
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -12,10 +11,9 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	e := empiretest.NewEmpire(t)
-	s := httptest.NewServer(server.New(e, server.Options{
+	s := empiretest.NewTestServer(t, nil, server.Options{
 		Authenticator: auth.StaticAuthenticator("fake", "bar", "", &empire.User{Name: "fake"}),
-	}))
+	})
 	defer s.Close()
 
 	input := "fake\nbar\n"
@@ -34,10 +32,9 @@ func TestLogin(t *testing.T) {
 }
 
 func TestLoginUnauthorized(t *testing.T) {
-	e := empiretest.NewEmpire(t)
-	s := httptest.NewServer(server.New(e, server.Options{
+	s := empiretest.NewTestServer(t, nil, server.Options{
 		Authenticator: auth.StaticAuthenticator("fake", "bar", "", &empire.User{Name: "fake"}),
-	}))
+	})
 	defer s.Close()
 
 	input := "foo\nbar\n"
@@ -56,10 +53,9 @@ func TestLoginUnauthorized(t *testing.T) {
 }
 
 func TestLoginTwoFactor(t *testing.T) {
-	e := empiretest.NewEmpire(t)
-	s := httptest.NewServer(server.New(e, server.Options{
+	s := empiretest.NewTestServer(t, nil, server.Options{
 		Authenticator: auth.StaticAuthenticator("twofactor", "bar", "code", &empire.User{Name: "fake"}),
-	}))
+	})
 	defer s.Close()
 
 	input := "twofactor\nbar\ncode\n"


### PR DESCRIPTION
This fixes an annoying issue in development, where tests that exercised the http server of Empire would silence panics.

This does a couple of things:

1. Production level middleware (logging, panic recovery, etc), is only wrapped around the server in `cmd/empire`, so `server.New` returns a clean httpx.Handler that we can test against.
2. The middleware was cleaned up, so we just create a root context.Context in `package main` that has a reporter and logger embedded, then inject this wherever it's needed (http server, and cloudformation resource provisioner).
3. The empire.Empire type no longer has `Logger` and `Reporter` fields. These were only there for the purpose of passing it to server.New, but were otherwise unused by empire core.

End result is less noisy tests, panics that actually panic, and no dependency on `pkg/httpx/middleware` (which will most likely become irrelevant with Go 1.7) hooray!