### PR TITLE
Don't set DNS parameter unless explicitly told to.

### DIFF
--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -61,7 +61,6 @@ func TestScheduler_Submit_NewStack(t *testing.T) {
 		StackName:   aws.String("acme-inc"),
 		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
 		Parameters: []*cloudformation.Parameter{
-			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
 			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 			{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
 		},
@@ -133,7 +132,6 @@ func TestScheduler_Submit_ExistingStack(t *testing.T) {
 		StackName:   aws.String("acme-inc"),
 		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
 		Parameters: []*cloudformation.Parameter{
-			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
 			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 		},
 	}).Return(&cloudformation.UpdateStackOutput{}, nil)
@@ -188,7 +186,6 @@ func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
 			{
 				StackStatus: aws.String("CREATE_COMPLETE"),
 				Parameters: []*cloudformation.Parameter{
-					{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
 					{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 					{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
 					{ParameterKey: aws.String("workerScale"), ParameterValue: aws.String("0")},
@@ -201,7 +198,6 @@ func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
 		StackName:   aws.String("acme-inc"),
 		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
 		Parameters: []*cloudformation.Parameter{
-			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
 			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 			{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
 		},

--- a/scheduler/cloudformation/migration.go
+++ b/scheduler/cloudformation/migration.go
@@ -8,6 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/remind101/empire/scheduler"
 	"github.com/remind101/empire/scheduler/ecs"
 )
@@ -129,7 +130,7 @@ func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, st
 		// Submit to cloudformation and wait for it to complete successfully.
 		// Don't make any DNS changes.
 		if err := s.cloudformation.SubmitWithOptions(ctx, app, SubmitOptions{
-			NoDNS: true,
+			NoDNS: aws.Bool(true),
 		}); err != nil {
 			return fmt.Errorf("error creating CloudFormation stack: %v", err)
 		}
@@ -148,7 +149,9 @@ func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, st
 
 		// The user may have already manually enabled the DNS change,
 		// but let's make sure.
-		if err := s.cloudformation.Submit(ctx, app); err != nil {
+		if err := s.cloudformation.SubmitWithOptions(ctx, app, SubmitOptions{
+			NoDNS: aws.Bool(false),
+		}); err != nil {
 			return fmt.Errorf("error updating CloudFormation stack: %v", err)
 		}
 

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -129,6 +129,7 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 		"DNS": map[string]string{
 			"Type":        "String",
 			"Description": "When set to `true`, CNAME's will be altered",
+			"Default":     "true",
 		},
 		restartParameter: map[string]string{
 			"Type": "String",

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -50,6 +50,7 @@
   },
   "Parameters": {
     "DNS": {
+      "Default": "true",
       "Description": "When set to `true`, CNAME's will be altered",
       "Type": "String"
     },

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -50,6 +50,7 @@
   },
   "Parameters": {
     "DNS": {
+      "Default": "true",
       "Description": "When set to `true`, CNAME's will be altered",
       "Type": "String"
     },

--- a/scheduler/cloudformation/templates/standard.json
+++ b/scheduler/cloudformation/templates/standard.json
@@ -50,6 +50,7 @@
   },
   "Parameters": {
     "DNS": {
+      "Default": "true",
       "Description": "When set to `true`, CNAME's will be altered",
       "Type": "String"
     },


### PR DESCRIPTION
This can be handy in some situations where you want to disable DNS, but still be able to make stack updates through Empire. With this change, Empire will only explicitly set the DNS parameter during step1 of the migration. Otherwise, it will use the previous parameter value.