### PR TITLE
Issue 697

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -129,7 +129,7 @@ func (s *appsService) Restart(ctx context.Context, db *gorm.DB, opts RestartOpts
 		return s.Scheduler.Stop(ctx, opts.PID)
 	}
 
-	return s.releases.Restart(ctx, db, opts.App)
+	return s.releases.Restart(ctx, db, opts.App, opts.PTYPE)
 }
 
 func (s *appsService) Scale(ctx context.Context, db *gorm.DB, opts ScaleOpts) ([]*Process, error) {

--- a/apps.go
+++ b/apps.go
@@ -129,7 +129,7 @@ func (s *appsService) Restart(ctx context.Context, db *gorm.DB, opts RestartOpts
 		return s.Scheduler.Stop(ctx, opts.PID)
 	}
 
-	return s.releases.ReleaseApp(ctx, db, opts.App)
+	return s.releases.Restart(ctx, db, opts.App)
 }
 
 func (s *appsService) Scale(ctx context.Context, db *gorm.DB, opts ScaleOpts) ([]*Process, error) {

--- a/certs.go
+++ b/certs.go
@@ -16,7 +16,7 @@ func (s *certsService) CertsAttach(ctx context.Context, db *gorm.DB, app *App, c
 		return err
 	}
 
-	if err := s.releases.Restart(ctx, db, app); err != nil {
+	if err := s.releases.Restart(ctx, db, app, ""); err != nil {
 		if err == ErrNoReleases {
 			return nil
 		}

--- a/certs.go
+++ b/certs.go
@@ -16,7 +16,7 @@ func (s *certsService) CertsAttach(ctx context.Context, db *gorm.DB, app *App, c
 		return err
 	}
 
-	if err := s.releases.ReleaseApp(ctx, db, app); err != nil {
+	if err := s.releases.Restart(ctx, db, app); err != nil {
 		if err == ErrNoReleases {
 			return nil
 		}

--- a/empire.go
+++ b/empire.go
@@ -338,6 +338,9 @@ type RestartOpts struct {
 	// detached processes.
 	PID string
 
+	// If provided without PID, will restart all the processes of this type.
+	PTYPE string
+
 	// Commit message
 	Message string
 }
@@ -347,6 +350,7 @@ func (opts RestartOpts) Event() RestartEvent {
 		User:    opts.User.Name,
 		App:     opts.App.Name,
 		PID:     opts.PID,
+		PTYPE:   opts.PTYPE,
 		Message: opts.Message,
 		app:     opts.App,
 	}

--- a/events.go
+++ b/events.go
@@ -53,6 +53,7 @@ type RestartEvent struct {
 	User    string
 	App     string
 	PID     string
+	PTYPE   string
 	Message string
 
 	app *App

--- a/releases.go
+++ b/releases.go
@@ -141,7 +141,7 @@ func (s *releasesService) Release(ctx context.Context, release *Release) error {
 
 // Restart will find the last release for an app and submit it to the scheduler
 // to restart the app.
-func (s *releasesService) Restart(ctx context.Context, db *gorm.DB, app *App) error {
+func (s *releasesService) Restart(ctx context.Context, db *gorm.DB, app *App, ptype string) error {
 	release, err := releasesFind(db, ReleasesQuery{App: app})
 	if err != nil {
 		if err == gorm.RecordNotFound {
@@ -155,7 +155,7 @@ func (s *releasesService) Restart(ctx context.Context, db *gorm.DB, app *App) er
 		return nil
 	}
 	a := newSchedulerApp(release)
-	return s.Scheduler.Restart(ctx, a)
+	return s.Scheduler.Restart(ctx, a, ptype)
 }
 
 // These associations are always available on a Release.

--- a/releases.go
+++ b/releases.go
@@ -139,8 +139,9 @@ func (s *releasesService) Release(ctx context.Context, release *Release) error {
 	return s.Scheduler.Submit(ctx, a)
 }
 
-// ReleaseApp will find the last release for an app and release it.
-func (s *releasesService) ReleaseApp(ctx context.Context, db *gorm.DB, app *App) error {
+// Restart will find the last release for an app and submit it to the scheduler
+// to restart the app.
+func (s *releasesService) Restart(ctx context.Context, db *gorm.DB, app *App) error {
 	release, err := releasesFind(db, ReleasesQuery{App: app})
 	if err != nil {
 		if err == gorm.RecordNotFound {
@@ -153,8 +154,8 @@ func (s *releasesService) ReleaseApp(ctx context.Context, db *gorm.DB, app *App)
 	if release == nil {
 		return nil
 	}
-
-	return s.Release(ctx, release)
+	a := newSchedulerApp(release)
+	return s.Scheduler.Restart(ctx, a)
 }
 
 // These associations are always available on a Release.

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -169,6 +169,10 @@ type SubmitOptions struct {
 	NoDNS bool
 }
 
+func (s *Scheduler) Restart(ctx context.Context, app *scheduler.App) error {
+	return s.Submit(ctx, app)
+}
+
 // SubmitWithOptions submits (or updates) the CloudFormation stack for the app.
 func (s *Scheduler) SubmitWithOptions(ctx context.Context, app *scheduler.App, opts SubmitOptions) error {
 	if opts.Done == nil {

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -62,8 +62,8 @@ func TestScheduler_Submit_NewStack(t *testing.T) {
 		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
 		Parameters: []*cloudformation.Parameter{
 			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
-			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 			{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
+			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 		},
 		Tags: []*cloudformation.Tag{
 			{Key: aws.String("empire.app.id"), Value: aws.String("c9366591-ab68-4d49-a333-95ce5a23df68")},
@@ -134,7 +134,7 @@ func TestScheduler_Submit_ExistingStack(t *testing.T) {
 		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
 		Parameters: []*cloudformation.Parameter{
 			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
-			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
+			{ParameterKey: aws.String("RestartKey"), UsePreviousValue: aws.Bool(true)},
 		},
 	}).Return(&cloudformation.UpdateStackOutput{}, nil)
 
@@ -202,8 +202,8 @@ func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
 		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
 		Parameters: []*cloudformation.Parameter{
 			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
-			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
 			{ParameterKey: aws.String("webScale"), ParameterValue: aws.String("1")},
+			{ParameterKey: aws.String("RestartKey"), UsePreviousValue: aws.Bool(true)},
 		},
 	}).Return(&cloudformation.UpdateStackOutput{}, nil)
 
@@ -262,6 +262,67 @@ func TestScheduler_Submit_TemplateTooLarge(t *testing.T) {
   Template Size: 2 bytes
   Error: ValidationError: Template may not exceed 460800 bytes in size.
 caused by: `)
+
+	c.AssertExpectations(t)
+	x.AssertExpectations(t)
+}
+
+func TestScheduler_Restart(t *testing.T) {
+	db := newDB(t)
+	defer db.Close()
+
+	x := new(mockS3Client)
+	c := new(mockCloudFormationClient)
+	s := &Scheduler{
+		Template:       template.Must(template.New("t").Parse("{}")),
+		Bucket:         "bucket",
+		cloudformation: c,
+		s3:             x,
+		db:             db,
+	}
+
+	x.On("PutObject", &s3.PutObjectInput{
+		Bucket:      aws.String("bucket"),
+		Body:        bytes.NewReader([]byte("{}")),
+		Key:         aws.String("/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
+		ContentType: aws.String("application/json"),
+	}).Return(&s3.PutObjectOutput{}, nil)
+
+	c.On("ValidateTemplate", &cloudformation.ValidateTemplateInput{
+		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
+	}).Return(&cloudformation.ValidateTemplateOutput{}, nil)
+
+	c.On("DescribeStacks", &cloudformation.DescribeStacksInput{
+		StackName: aws.String("acme-inc"),
+	}).Return(&cloudformation.DescribeStacksOutput{
+		Stacks: []*cloudformation.Stack{
+			{StackStatus: aws.String("CREATE_COMPLETE")},
+		},
+	}, nil)
+
+	c.On("UpdateStack", &cloudformation.UpdateStackInput{
+		StackName:   aws.String("acme-inc"),
+		TemplateURL: aws.String("https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"),
+		Parameters: []*cloudformation.Parameter{
+			{ParameterKey: aws.String("DNS"), ParameterValue: aws.String("true")},
+			{ParameterKey: aws.String("RestartKey"), ParameterValue: aws.String("uuid")},
+		},
+	}).Return(&cloudformation.UpdateStackOutput{}, nil)
+
+	c.On("WaitUntilStackUpdateComplete", &cloudformation.DescribeStacksInput{
+		StackName: aws.String("acme-inc"),
+	}).Return(nil)
+
+	done := make(chan error)
+	err := s.SubmitWithOptions(context.Background(), &scheduler.App{
+		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
+		Name: "acme-inc",
+	}, SubmitOptions{
+		Done:    done,
+		Restart: true,
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, <-done)
 
 	c.AssertExpectations(t)
 	x.AssertExpectations(t)

--- a/scheduler/cloudformation/migration.go
+++ b/scheduler/cloudformation/migration.go
@@ -112,7 +112,11 @@ func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App) err
 }
 
 func (s *MigrationScheduler) Restart(ctx context.Context, app *scheduler.App) error {
-	return s.Submit(ctx, app)
+	b, err := s.Backend(app.ID)
+	if err != nil {
+		return err
+	}
+	return b.Restart(ctx, app)
 }
 
 // Migrate submits the app to the CloudFormation scheduler, waits for the stack

--- a/scheduler/cloudformation/migration.go
+++ b/scheduler/cloudformation/migration.go
@@ -51,7 +51,7 @@ type MigrationScheduler struct {
 	db *sql.DB
 }
 
-// NewMigrationScheduler returns a new MigrationSchedeuler instance.
+// NewMigrationScheduler returns a new MigrationScheduler instance.
 func NewMigrationScheduler(db *sql.DB, c *Scheduler, e *ecs.Scheduler) *MigrationScheduler {
 	return &MigrationScheduler{
 		db:             db,
@@ -109,6 +109,10 @@ func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App) err
 		return err
 	}
 	return b.Submit(ctx, app)
+}
+
+func (s *MigrationScheduler) Restart(ctx context.Context, app *scheduler.App) error {
+	return s.Submit(ctx, app)
 }
 
 // Migrate submits the app to the CloudFormation scheduler, waits for the stack

--- a/scheduler/cloudformation/migration.go
+++ b/scheduler/cloudformation/migration.go
@@ -111,12 +111,12 @@ func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App) err
 	return b.Submit(ctx, app)
 }
 
-func (s *MigrationScheduler) Restart(ctx context.Context, app *scheduler.App) error {
+func (s *MigrationScheduler) Restart(ctx context.Context, app *scheduler.App, ptype string) error {
 	b, err := s.Backend(app.ID)
 	if err != nil {
 		return err
 	}
-	return b.Restart(ctx, app)
+	return b.Restart(ctx, app, ptype)
 }
 
 // Migrate submits the app to the CloudFormation scheduler, waits for the stack

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -56,7 +56,13 @@
     "RestartKey": {
       "Type": "String"
     },
+    "webRestartKey": {
+      "Type": "String"
+    },
     "webScale": {
+      "Type": "String"
+    },
+    "workerRestartKey": {
       "Type": "String"
     },
     "workerScale": {
@@ -157,6 +163,9 @@
             ],
             "Cpu": 256,
             "DockerLabels": {
+              "cloudformation.process-restart-key": {
+                "Ref": "webRestartKey"
+              },
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
               },
@@ -230,6 +239,9 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
+              "cloudformation.process-restart-key": {
+                "Ref": "workerRestartKey"
+              },
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
               },

--- a/scheduler/cloudformation/templates/fast.json
+++ b/scheduler/cloudformation/templates/fast.json
@@ -56,7 +56,13 @@
     "RestartKey": {
       "Type": "String"
     },
+    "webRestartKey": {
+      "Type": "String"
+    },
     "webScale": {
+      "Type": "String"
+    },
+    "workerRestartKey": {
       "Type": "String"
     },
     "workerScale": {
@@ -159,6 +165,9 @@
             ],
             "Cpu": 256,
             "DockerLabels": {
+              "cloudformation.process-restart-key": {
+                "Ref": "webRestartKey"
+              },
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
               },
@@ -226,6 +235,9 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
+              "cloudformation.process-restart-key": {
+                "Ref": "workerRestartKey"
+              },
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
               },

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -56,7 +56,13 @@
     "RestartKey": {
       "Type": "String"
     },
+    "apiRestartKey": {
+      "Type": "String"
+    },
     "apiScale": {
+      "Type": "String"
+    },
+    "webRestartKey": {
       "Type": "String"
     },
     "webScale": {
@@ -181,6 +187,9 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
+              "cloudformation.process-restart-key": {
+                "Ref": "apiRestartKey"
+              },
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
               }
@@ -300,6 +309,9 @@
             ],
             "Cpu": 0,
             "DockerLabels": {
+              "cloudformation.process-restart-key": {
+                "Ref": "webRestartKey"
+              },
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
               }

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -208,6 +208,11 @@ func (m *Scheduler) Submit(ctx context.Context, app *scheduler.App) error {
 	return nil
 }
 
+// Restart restarts all of the processes for the app.
+func (m *Scheduler) Restart(ctx context.Context, app *scheduler.App) error {
+	return m.Submit(ctx, app)
+}
+
 // Remove removes all of the AWS resources for this app.
 func (m *Scheduler) Remove(ctx context.Context, appID string) error {
 	return m.RemoveWithOptions(ctx, appID, RemoveOptions{})

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -209,7 +209,7 @@ func (m *Scheduler) Submit(ctx context.Context, app *scheduler.App) error {
 }
 
 // Restart restarts all of the processes for the app.
-func (m *Scheduler) Restart(ctx context.Context, app *scheduler.App) error {
+func (m *Scheduler) Restart(ctx context.Context, app *scheduler.App, ptype string) error {
 	return m.Submit(ctx, app)
 }
 

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -168,7 +168,7 @@ func TestScheduler_Restart(t *testing.T) {
 		{Name: "lb-1234", InstancePort: 8080},
 	}, nil)
 
-	if err := m.Restart(context.Background(), fakeApp); err != nil {
+	if err := m.Restart(context.Background(), fakeApp, ""); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -96,6 +96,83 @@ func TestScheduler_Submit(t *testing.T) {
 	}
 }
 
+func TestScheduler_Restart(t *testing.T) {
+	h := awsutil.NewHandler([]awsutil.Cycle{
+		awsutil.Cycle{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Operation:  "AmazonEC2ContainerServiceV20141113.ListServices",
+				Body:       `{"cluster":"empire"}`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body:       `{"serviceArns":["arn:aws:ecs:us-east-1:249285743859:service/1234--web"]}`,
+			},
+		},
+
+		awsutil.Cycle{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Operation:  "AmazonEC2ContainerServiceV20141113.DescribeServices",
+				Body:       `{"cluster":"empire","services":["arn:aws:ecs:us-east-1:249285743859:service/1234--web"]}`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body:       `{"services":[{"taskDefinition":"1234--web"}]}`,
+			},
+		},
+
+		awsutil.Cycle{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Operation:  "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
+				Body:       `{"taskDefinition":"1234--web"}`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body:       `{"taskDefinition":{"containerDefinitions":[{"cpu":128,"command":["acme-inc", "web", "--port 80"],"environment":[{"name":"USER","value":"foo"},{"name":"PORT","value":"8080"}],"essential":true,"image":"remind101/acme-inc:latest","memory":128,"name":"web"}]}}`,
+			},
+		},
+
+		awsutil.Cycle{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Operation:  "AmazonEC2ContainerServiceV20141113.RegisterTaskDefinition",
+				Body:       `{"containerDefinitions":[{"cpu":128,"command":["acme-inc", "web", "--port", "80"],"environment":[{"name":"USER","value":"foo"},{"name":"PORT","value":"8080"}],"dockerLabels":{"label1":"foo","label2":"bar"},"essential":true,"image":"remind101/acme-inc:latest","memory":128,"name":"web","portMappings":[{"containerPort":8080,"hostPort":8080}]}],"family":"1234--web"}`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body:       "",
+			},
+		},
+
+		awsutil.Cycle{
+			Request: awsutil.Request{
+				RequestURI: "/",
+				Operation:  "AmazonEC2ContainerServiceV20141113.UpdateService",
+				Body:       `{"cluster":"empire","desiredCount":0,"service":"1234--web","taskDefinition":"1234--web"}`,
+			},
+			Response: awsutil.Response{
+				StatusCode: 200,
+				Body:       `{"service": {}}`,
+			},
+		},
+	})
+	m, s := newTestScheduler(h)
+	defer s.Close()
+
+	m.lb.(*mockLBManager).On("LoadBalancers", map[string]string{
+		"AppID":       "1234",
+		"ProcessType": "web",
+	}).Return([]*lb.LoadBalancer{
+		{Name: "lb-1234", InstancePort: 8080},
+	}, nil)
+
+	if err := m.Restart(context.Background(), fakeApp); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestScheduler_scale(t *testing.T) {
 	h := awsutil.NewHandler([]awsutil.Cycle{
 		awsutil.Cycle{

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -23,6 +23,10 @@ func (m *FakeScheduler) Submit(ctx context.Context, app *App) error {
 	return nil
 }
 
+func (m *FakeScheduler) Restart(ctx context.Context, app *App) error {
+	return m.Submit(ctx, app)
+}
+
 func (m *FakeScheduler) Scale(ctx context.Context, app string, ptype string, instances uint) error {
 	if a, ok := m.apps[app]; ok {
 		var process *Process

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -23,7 +23,7 @@ func (m *FakeScheduler) Submit(ctx context.Context, app *App) error {
 	return nil
 }
 
-func (m *FakeScheduler) Restart(ctx context.Context, app *App) error {
+func (m *FakeScheduler) Restart(ctx context.Context, app *App, ptype string) error {
 	return m.Submit(ctx, app)
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -129,6 +129,9 @@ type Scheduler interface {
 	// Stop stops an instance. The scheduler will automatically start a new
 	// instance.
 	Stop(ctx context.Context, instanceID string) error
+
+	// Restart restarts the processes within the App.
+	Restart(context.Context, *App) error
 }
 
 // Env merges the App environment with any environment variables provided

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -130,8 +130,8 @@ type Scheduler interface {
 	// instance.
 	Stop(ctx context.Context, instanceID string) error
 
-	// Restart restarts the processes within the App.
-	Restart(context.Context, *App) error
+	// Restart restarts the processes or a specific process within the App.
+	Restart(ctx context.Context, app *App, ptype string) error
 }
 
 // Env merges the App environment with any environment variables provided

--- a/server/heroku/heroku.go
+++ b/server/heroku/heroku.go
@@ -55,7 +55,7 @@ func New(e *empire.Empire, authenticator auth.Authenticator) httpx.Handler {
 	r.Handle("/apps/{app}/dynos", &PostProcess{e}).Methods("POST")                     // hk run
 	r.Handle("/apps/{app}/dynos", &DeleteProcesses{e}).Methods("DELETE")               // hk restart
 	r.Handle("/apps/{app}/dynos/{ptype}.{pid}", &DeleteProcesses{e}).Methods("DELETE") // hk restart web.1
-	r.Handle("/apps/{app}/dynos/{pid}", &DeleteProcesses{e}).Methods("DELETE")         // hk restart web
+	r.Handle("/apps/{app}/dynos/{either}", &DeleteProcesses{e}).Methods("DELETE")      // hk restart web|1e5a2da0-88ae-4888-8762-71d465d9c9c5
 
 	// Formations
 	r.Handle("/apps/{app}/formation", &GetFormation{e}).Methods("GET")     // hk scale -l

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"code.google.com/p/go-uuid/uuid"
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/pkg/heroku"
 	"github.com/remind101/empire/pkg/hijack"
@@ -145,9 +146,15 @@ type DeleteProcesses struct {
 func (h *DeleteProcesses) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	vars := httpx.Vars(ctx)
 	pid := vars["pid"]
-
-	if vars["ptype"] != "" {
-		return errNotImplemented("Restarting a process type is currently not implemented.")
+	ptype := vars["ptype"]
+	if vars["either"] != "" {
+		e := vars["either"]
+		u := uuid.Parse(e)
+		if u == nil {
+			ptype = e
+		} else {
+			pid = e
+		}
 	}
 
 	a, err := findApp(ctx, h)
@@ -164,6 +171,7 @@ func (h *DeleteProcesses) ServeHTTPContext(ctx context.Context, w http.ResponseW
 		User:    UserFromContext(ctx),
 		App:     a,
 		PID:     pid,
+		PTYPE:   ptype,
 		Message: m,
 	}); err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/697

- We only bump the `RestartKey` within the cloudformation scheduler on `emp restart`
- If the app can support a restart key per process (less than 25 processes), `emp restart <process type>` will do a rolling restart of the specified process type.
- `emp restart <task-id>` works as it did before, killing the process. We had talked about pulling this out into a `kill` method, but since the task definition can still exist and bring up another process in its place it really is a restart so I just left it alone.

Todos:
- [ ] If a restart key per process is not enabled, we should throw an error if you specify a process type
- [ ] Update the event message if process type is specified