### PR TITLE
Switch default ECS service resource to Custom::ECSService.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 **Improvements**
 
 * The Custom::ECSService custom resource now waits for newly created ECS services to stabilize [#878](https://github.com/remind101/empire/pull/878)
+* The CloudFormation backend now uses the Custom::ECSService resource instead of AWS::ECS::Service, by default [#877](https://github.com/remind101/empire/pull/877)
 
 **Bugs**
 

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -93,13 +93,13 @@ func TestEmpireTemplate(t *testing.T) {
 		},
 
 		{
-			"fast.json",
+			"standard.json",
 			&scheduler.App{
 				ID:      "1234",
 				Release: "v1",
 				Name:    "acme-inc",
 				Env: map[string]string{
-					"ECS_UPDATES": "fast",
+					"ECS_SERVICE": "standard",
 				},
 				Processes: []*scheduler.Process{
 					{

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -27,7 +27,7 @@
                 [
                   "web",
                   {
-                    "Ref": "web"
+                    "Ref": "webService"
                   }
                 ]
               ]
@@ -38,7 +38,7 @@
                 [
                   "worker",
                   {
-                    "Ref": "worker"
+                    "Ref": "workerService"
                   }
                 ]
               ]
@@ -81,28 +81,6 @@
         "Type": "CNAME"
       },
       "Type": "AWS::Route53::RecordSet"
-    },
-    "web": {
-      "Properties": {
-        "Cluster": "cluster",
-        "DesiredCount": {
-          "Ref": "webScale"
-        },
-        "LoadBalancers": [
-          {
-            "ContainerName": "web",
-            "ContainerPort": 8080,
-            "LoadBalancerName": {
-              "Ref": "webLoadBalancer"
-            }
-          }
-        ],
-        "Role": "ecsServiceRole",
-        "TaskDefinition": {
-          "Ref": "webTaskDefinition"
-        }
-      },
-      "Type": "AWS::ECS::Service"
     },
     "web8080InstancePort": {
       "Properties": {
@@ -147,6 +125,30 @@
         ]
       },
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+    },
+    "webService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "webScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "webLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "ServiceName": "acme-inc-web",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "webTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService"
     },
     "webTaskDefinition": {
       "Properties": {
@@ -208,18 +210,20 @@
       },
       "Type": "AWS::ECS::TaskDefinition"
     },
-    "worker": {
+    "workerService": {
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {
           "Ref": "workerScale"
         },
         "LoadBalancers": [],
+        "ServiceName": "acme-inc-worker",
+        "ServiceToken": "sns topic arn",
         "TaskDefinition": {
           "Ref": "workerTaskDefinition"
         }
       },
-      "Type": "AWS::ECS::Service"
+      "Type": "Custom::ECSService"
     },
     "workerTaskDefinition": {
       "Properties": {

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -27,7 +27,7 @@
                 [
                   "web",
                   {
-                    "Ref": "web"
+                    "Ref": "webService"
                   }
                 ]
               ]
@@ -38,7 +38,7 @@
                 [
                   "api",
                   {
-                    "Ref": "api"
+                    "Ref": "apiService"
                   }
                 ]
               ]
@@ -81,28 +81,6 @@
         "Type": "CNAME"
       },
       "Type": "AWS::Route53::RecordSet"
-    },
-    "api": {
-      "Properties": {
-        "Cluster": "cluster",
-        "DesiredCount": {
-          "Ref": "apiScale"
-        },
-        "LoadBalancers": [
-          {
-            "ContainerName": "api",
-            "ContainerPort": 8080,
-            "LoadBalancerName": {
-              "Ref": "apiLoadBalancer"
-            }
-          }
-        ],
-        "Role": "ecsServiceRole",
-        "TaskDefinition": {
-          "Ref": "apiTaskDefinition"
-        }
-      },
-      "Type": "AWS::ECS::Service"
     },
     "api8080InstancePort": {
       "Properties": {
@@ -172,6 +150,30 @@
       },
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
     },
+    "apiService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "apiScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "api",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "apiLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "ServiceName": "acme-inc-api",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "apiTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService"
+    },
     "apiTaskDefinition": {
       "Properties": {
         "ContainerDefinitions": [
@@ -212,28 +214,6 @@
         "Volumes": []
       },
       "Type": "AWS::ECS::TaskDefinition"
-    },
-    "web": {
-      "Properties": {
-        "Cluster": "cluster",
-        "DesiredCount": {
-          "Ref": "webScale"
-        },
-        "LoadBalancers": [
-          {
-            "ContainerName": "web",
-            "ContainerPort": 8080,
-            "LoadBalancerName": {
-              "Ref": "webLoadBalancer"
-            }
-          }
-        ],
-        "Role": "ecsServiceRole",
-        "TaskDefinition": {
-          "Ref": "webTaskDefinition"
-        }
-      },
-      "Type": "AWS::ECS::Service"
     },
     "web8080InstancePort": {
       "Properties": {
@@ -290,6 +270,30 @@
         ]
       },
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+    },
+    "webService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "webScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "webLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "ServiceName": "acme-inc-web",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "webTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService"
     },
     "webTaskDefinition": {
       "Properties": {

--- a/scheduler/cloudformation/templates/standard.json
+++ b/scheduler/cloudformation/templates/standard.json
@@ -27,7 +27,7 @@
                 [
                   "web",
                   {
-                    "Ref": "webService"
+                    "Ref": "web"
                   }
                 ]
               ]
@@ -38,7 +38,7 @@
                 [
                   "worker",
                   {
-                    "Ref": "workerService"
+                    "Ref": "worker"
                   }
                 ]
               ]
@@ -81,6 +81,28 @@
         "Type": "CNAME"
       },
       "Type": "AWS::Route53::RecordSet"
+    },
+    "web": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "webScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "webLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "TaskDefinition": {
+          "Ref": "webTaskDefinition"
+        }
+      },
+      "Type": "AWS::ECS::Service"
     },
     "web8080InstancePort": {
       "Properties": {
@@ -126,30 +148,6 @@
       },
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
     },
-    "webService": {
-      "Properties": {
-        "Cluster": "cluster",
-        "DesiredCount": {
-          "Ref": "webScale"
-        },
-        "LoadBalancers": [
-          {
-            "ContainerName": "web",
-            "ContainerPort": 8080,
-            "LoadBalancerName": {
-              "Ref": "webLoadBalancer"
-            }
-          }
-        ],
-        "Role": "ecsServiceRole",
-        "ServiceName": "acme-inc-web",
-        "ServiceToken": "sns topic arn",
-        "TaskDefinition": {
-          "Ref": "webTaskDefinition"
-        }
-      },
-      "Type": "Custom::ECSService"
-    },
     "webTaskDefinition": {
       "Properties": {
         "ContainerDefinitions": [
@@ -166,8 +164,8 @@
             },
             "Environment": [
               {
-                "Name": "ECS_UPDATES",
-                "Value": "fast"
+                "Name": "ECS_SERVICE",
+                "Value": "standard"
               },
               {
                 "Name": "PORT",
@@ -202,20 +200,18 @@
       },
       "Type": "AWS::ECS::TaskDefinition"
     },
-    "workerService": {
+    "worker": {
       "Properties": {
         "Cluster": "cluster",
         "DesiredCount": {
           "Ref": "workerScale"
         },
         "LoadBalancers": [],
-        "ServiceName": "acme-inc-worker",
-        "ServiceToken": "sns topic arn",
         "TaskDefinition": {
           "Ref": "workerTaskDefinition"
         }
       },
-      "Type": "Custom::ECSService"
+      "Type": "AWS::ECS::Service"
     },
     "workerTaskDefinition": {
       "Properties": {
@@ -233,8 +229,8 @@
             },
             "Environment": [
               {
-                "Name": "ECS_UPDATES",
-                "Value": "fast"
+                "Name": "ECS_SERVICE",
+                "Value": "standard"
               },
               {
                 "Name": "FOO",


### PR DESCRIPTION
This has been working pretty well on the apps that we've enabled it on, and the overall user experience will be better (especially in cases where rollback is necessary).

I think this should be merged before we release 0.11.0, but I don't plan on merging this until we've manually switched our applications over to Custom::ECSService, since it potentially incurs some downtime when the old ECS services are destroyed.