### PR TITLE
Better Godocs

### DIFF
--- a/access_tokens.go
+++ b/access_tokens.go
@@ -22,13 +22,13 @@ func (t *AccessToken) IsValid() error {
 }
 
 type accessTokensService struct {
-	Secret []byte // Secret used to sign jwt tokens.
+	*Empire
 }
 
 // AccessTokensCreate "creates" the token by jwt signing it and setting the
 // Token value.
 func (s *accessTokensService) AccessTokensCreate(token *AccessToken) (*AccessToken, error) {
-	signed, err := SignToken(s.Secret, token)
+	signed, err := signToken(s.Secret, token)
 	if err != nil {
 		return token, err
 	}
@@ -39,7 +39,7 @@ func (s *accessTokensService) AccessTokensCreate(token *AccessToken) (*AccessTok
 }
 
 func (s *accessTokensService) AccessTokensFind(token string) (*AccessToken, error) {
-	at, err := ParseToken(s.Secret, token)
+	at, err := parseToken(s.Secret, token)
 	if err != nil {
 		switch err.(type) {
 		case *jwt.ValidationError:
@@ -56,15 +56,15 @@ func (s *accessTokensService) AccessTokensFind(token string) (*AccessToken, erro
 	return at, at.IsValid()
 }
 
-// SignToken jwt signs the token and adds the signature to the Token field.
-func SignToken(secret []byte, token *AccessToken) (string, error) {
+// signToken jwt signs the token and adds the signature to the Token field.
+func signToken(secret []byte, token *AccessToken) (string, error) {
 	t := accessTokenToJwt(token)
 	return t.SignedString(secret)
 }
 
-// ParseToken parses a string token, verifies it, and returns an AccessToken
+// parseToken parses a string token, verifies it, and returns an AccessToken
 // instance.
-func ParseToken(secret []byte, token string) (*AccessToken, error) {
+func parseToken(secret []byte, token string) (*AccessToken, error) {
 	t, err := jwtParse(secret, token)
 
 	if err != nil {

--- a/access_tokens.go
+++ b/access_tokens.go
@@ -8,8 +8,11 @@ import (
 
 // AccessToken represents a token that allow access to the api.
 type AccessToken struct {
+	// The encoded token.
 	Token string
-	User  *User
+
+	// The user that this AccessToken belongs to.
+	User *User
 }
 
 // IsValid returns nil if the AccessToken is valid.

--- a/access_tokens_test.go
+++ b/access_tokens_test.go
@@ -8,7 +8,7 @@ import (
 var testSecret = []byte("secret")
 
 func TestAccessTokensFind(t *testing.T) {
-	s := &accessTokensService{Secret: testSecret}
+	s := &accessTokensService{Empire: &Empire{Secret: testSecret}}
 
 	at, err := s.AccessTokensFind("")
 	if err != nil {

--- a/apps.go
+++ b/apps.go
@@ -1,7 +1,6 @@
 package empire
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -17,20 +16,13 @@ const (
 	ExposePublic  = "public"
 )
 
-var (
-	// ErrInvalidName is used to indicate that the app name is not valid.
-	ErrInvalidName = &ValidationError{
-		errors.New("An app name must be alphanumeric and dashes only, 3-30 chars in length."),
-	}
-)
-
 // NamePattern is a regex pattern that app names must conform to.
 var NamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{2,30}$`)
 
-// AppNameFromRepo generates a name from a Repo
+// appNameFromRepo generates a name from a Repo
 //
 //	remind101/r101-api => r101-api
-func AppNameFromRepo(repo string) string {
+func appNameFromRepo(repo string) string {
 	p := strings.Split(repo, "/")
 	return p[len(p)-1]
 }
@@ -102,13 +94,6 @@ func (q AppsQuery) Scope(db *gorm.DB) *gorm.DB {
 	}
 
 	return scope.Scope(db)
-}
-
-// AppID returns a scope to find an app by id.
-func AppID(id string) func(*gorm.DB) *gorm.DB {
-	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("id = ?", id)
-	}
 }
 
 type appsService struct {
@@ -195,7 +180,7 @@ func appsEnsureRepo(db *gorm.DB, app *App, repo string) error {
 // appsFindOrCreateByRepo first attempts to find an app by repo, falling back to
 // creating a new app.
 func appsFindOrCreateByRepo(db *gorm.DB, repo string) (*App, error) {
-	n := AppNameFromRepo(repo)
+	n := appNameFromRepo(repo)
 	a, err := appsFind(db, AppsQuery{Name: &n})
 	if err != nil && err != gorm.RecordNotFound {
 		return a, err

--- a/apps.go
+++ b/apps.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	ExposePrivate = "private"
-	ExposePublic  = "public"
+	exposePrivate = "private"
+	exposePublic  = "public"
 )
 
 // NamePattern is a regex pattern that app names must conform to.
@@ -27,20 +27,26 @@ func appNameFromRepo(repo string) string {
 	return p[len(p)-1]
 }
 
-// App represents an app.
+// App represents an Empire application.
 type App struct {
+	// A unique uuid that identifies the application.
 	ID string
 
+	// The name of the application.
 	Name string
 
+	// If provided, the Docker repo that this application is linked to.
+	// Deployments to Empire, which don't specify an application, will use
+	// this field to determine what app an image should be deployed to.
 	Repo *string
 
-	// Valid values are empire.ExposePrivate and empire.ExposePublic.
+	// Valid values are exposePrivate and exposePublic.
 	Exposure string
 
 	// The name of an SSL cert for the web process of this app.
 	Cert string
 
+	// The time that this application was created.
 	CreatedAt *time.Time
 }
 
@@ -58,7 +64,7 @@ func (a *App) BeforeCreate() error {
 	a.CreatedAt = &t
 
 	if a.Exposure == "" {
-		a.Exposure = ExposePrivate
+		a.Exposure = exposePrivate
 	}
 
 	return a.IsValid()

--- a/apps.go
+++ b/apps.go
@@ -64,7 +64,7 @@ func (a *App) BeforeCreate() error {
 	return a.IsValid()
 }
 
-// AppsQuery is a Scope implementation for common things to filter releases
+// AppsQuery is a scope implementation for common things to filter releases
 // by.
 type AppsQuery struct {
 	// If provided, an App ID to find.
@@ -77,23 +77,23 @@ type AppsQuery struct {
 	Repo *string
 }
 
-// Scope implements the Scope interface.
-func (q AppsQuery) Scope(db *gorm.DB) *gorm.DB {
-	var scope ComposedScope
+// scope implements the scope interface.
+func (q AppsQuery) scope(db *gorm.DB) *gorm.DB {
+	var scope composedScope
 
 	if q.ID != nil {
-		scope = append(scope, ID(*q.ID))
+		scope = append(scope, idEquals(*q.ID))
 	}
 
 	if q.Name != nil {
-		scope = append(scope, FieldEquals("name", *q.Name))
+		scope = append(scope, fieldEquals("name", *q.Name))
 	}
 
 	if q.Repo != nil {
-		scope = append(scope, FieldEquals("repo", *q.Repo))
+		scope = append(scope, fieldEquals("repo", *q.Repo))
 	}
 
-	return scope.Scope(db)
+	return scope.scope(db)
 }
 
 type appsService struct {
@@ -200,16 +200,16 @@ func appsFindOrCreateByRepo(db *gorm.DB, repo string) (*App, error) {
 }
 
 // appsFind finds a single app given the scope.
-func appsFind(db *gorm.DB, scope Scope) (*App, error) {
+func appsFind(db *gorm.DB, scope scope) (*App, error) {
 	var app App
 	return &app, first(db, scope, &app)
 }
 
 // apps finds all apps matching the scope.
-func apps(db *gorm.DB, scope Scope) ([]*App, error) {
+func apps(db *gorm.DB, scope scope) ([]*App, error) {
 	var apps []*App
 	// Default to ordering by name.
-	scope = ComposedScope{Order("name"), scope}
+	scope = composedScope{order("name"), scope}
 	return apps, find(db, scope, &apps)
 }
 

--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -86,18 +86,17 @@ func newEmpire(db *empire.DB, c *cli.Context) (*empire.Empire, error) {
 		return nil, err
 	}
 
-	e := empire.New(db, empire.Options{
-		Secret: c.String(FlagSecret),
-	})
+	e := empire.New(db)
 	e.Scheduler = scheduler
-	if logs != nil {
-		e.LogsStreamer = logs
-	}
+	e.Secret = []byte(c.String(FlagSecret))
 	e.EventStream = empire.AsyncEvents(streams)
 	e.ProcfileExtractor = empire.PullAndExtract(docker)
 	e.Environment = c.String(FlagEnvironment)
 	e.RunRecorder = runRecorder
 	e.MessagesRequired = c.Bool(FlagMessagesRequired)
+	if logs != nil {
+		e.LogsStreamer = logs
+	}
 
 	return e, nil
 }

--- a/configs.go
+++ b/configs.go
@@ -21,9 +21,9 @@ type Config struct {
 	App   *App
 }
 
-// NewConfig initializes a new config based on the old config, with the new
+// newConfig initializes a new config based on the old config, with the new
 // variables provided.
-func NewConfig(old *Config, vars Vars) *Config {
+func newConfig(old *Config, vars Vars) *Config {
 	v := mergeVars(old.Vars, vars)
 
 	return &Config{
@@ -126,7 +126,7 @@ func (s *configsService) Set(ctx context.Context, db *gorm.DB, opts SetOpts) (*C
 		return nil, err
 	}
 
-	c, err := configsCreate(db, NewConfig(old, vars))
+	c, err := configsCreate(db, newConfig(old, vars))
 	if err != nil {
 		return c, err
 	}

--- a/configs.go
+++ b/configs.go
@@ -77,7 +77,7 @@ func (v Vars) Value() (driver.Value, error) {
 	return h.Value()
 }
 
-// ConfigsQuery is a Scope implementation for common things to filter releases
+// ConfigsQuery is a scope implementation for common things to filter releases
 // by.
 type ConfigsQuery struct {
 	// If provided, returns finds the config with the given id.
@@ -87,25 +87,25 @@ type ConfigsQuery struct {
 	App *App
 }
 
-// Scope implements the Scope interface.
-func (q ConfigsQuery) Scope(db *gorm.DB) *gorm.DB {
-	var scope ComposedScope
+// scope implements the scope interface.
+func (q ConfigsQuery) scope(db *gorm.DB) *gorm.DB {
+	var scope composedScope
 
 	if q.ID != nil {
-		scope = append(scope, ID(*q.ID))
+		scope = append(scope, idEquals(*q.ID))
 	}
 
 	if q.App != nil {
-		scope = append(scope, ForApp(q.App))
+		scope = append(scope, forApp(q.App))
 	}
 
-	return scope.Scope(db)
+	return scope.scope(db)
 }
 
 // configsFind returns the first matching config.
-func configsFind(db *gorm.DB, scope Scope) (*Config, error) {
+func configsFind(db *gorm.DB, scope scope) (*Config, error) {
 	var config Config
-	scope = ComposedScope{Order("created_at desc"), scope}
+	scope = composedScope{order("created_at desc"), scope}
 	return &config, first(db, scope, &config)
 }
 

--- a/configs.go
+++ b/configs.go
@@ -14,11 +14,17 @@ import (
 
 // Config represents a collection of environment variables.
 type Config struct {
-	ID   string
+	// A unique uuid representing this Config.
+	ID string
+
+	// The environment variables in this config.
 	Vars Vars
 
+	// The id of the app that this config relates to.
 	AppID string
-	App   *App
+
+	// The app that this config relates to.
+	App *App
 }
 
 // newConfig initializes a new config based on the old config, with the new

--- a/constraints.go
+++ b/constraints.go
@@ -24,7 +24,7 @@ var (
 	DefaultConstraints = Constraints1X
 )
 
-// Constraints aliases empire.Constraints type to implement the
+// Constraints aliases the constraints.Constraints type to implement the
 // json.Unmarshaller interface.
 type Constraints constraints.Constraints
 

--- a/db.go
+++ b/db.go
@@ -65,7 +65,7 @@ func OpenDB(uri string) (*DB, error) {
 
 // MigrateUp migrates the database to the latest version of the schema.
 func (db *DB) MigrateUp() error {
-	return db.migrator.Exec(migrate.Up, Migrations...)
+	return db.migrator.Exec(migrate.Up, migrations...)
 }
 
 // Reset resets the database to a pristine state.

--- a/db_test.go
+++ b/db_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestComposedScope(t *testing.T) {
-	var scope ComposedScope
+	var scope composedScope
 
 	a, b := make(chan struct{}), make(chan struct{})
 
@@ -21,7 +21,7 @@ func TestComposedScope(t *testing.T) {
 
 	db := &gorm.DB{}
 
-	go scope.Scope(db)
+	go scope.scope(db)
 
 	select {
 	case <-a:
@@ -38,8 +38,8 @@ func TestComposedScope(t *testing.T) {
 
 // MockScope is a Scope implementation that closes the channel when it is
 // called.
-func MockScope(called chan struct{}) Scope {
-	return ScopeFunc(func(db *gorm.DB) *gorm.DB {
+func MockScope(called chan struct{}) scope {
+	return scopeFunc(func(db *gorm.DB) *gorm.DB {
 		close(called)
 		return db
 	})
@@ -47,7 +47,7 @@ func MockScope(called chan struct{}) Scope {
 
 // scopeTest is a struct for testing scopes.
 type scopeTest struct {
-	scope Scope
+	scope scope
 	sql   string
 	vars  []interface{}
 }
@@ -73,11 +73,11 @@ func (tests scopeTests) Run(t testing.TB) {
 	}
 }
 
-// conditionSql takes a Scope and generates the condition sql that gorm will use
+// conditionSql takes a scope and generates the condition sql that gorm will use
 // for the query.
-func conditionSql(scope Scope) (sql string, vars []interface{}) {
+func conditionSql(scope scope) (sql string, vars []interface{}) {
 	db, _ := gorm.Open("postgres", &gosql.DB{})
-	ds := scope.Scope(&db).NewScope(nil)
+	ds := scope.scope(&db).NewScope(nil)
 	sql = strings.TrimSpace(ds.CombinedConditionSql())
 	vars = ds.SqlVars
 	return

--- a/deployments.go
+++ b/deployments.go
@@ -16,7 +16,7 @@ type deployerService struct {
 }
 
 // deploy does the actual deployment
-func (s *deployerService) deploy(ctx context.Context, db *gorm.DB, opts DeploymentsCreateOpts) (*Release, error) {
+func (s *deployerService) deploy(ctx context.Context, db *gorm.DB, opts DeployOpts) (*Release, error) {
 	app, img := opts.App, opts.Image
 
 	// If no app is specified, attempt to find the app that relates to this
@@ -64,7 +64,7 @@ func (s *deployerService) deploy(ctx context.Context, db *gorm.DB, opts Deployme
 
 // Deploy is a thin wrapper around deploy to that adds the error to the
 // jsonmessage stream.
-func (s *deployerService) Deploy(ctx context.Context, db *gorm.DB, opts DeploymentsCreateOpts) (*Release, error) {
+func (s *deployerService) Deploy(ctx context.Context, db *gorm.DB, opts DeployOpts) (*Release, error) {
 	var msg jsonmessage.JSONMessage
 
 	r, err := s.deploy(ctx, db, opts)

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,8 @@
+// Package empire provides the core API to the Empire PaaS. This provides a
+// simple API to performing actions like creating applications, setting
+// environment variables and performing deployments.
+//
+// Consumers of this API are usually in-process control layers, like the Heroku
+// Platform API compatibility layer, and the GitHub Deployments integration,
+// which can be found under the server package.
+package empire

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,5 @@
-// Package empire provides the core API to the Empire PaaS. This provides a
-// simple API to performing actions like creating applications, setting
+// Package empire provides the core internal API to Empire. This provides a
+// simple API for performing actions like creating applications, setting
 // environment variables and performing deployments.
 //
 // Consumers of this API are usually in-process control layers, like the Heroku

--- a/domains.go
+++ b/domains.go
@@ -1,20 +1,12 @@
 package empire
 
 import (
-	"errors"
-
 	"golang.org/x/net/context"
 
 	"time"
 
 	"github.com/jinzhu/gorm"
 	"github.com/remind101/pkg/timex"
-)
-
-var (
-	ErrDomainInUse        = errors.New("Domain currently in use by another app.")
-	ErrDomainAlreadyAdded = errors.New("Domain already added to this app.")
-	ErrDomainNotFound     = errors.New("Domain could not be found.")
 )
 
 type Domain struct {

--- a/domains.go
+++ b/domains.go
@@ -74,7 +74,7 @@ func (s *domainsService) DomainsDestroy(ctx context.Context, db *gorm.DB, domain
 	return nil
 }
 
-// DomainsQuery is a Scope implementation for common things to filter releases
+// DomainsQuery is a scope implementation for common things to filter releases
 // by.
 type DomainsQuery struct {
 	// If provided, finds domains matching the given hostname.
@@ -84,29 +84,29 @@ type DomainsQuery struct {
 	App *App
 }
 
-// Scope implements the Scope interface.
-func (q DomainsQuery) Scope(db *gorm.DB) *gorm.DB {
-	var scope ComposedScope
+// scope implements the scope interface.
+func (q DomainsQuery) scope(db *gorm.DB) *gorm.DB {
+	var scope composedScope
 
 	if q.Hostname != nil {
-		scope = append(scope, FieldEquals("hostname", *q.Hostname))
+		scope = append(scope, fieldEquals("hostname", *q.Hostname))
 	}
 
 	if q.App != nil {
-		scope = append(scope, ForApp(q.App))
+		scope = append(scope, forApp(q.App))
 	}
 
-	return scope.Scope(db)
+	return scope.scope(db)
 }
 
 // domainsFind returns the first matching domain.
-func domainsFind(db *gorm.DB, scope Scope) (*Domain, error) {
+func domainsFind(db *gorm.DB, scope scope) (*Domain, error) {
 	var domain Domain
 	return &domain, first(db, scope, &domain)
 }
 
 // domains returns all domains matching the scope.
-func domains(db *gorm.DB, scope Scope) ([]*Domain, error) {
+func domains(db *gorm.DB, scope scope) ([]*Domain, error) {
 	var domains []*Domain
 	return domains, find(db, scope, &domains)
 }

--- a/empire.go
+++ b/empire.go
@@ -33,11 +33,8 @@ var (
 	}
 )
 
-// Empire provides the core API to the Empire PaaS. This provides a simple API
-// to performing actions like creating applications, setting environment
-// variables and performing deployments. Consumers of this API are usually
-// in-process control layers, like the Heroku Platform API compatibility layer,
-// and the GitHub Deployments integration.
+// Empire provides the core public API for Empire. Refer to the package
+// documentation for details.
 type Empire struct {
 	DB *DB
 	db *gorm.DB

--- a/empire.go
+++ b/empire.go
@@ -706,6 +706,8 @@ func (e *ValidationError) Error() string {
 	return e.Err.Error()
 }
 
+// MessageRequiredError is an error implementation, which is returned by Empire
+// when a commit message is required for the operation.
 type MessageRequiredError struct{}
 
 func (e *MessageRequiredError) Error() string {

--- a/empire.go
+++ b/empire.go
@@ -16,11 +16,8 @@ import (
 )
 
 const (
-	// WebPort is the default PORT to set on web processes.
-	WebPort = 8080
-
-	// WebProcessType is the process type we assume are web server processes.
-	WebProcessType = "web"
+	// webProcessType is the process type we assume are web server processes.
+	webProcessType = "web"
 )
 
 // Various errors that may be returned.
@@ -86,7 +83,7 @@ type Empire struct {
 func New(db *DB) *Empire {
 	e := &Empire{
 		LogsStreamer: logsDisabled,
-		EventStream:  NullEventStream,
+		EventStream:  nullEventStream,
 
 		DB: db,
 		db: db.DB,
@@ -731,9 +728,9 @@ func newJSONMessageError(err error) jsonmessage.JSONMessage {
 // docker client, then attempt to extract the the Procfile, or fallback to the
 // CMD directive in the Dockerfile.
 func PullAndExtract(c *dockerutil.Client) ProcfileExtractor {
-	e := MultiExtractor(
-		NewFileExtractor(c.Client),
-		NewCMDExtractor(c.Client),
+	e := multiExtractor(
+		newFileExtractor(c.Client),
+		newCMDExtractor(c.Client),
 	)
 
 	return ProcfileExtractorFunc(func(ctx context.Context, img image.Image, w io.Writer) ([]byte, error) {

--- a/empire.go
+++ b/empire.go
@@ -83,7 +83,7 @@ type Empire struct {
 func New(db *DB) *Empire {
 	e := &Empire{
 		LogsStreamer: logsDisabled,
-		EventStream:  nullEventStream,
+		EventStream:  NullEventStream,
 
 		DB: db,
 		db: db.DB,
@@ -523,9 +523,9 @@ func (e *Empire) Rollback(ctx context.Context, opts RollbackOpts) (*Release, err
 	return r, e.PublishEvent(opts.Event())
 }
 
-// DeploymentsCreateOpts represents options that can be passed when deploying to
+// DeployOpts represents options that can be passed when deploying to
 // an application.
-type DeploymentsCreateOpts struct {
+type DeployOpts struct {
 	// User the user that is triggering the deployment.
 	User *User
 
@@ -546,7 +546,7 @@ type DeploymentsCreateOpts struct {
 	Message string
 }
 
-func (opts DeploymentsCreateOpts) Event() DeployEvent {
+func (opts DeployOpts) Event() DeployEvent {
 	e := DeployEvent{
 		User:    opts.User.Name,
 		Image:   opts.Image.String(),
@@ -560,12 +560,12 @@ func (opts DeploymentsCreateOpts) Event() DeployEvent {
 	return e
 }
 
-func (opts DeploymentsCreateOpts) Validate(e *Empire) error {
+func (opts DeployOpts) Validate(e *Empire) error {
 	return e.requireMessages(opts.Message)
 }
 
 // Deploy deploys an image and streams the output to w.
-func (e *Empire) Deploy(ctx context.Context, opts DeploymentsCreateOpts) (*Release, error) {
+func (e *Empire) Deploy(ctx context.Context, opts DeployOpts) (*Release, error) {
 	if err := opts.Validate(e); err != nil {
 		return nil, err
 	}

--- a/empire_test.go
+++ b/empire_test.go
@@ -1,0 +1,24 @@
+package empire_test
+
+import (
+	"fmt"
+
+	"github.com/remind101/empire"
+)
+
+func Example() {
+	// Open a postgres connection.
+	db, _ := empire.OpenDB("postgres://localhost/empire?sslmode=disable")
+
+	// Migrate the database schema.
+	_ = db.MigrateUp()
+
+	// Initialize a new Empire instance.
+	e := empire.New(db)
+
+	// Run operations against Empire.
+	apps, _ := e.Apps(empire.AppsQuery{})
+	fmt.Println(apps)
+	// Output:
+	// []
+}

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -45,7 +45,7 @@ func NewEmpire(t testing.TB) *empire.Empire {
 		db.Debug()
 	}
 
-	e := empire.New(db, empire.DefaultOptions)
+	e := empire.New(db)
 	e.Scheduler = scheduler.NewFakeScheduler()
 	e.ProcfileExtractor = empire.ProcfileExtractorFunc(ExtractProcfile)
 	e.RunRecorder = empire.RecordTo(ioutil.Discard)

--- a/events.go
+++ b/events.go
@@ -273,8 +273,8 @@ func (fn EventStreamFunc) PublishEvent(event Event) error {
 	return fn(event)
 }
 
-// nullEventStream an events service that does nothing.
-var nullEventStream = EventStreamFunc(func(event Event) error {
+// NullEventStream an events service that does nothing.
+var NullEventStream = EventStreamFunc(func(event Event) error {
 	return nil
 })
 

--- a/events.go
+++ b/events.go
@@ -273,8 +273,8 @@ func (fn EventStreamFunc) PublishEvent(event Event) error {
 	return fn(event)
 }
 
-// NullEventStream an events service that does nothing.
-var NullEventStream = EventStreamFunc(func(event Event) error {
+// nullEventStream an events service that does nothing.
+var nullEventStream = EventStreamFunc(func(event Event) error {
 	return nil
 })
 
@@ -291,30 +291,30 @@ func (streams MultiEventStream) PublishEvent(e Event) error {
 	return result.ErrorOrNil()
 }
 
-// AsyncEventStream wraps an array of EventStreams to publish events
+// asyncEventStream wraps an array of EventStreams to publish events
 // asynchronously in a goroutine
-type AsyncEventStream struct {
-	EventStream
+type asyncEventStream struct {
+	e      EventStream
 	events chan Event
 }
 
 // AsyncEvents returns a new AsyncEventStream that will buffer upto 100 events
 // before applying backpressure.
-func AsyncEvents(e EventStream) *AsyncEventStream {
-	s := &AsyncEventStream{
-		EventStream: e,
-		events:      make(chan Event, 100),
+func AsyncEvents(e EventStream) EventStream {
+	s := &asyncEventStream{
+		e:      e,
+		events: make(chan Event, 100),
 	}
 	go s.start()
 	return s
 }
 
-func (e *AsyncEventStream) PublishEvent(event Event) error {
+func (e *asyncEventStream) PublishEvent(event Event) error {
 	e.events <- event
 	return nil
 }
 
-func (e *AsyncEventStream) start() {
+func (e *asyncEventStream) start() {
 	for event := range e.events {
 		err := e.publishEvent(event)
 		if err != nil {
@@ -323,7 +323,7 @@ func (e *AsyncEventStream) start() {
 	}
 }
 
-func (e *AsyncEventStream) publishEvent(event Event) (err error) {
+func (e *asyncEventStream) publishEvent(event Event) (err error) {
 	defer func() {
 		if v := recover(); v != nil {
 			var ok bool
@@ -334,25 +334,6 @@ func (e *AsyncEventStream) publishEvent(event Event) (err error) {
 			err = fmt.Errorf("panic: %v", v)
 		}
 	}()
-	err = e.EventStream.PublishEvent(event)
+	err = e.e.PublishEvent(event)
 	return
-}
-
-// prettyDelta is a fmt.Stringer that formats a delta by prefixing it with a `+`
-// or `-`.
-type prettyDelta struct {
-	delta int
-}
-
-// String implements the fmt.Stringer interface.
-func (d prettyDelta) String() string {
-	if d.delta > 0 {
-		return fmt.Sprintf("+%d", d.delta)
-	}
-
-	if d.delta < 0 {
-		return fmt.Sprintf("-%d", d.delta*-1)
-	}
-
-	return fmt.Sprintf("no change")
 }

--- a/extractor.go
+++ b/extractor.go
@@ -69,7 +69,7 @@ func multiExtractor(extractors ...ProcfileExtractor) ProcfileExtractor {
 			}
 
 			// Try the next one
-			if _, ok := err.(*ProcfileError); ok {
+			if _, ok := err.(*procfileError); ok {
 				continue
 			}
 
@@ -77,7 +77,7 @@ func multiExtractor(extractors ...ProcfileExtractor) ProcfileExtractor {
 			return p, err
 		}
 
-		return nil, &ProcfileError{
+		return nil, &procfileError{
 			Err: errors.New("no suitable Procfile extractor found"),
 		}
 	})
@@ -110,7 +110,7 @@ func (e *fileExtractor) Extract(_ context.Context, img image.Image, w io.Writer)
 
 	b, err := e.copyFile(c.ID, pfile)
 	if err != nil {
-		return nil, &ProcfileError{Err: err}
+		return nil, &procfileError{Err: err}
 	}
 
 	return b, nil
@@ -167,11 +167,11 @@ func (e *fileExtractor) copyFile(containerID, path string) ([]byte, error) {
 }
 
 // Example instance: Procfile doesn't exist
-type ProcfileError struct {
+type procfileError struct {
 	Err error
 }
 
-func (e *ProcfileError) Error() string {
+func (e *procfileError) Error() string {
 	return fmt.Sprintf("Procfile not found: %s", e.Err)
 }
 
@@ -196,7 +196,7 @@ func formationFromProcfile(p procfile.Procfile) (Formation, error) {
 	case procfile.ExtendedProcfile:
 		return formationFromExtendedProcfile(p)
 	default:
-		return nil, &ProcfileError{
+		return nil, &procfileError{
 			Err: errors.New("unknown Procfile format"),
 		}
 	}

--- a/extractor.go
+++ b/extractor.go
@@ -16,10 +16,9 @@ import (
 	"github.com/fsouza/go-dockerclient"
 )
 
-var (
-	// ProcfileName is the name of the Procfile file.
-	ProcfileName = "Procfile"
-)
+// Procfile is the name of the Procfile file that Empire will use to
+// determine the process formation.
+const Procfile = "Procfile"
 
 // ProcfileExtractor represents something that can extract a Procfile from an image.
 type ProcfileExtractor interface {
@@ -32,19 +31,19 @@ func (fn ProcfileExtractorFunc) Extract(ctx context.Context, image image.Image, 
 	return fn(ctx, image, w)
 }
 
-// CommandExtractor is an Extractor implementation that returns a Procfile based
+// cmdExtractor is an Extractor implementation that returns a Procfile based
 // on the CMD directive in the Dockerfile. It makes the assumption that the cmd
 // is a "web" process.
-type CMDExtractor struct {
+type cmdExtractor struct {
 	// Client is the docker client to use to pull the container image.
 	client *docker.Client
 }
 
-func NewCMDExtractor(c *docker.Client) *CMDExtractor {
-	return &CMDExtractor{client: c}
+func newCMDExtractor(c *docker.Client) *cmdExtractor {
+	return &cmdExtractor{client: c}
 }
 
-func (e *CMDExtractor) Extract(_ context.Context, img image.Image, _ io.Writer) ([]byte, error) {
+func (e *cmdExtractor) Extract(_ context.Context, img image.Image, _ io.Writer) ([]byte, error) {
 	i, err := e.client.InspectImage(img.String())
 	if err != nil {
 		return nil, err
@@ -57,9 +56,9 @@ func (e *CMDExtractor) Extract(_ context.Context, img image.Image, _ io.Writer) 
 	})
 }
 
-// MultiExtractor is an Extractor implementation that tries multiple Extractors
+// multiExtractor is an Extractor implementation that tries multiple Extractors
 // in succession until one succeeds.
-func MultiExtractor(extractors ...ProcfileExtractor) ProcfileExtractor {
+func multiExtractor(extractors ...ProcfileExtractor) ProcfileExtractor {
 	return ProcfileExtractorFunc(func(ctx context.Context, image image.Image, w io.Writer) ([]byte, error) {
 		for _, extractor := range extractors {
 			p, err := extractor.Extract(ctx, image, w)
@@ -84,19 +83,19 @@ func MultiExtractor(extractors ...ProcfileExtractor) ProcfileExtractor {
 	})
 }
 
-// FileExtractor is an implementation of the Extractor interface that extracts
+// fileExtractor is an implementation of the Extractor interface that extracts
 // the Procfile from the images WORKDIR.
-type FileExtractor struct {
+type fileExtractor struct {
 	// Client is the docker client to use to pull the container image.
 	client *docker.Client
 }
 
-func NewFileExtractor(c *docker.Client) *FileExtractor {
-	return &FileExtractor{client: c}
+func newFileExtractor(c *docker.Client) *fileExtractor {
+	return &fileExtractor{client: c}
 }
 
 // Extract implements Extractor Extract.
-func (e *FileExtractor) Extract(_ context.Context, img image.Image, w io.Writer) ([]byte, error) {
+func (e *fileExtractor) Extract(_ context.Context, img image.Image, w io.Writer) ([]byte, error) {
 	c, err := e.createContainer(img)
 	if err != nil {
 		return nil, err
@@ -119,7 +118,7 @@ func (e *FileExtractor) Extract(_ context.Context, img image.Image, w io.Writer)
 
 // procfile returns the path to the Procfile. If the container has a WORKDIR
 // set, then this will return a path to the Procfile within that directory.
-func (e *FileExtractor) procfile(id string) (string, error) {
+func (e *fileExtractor) procfile(id string) (string, error) {
 	p := ""
 
 	c, err := e.client.InspectContainer(id)
@@ -131,11 +130,11 @@ func (e *FileExtractor) procfile(id string) (string, error) {
 		p = c.Config.WorkingDir
 	}
 
-	return path.Join(p, ProcfileName), nil
+	return path.Join(p, Procfile), nil
 }
 
 // createContainer creates a new docker container for the given docker image.
-func (e *FileExtractor) createContainer(img image.Image) (*docker.Container, error) {
+func (e *fileExtractor) createContainer(img image.Image) (*docker.Container, error) {
 	return e.client.CreateContainer(docker.CreateContainerOptions{
 		Config: &docker.Config{
 			Image: img.String(),
@@ -144,14 +143,14 @@ func (e *FileExtractor) createContainer(img image.Image) (*docker.Container, err
 }
 
 // removeContainer removes a container by its ID.
-func (e *FileExtractor) removeContainer(containerID string) error {
+func (e *fileExtractor) removeContainer(containerID string) error {
 	return e.client.RemoveContainer(docker.RemoveContainerOptions{
 		ID: containerID,
 	})
 }
 
 // copyFile copies a file from a container.
-func (e *FileExtractor) copyFile(containerID, path string) ([]byte, error) {
+func (e *fileExtractor) copyFile(containerID, path string) ([]byte, error) {
 	var buf bytes.Buffer
 	if err := e.client.CopyFromContainer(docker.CopyFromContainerOptions{
 		Container:    containerID,

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -22,7 +22,7 @@ func TestCMDExtractor(t *testing.T) {
 	c, s := newTestDockerClient(t, api)
 	defer s.Close()
 
-	e := CMDExtractor{
+	e := cmdExtractor{
 		client: c,
 	}
 
@@ -63,7 +63,7 @@ func TestProcfileExtractor(t *testing.T) {
 	c, s := newTestDockerClient(t, api)
 	defer s.Close()
 
-	e := FileExtractor{
+	e := fileExtractor{
 		client: c,
 	}
 
@@ -104,9 +104,9 @@ func TestProcfileFallbackExtractor(t *testing.T) {
 	c, s := newTestDockerClient(t, api)
 	defer s.Close()
 
-	e := MultiExtractor(
-		NewFileExtractor(c),
-		NewCMDExtractor(c),
+	e := multiExtractor(
+		newFileExtractor(c),
+		newCMDExtractor(c),
 	)
 
 	got, err := e.Extract(nil, image.Image{

--- a/migrations.go
+++ b/migrations.go
@@ -550,5 +550,5 @@ ALTER TABLE apps ADD COLUMN exposure TEXT NOT NULL default 'private'`,
 // latestSchema returns the schema version that this version of Empire should be
 // using.
 func latestSchema() int {
-	return Migrations[len(Migrations)-1].ID
+	return migrations[len(migrations)-1].ID
 }

--- a/migrations.go
+++ b/migrations.go
@@ -10,7 +10,7 @@ import (
 	"github.com/remind101/migrate"
 )
 
-var Migrations = []migrate.Migration{
+var migrations = []migrate.Migration{
 	{
 		ID: 1,
 		Up: migrate.Queries([]string{

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -15,16 +15,16 @@ func TestMigrations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = db.migrator.Exec(migrate.Up, Migrations...)
+	err = db.migrator.Exec(migrate.Up, migrations...)
 	assert.NoError(t, err)
 
 	err = db.Reset()
 	assert.NoError(t, err)
 
-	err = db.migrator.Exec(migrate.Down, Migrations...)
+	err = db.migrator.Exec(migrate.Down, migrations...)
 	assert.NoError(t, err)
 
-	err = db.migrator.Exec(migrate.Up, Migrations...)
+	err = db.migrator.Exec(migrate.Up, migrations...)
 	assert.NoError(t, err)
 }
 

--- a/processes.go
+++ b/processes.go
@@ -16,12 +16,11 @@ var DefaultQuantities = map[string]int{
 	"web": 1,
 }
 
-// Command represents the actual shell command that gets executed for a given
-// ProcessType.
+// Command represents a command and it's arguments. For example:
 type Command []string
 
 // ParseCommand parses a string into a Command, taking quotes and other shell
-// words into account.
+// words into account. For example:
 func ParseCommand(command string) (Command, error) {
 	return shellwords.Parse(command)
 }

--- a/processes.go
+++ b/processes.go
@@ -67,11 +67,20 @@ func (c Command) String() string {
 
 // Process holds configuration information about a Process.
 type Process struct {
-	Command  Command              `json:"Command,omitempty"`
-	Quantity int                  `json:"Quantity,omitempty"`
-	Memory   constraints.Memory   `json:"Memory,omitempty"`
+	// Command is the command to run.
+	Command Command `json:"Command,omitempty"`
+
+	// Quantity is the desired number of instances of this process.
+	Quantity int `json:"Quantity,omitempty"`
+
+	// The memory constraints, in bytes.
+	Memory constraints.Memory `json:"Memory,omitempty"`
+
+	// The amount of CPU share to give.
 	CPUShare constraints.CPUShare `json:"CPUShare,omitempty"`
-	Nproc    constraints.Nproc    `json:"Nproc,omitempty"`
+
+	// The allow number of unix processes within the container.
+	Nproc constraints.Nproc `json:"Nproc,omitempty"`
 }
 
 // Constraints returns a constraints.Constraints from this Process definition.

--- a/processes_test.go
+++ b/processes_test.go
@@ -1,6 +1,7 @@
 package empire
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,4 +104,20 @@ func TestNewFormation(t *testing.T) {
 		f := tt.f.Merge(tt.other)
 		assert.Equal(t, tt.expected, f)
 	}
+}
+
+func ExampleCommand() {
+	cmd := Command{"/bin/ls", "-h"}
+	fmt.Println(cmd)
+}
+
+func ExampleParseCommand() {
+	cmd1, _ := ParseCommand(`/bin/ls -h`)
+	cmd2, _ := ParseCommand(`/bin/echo 'hello world'`)
+	fmt.Printf("%#v\n", cmd1)
+	fmt.Printf("%#v\n", cmd2)
+	// Output:
+	// empire.Command{"/bin/ls", "-h"}
+	// empire.Command{"/bin/echo", "hello world"}
+
 }

--- a/procfile/procfile.go
+++ b/procfile/procfile.go
@@ -1,3 +1,5 @@
+// Package procfile provides methods for parsing standard and extended
+// Procfiles.
 package procfile
 
 import (

--- a/releases.go
+++ b/releases.go
@@ -39,7 +39,7 @@ func (r *Release) BeforeCreate() error {
 	return nil
 }
 
-// ReleasesQuery is a Scope implementation for common things to filter releases
+// ReleasesQuery is a scope implementation for common things to filter releases
 // by.
 type ReleasesQuery struct {
 	// If provided, an app to filter by.
@@ -52,21 +52,21 @@ type ReleasesQuery struct {
 	Range headerutil.Range
 }
 
-// Scope implements the Scope interface.
-func (q ReleasesQuery) Scope(db *gorm.DB) *gorm.DB {
-	var scope ComposedScope
+// scope implements the scope interface.
+func (q ReleasesQuery) scope(db *gorm.DB) *gorm.DB {
+	var scope composedScope
 
 	if app := q.App; app != nil {
-		scope = append(scope, FieldEquals("app_id", app.ID))
+		scope = append(scope, fieldEquals("app_id", app.ID))
 	}
 
 	if version := q.Version; version != nil {
-		scope = append(scope, FieldEquals("version", *version))
+		scope = append(scope, fieldEquals("version", *version))
 	}
 
-	scope = append(scope, Range(q.Range.WithDefaults(q.DefaultRange())))
+	scope = append(scope, inRange(q.Range.WithDefaults(q.DefaultRange())))
 
-	return scope.Scope(db)
+	return scope.scope(db)
 }
 
 // DefaultRange returns the default headerutil.Range used if values aren't
@@ -155,13 +155,13 @@ func (s *releasesService) ReleaseApp(ctx context.Context, db *gorm.DB, app *App)
 }
 
 // These associations are always available on a Release.
-var releasesPreload = Preload("App", "Config", "Slug")
+var releasesPreload = preload("App", "Config", "Slug")
 
 // releasesFind returns the first matching release.
-func releasesFind(db *gorm.DB, scope Scope) (*Release, error) {
+func releasesFind(db *gorm.DB, scope scope) (*Release, error) {
 	var release Release
 
-	scope = ComposedScope{releasesPreload, scope}
+	scope = composedScope{releasesPreload, scope}
 	if err := first(db, scope, &release); err != nil {
 		return &release, err
 	}
@@ -170,9 +170,9 @@ func releasesFind(db *gorm.DB, scope Scope) (*Release, error) {
 }
 
 // releases returns all releases matching the scope.
-func releases(db *gorm.DB, scope Scope) ([]*Release, error) {
+func releases(db *gorm.DB, scope scope) ([]*Release, error) {
 	var releases []*Release
-	scope = ComposedScope{releasesPreload, scope}
+	scope = composedScope{releasesPreload, scope}
 	return releases, find(db, scope, &releases)
 }
 

--- a/releases.go
+++ b/releases.go
@@ -1,7 +1,6 @@
 package empire
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -11,8 +10,6 @@ import (
 	"github.com/remind101/pkg/timex"
 	"golang.org/x/net/context"
 )
-
-var ErrNoReleases = errors.New("no releases")
 
 // Release is a combination of a Config and a Slug, which form a deployable
 // release.

--- a/releases.go
+++ b/releases.go
@@ -314,12 +314,12 @@ func environment(vars Vars) map[string]string {
 
 func processExposure(app *App, process string) *scheduler.Exposure {
 	// For now, only the `web` process can be exposed.
-	if process != WebProcessType {
+	if process != webProcessType {
 		return nil
 	}
 
 	exposure := &scheduler.Exposure{
-		External: app.Exposure == ExposePublic,
+		External: app.Exposure == exposePublic,
 	}
 
 	switch app.Cert {

--- a/releases.go
+++ b/releases.go
@@ -12,24 +12,43 @@ import (
 )
 
 // Release is a combination of a Config and a Slug, which form a deployable
-// release.
+// release. Releases are generally considered immutable, the only operation that
+// changes a release is when altering the Quantity or Constraints inside the
+// Formation.
 type Release struct {
-	ID      string
+	// A unique uuid to identify this release.
+	ID string
+
+	// An auto incremented ID for this release, scoped to the application.
 	Version int
 
+	// The id of the application that this release relates to.
 	AppID string
-	App   *App
 
+	// The application that this release relates to.
+	App *App
+
+	// The id of the config that this release uses.
 	ConfigID string
-	Config   *Config
 
+	// The config that this release uses.
+	Config *Config
+
+	// The id of the slug that this release uses.
 	SlugID string
-	Slug   *Slug
 
+	// The Slug that this release uses.
+	Slug *Slug
+
+	// The process formation to use.
 	Formation Formation
 
+	// A description for the release. Usually contains the reason for why
+	// the release was created (e.g. deployment, config changes, etc).
 	Description string
-	CreatedAt   *time.Time
+
+	// The time that this release was created.
+	CreatedAt *time.Time
 }
 
 // BeforeCreate sets created_at before inserting.

--- a/scheduler/ecs/lb/dns.go
+++ b/scheduler/ecs/lb/dns.go
@@ -1,7 +1,6 @@
 package lb
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -9,9 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/route53"
 )
-
-// errHostedZone is returned when the hosted zone is not found.
-var errHostedZone = errors.New("hosted zone not found, unable to update records")
 
 // Nameserver represents a service for creating dns records.
 type Nameserver interface {

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -1,3 +1,5 @@
+// Package cloudformation provides a server for the CloudFormation interface to
+// Empire.
 package cloudformation
 
 import (

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -27,7 +27,7 @@ func (fn DeployerFunc) Deploy(ctx context.Context, event events.Deployment, w io
 
 // empire mocks the Empire interface we use.
 type empireClient interface {
-	Deploy(context.Context, empire.DeploymentsCreateOpts) (*empire.Release, error)
+	Deploy(context.Context, empire.DeployOpts) (*empire.Release, error)
 }
 
 // EmpireDeployer is a deployer implementation that uses the Deploy method in
@@ -56,7 +56,7 @@ func (d *EmpireDeployer) Deploy(ctx context.Context, event events.Deployment, w 
 	// stream.
 	p := dockerutil.DecodeJSONMessageStream(w)
 
-	_, err = d.empire.Deploy(ctx, empire.DeploymentsCreateOpts{
+	_, err = d.empire.Deploy(ctx, empire.DeployOpts{
 		Image:  img,
 		Output: p,
 		User:   &empire.User{Name: event.Deployment.Creator.Login},

--- a/server/github/deployer_test.go
+++ b/server/github/deployer_test.go
@@ -28,7 +28,7 @@ func TestEmpireDeployer_Deploy(t *testing.T) {
 
 	b := new(bytes.Buffer)
 
-	e.On("Deploy", empire.DeploymentsCreateOpts{
+	e.On("Deploy", empire.DeployOpts{
 		User: &empire.User{Name: "ejholmes"},
 		Image: image.Image{
 			Repository: "remind101/acme-inc",
@@ -51,7 +51,7 @@ type mockEmpire struct {
 	mock.Mock
 }
 
-func (m *mockEmpire) Deploy(ctx context.Context, opts empire.DeploymentsCreateOpts) (*empire.Release, error) {
+func (m *mockEmpire) Deploy(ctx context.Context, opts empire.DeployOpts) (*empire.Release, error) {
 	w := opts.Output
 	if err := dockerutil.FakePull(image.Image{Repository: "remind101/acme-inc", Tag: "latest"}, w); err != nil {
 		panic(err)

--- a/server/github/github.go
+++ b/server/github/github.go
@@ -1,3 +1,5 @@
+// Package github provides an http.Handler implementation that allows Empire to
+// handle GitHub Deployments.
 package github
 
 import (

--- a/server/heroku/apps.go
+++ b/server/heroku/apps.go
@@ -95,7 +95,7 @@ func (h *DeployApp) ServeHTTPContext(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	opts, err := newDeploymentsCreateOpts(ctx, w, r)
+	opts, err := newDeployOpts(ctx, w, r)
 	opts.App = a
 	if err != nil {
 		return err

--- a/server/heroku/deployments.go
+++ b/server/heroku/deployments.go
@@ -22,7 +22,7 @@ type PostDeployForm struct {
 
 // ServeHTTPContext implements the Handler interface.
 func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
-	opts, err := newDeploymentsCreateOpts(ctx, w, req)
+	opts, err := newDeployOpts(ctx, w, req)
 	if err != nil {
 		return err
 	}
@@ -33,7 +33,7 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 	return nil
 }
 
-func newDeploymentsCreateOpts(ctx context.Context, w http.ResponseWriter, req *http.Request) (*empire.DeploymentsCreateOpts, error) {
+func newDeployOpts(ctx context.Context, w http.ResponseWriter, req *http.Request) (*empire.DeployOpts, error) {
 	var form PostDeployForm
 
 	if err := Decode(req, &form); err != nil {
@@ -51,7 +51,7 @@ func newDeploymentsCreateOpts(ctx context.Context, w http.ResponseWriter, req *h
 		form.Image.Tag = "latest"
 	}
 
-	opts := empire.DeploymentsCreateOpts{
+	opts := empire.DeployOpts{
 		User:    UserFromContext(ctx),
 		Image:   form.Image,
 		Output:  streamhttp.StreamingResponseWriter(w),

--- a/server/heroku/heroku.go
+++ b/server/heroku/heroku.go
@@ -1,3 +1,5 @@
+// Package heroku provides a Heroku Platform API compatible http.Handler
+// implementation for Empire.
 package heroku
 
 import (

--- a/server/server.go
+++ b/server/server.go
@@ -1,3 +1,6 @@
+// Package server provides an http.Handler implementation that includes the
+// Heroku Platform API compatibility layer, GitHub Deployments integration and a
+// simple health check.
 package server
 
 import (

--- a/slugs.go
+++ b/slugs.go
@@ -11,8 +11,13 @@ import (
 
 // Slug represents a container image with the extracted ProcessType.
 type Slug struct {
-	ID       string
-	Image    image.Image
+	// A unique uuid that identifies this slug.
+	ID string
+
+	// The Docker image that this slug is for.
+	Image image.Image
+
+	// The raw Procfile that was extracted from the Docker image.
 	Procfile []byte
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -11,11 +11,22 @@ import (
 
 // Task represents a running process.
 type Task struct {
-	Name        string
-	Type        string
-	Command     Command
-	State       string
-	UpdatedAt   time.Time
+	// The name of the task.
+	Name string
+
+	// The name of the process that this task is for.
+	Type string
+
+	// The command that this task is running.
+	Command Command
+
+	// The state of the task.
+	State string
+
+	// The time that the state was recorded.
+	UpdatedAt time.Time
+
+	// The constraints of the Process.
 	Constraints Constraints
 }
 

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -134,7 +134,7 @@ func TestEmpire_Deploy(t *testing.T) {
 		},
 	}).Return(nil)
 
-	_, err = e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
 		Output: ioutil.Discard,
@@ -155,7 +155,7 @@ func TestEmpire_Deploy_ImageNotFound(t *testing.T) {
 
 	// Deploying an image to an app that doesn't exist will create a new
 	// app.
-	_, err := e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+	_, err := e.Deploy(context.Background(), empire.DeployOpts{
 		User:   &empire.User{Name: "ejholmes"},
 		Output: ioutil.Discard,
 		Image:  image.Image{Repository: "remind101/acme-inc"},
@@ -186,7 +186,7 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 	user := &empire.User{Name: "ejholmes"}
 
 	// Create the first release for this app.
-	r, err := e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+	r, err := e.Deploy(context.Background(), empire.DeployOpts{
 		User:   user,
 		Output: ioutil.Discard,
 		Image:  image.Image{Repository: "remind101/acme-inc"},
@@ -214,7 +214,7 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 
 	v2Done := make(chan struct{})
 	go func() {
-		r, err = e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+		r, err = e.Deploy(context.Background(), empire.DeployOpts{
 			User:   user,
 			Output: ioutil.Discard,
 			Image:  image.Image{Repository: "remind101/acme-inc", Tag: "v2"},
@@ -226,7 +226,7 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 
 	<-v2Started
 
-	r, err = e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+	r, err = e.Deploy(context.Background(), empire.DeployOpts{
 		User:   user,
 		Output: ioutil.Discard,
 		Image:  image.Image{Repository: "remind101/acme-inc", Tag: "v3"},
@@ -251,7 +251,7 @@ func TestEmpire_Run(t *testing.T) {
 	assert.NoError(t, err)
 
 	img := image.Image{Repository: "remind101/acme-inc"}
-	_, err = e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
 		Output: ioutil.Discard,
@@ -325,7 +325,7 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 	assert.NoError(t, err)
 
 	img := image.Image{Repository: "remind101/acme-inc"}
-	_, err = e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
 		Output: ioutil.Discard,
@@ -455,7 +455,7 @@ func TestEmpire_Set(t *testing.T) {
 		},
 	}).Once().Return(nil)
 
-	_, err = e.Deploy(context.Background(), empire.DeploymentsCreateOpts{
+	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
 		Output: ioutil.Discard,

--- a/users.go
+++ b/users.go
@@ -2,7 +2,10 @@ package empire
 
 // User represents a user of Empire.
 type User struct {
-	Name        string `json:"name"`
+	// Name is the users username.
+	Name string `json:"name"`
+
+	// GitHubToken is a GitHub access token.
 	GitHubToken string `json:"-"`
 }
 

--- a/users.go
+++ b/users.go
@@ -1,9 +1,5 @@
 package empire
 
-import "errors"
-
-var ErrUserName = errors.New("Name is required")
-
 // User represents a user of Empire.
 type User struct {
 	Name        string `json:"name"`

--- a/version.go
+++ b/version.go
@@ -1,3 +1,4 @@
 package empire
 
+// The version of Empire.
 const Version = "0.10.1"


### PR DESCRIPTION
This is just some general house keeping, mostly geared at improving the [generated package documentation](https://godoc.org/github.com/remind101/empire)

This looks big, but it's primarily cosmetic; there shouldn't be any functional/behavior changes. In a nutshell:

* Various types that were previously unnecessarily exported in `package empire` are now private (e.g. `Scope`, `Migrations`, etc).
* `package empire` has some improved top level documentation that describes the core internal Empire API.
* Some inconsistently named structs were renamed (DeploymentsCreateOpts -> DeployOpts).
* Some exported types/functions got some example tests added, which show up in godocs.

If you wanna see the new godocs, you can run `godoc -http=":6060"` and visit <http://localhost:6060/pkg/github.com/remind101/empire>.

