### PR TITLE
Add schema version check to db health check.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * The Custom::ECSService custom resource now waits for newly created ECS services to stabilize [#878](https://github.com/remind101/empire/pull/878)
 * The CloudFormation backend now uses the Custom::ECSService resource instead of AWS::ECS::Service, by default [#877](https://github.com/remind101/empire/pull/877)
+* The database schema version is now checked at boot, as well as in the http health checks. [#893](https://github.com/remind101/empire/pull/893)
 
 **Bugs**
 

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -45,6 +45,8 @@ func runServer(c *cli.Context) {
 		}
 
 		log.Fatal(err)
+	} else {
+		log.Println("Health checks passed")
 	}
 
 	if c.String(FlagCustomResourcesQueue) != "" {

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -37,6 +37,16 @@ func runServer(c *cli.Context) {
 		log.Fatal(err)
 	}
 
+	// Do a preliminary health check to make sure everything is good at
+	// boot.
+	if err := e.IsHealthy(); err != nil {
+		if err, ok := err.(*empire.IncompatibleSchemaError); ok {
+			log.Fatal(fmt.Errorf("%v. You can resolve this error by running the migrations with `empire migrate` or with the `--automigrate` flag", err))
+		}
+
+		log.Fatal(err)
+	}
+
 	if c.String(FlagCustomResourcesQueue) != "" {
 		p, err := newCloudFormationCustomResourceProvisioner(db, c)
 		if err != nil {

--- a/empire.go
+++ b/empire.go
@@ -689,7 +689,7 @@ func (e *Empire) Reset() error {
 
 // IsHealthy returns true if Empire is healthy, which means it can connect to
 // the services it depends on.
-func (e *Empire) IsHealthy() bool {
+func (e *Empire) IsHealthy() error {
 	return e.DB.IsHealthy()
 }
 

--- a/migrations.go
+++ b/migrations.go
@@ -546,3 +546,9 @@ ALTER TABLE apps ADD COLUMN exposure TEXT NOT NULL default 'private'`,
 		}),
 	},
 }
+
+// latestSchema returns the schema version that this version of Empire should be
+// using.
+func latestSchema() int {
+	return Migrations[len(Migrations)-1].ID
+}

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -27,3 +27,7 @@ func TestMigrations(t *testing.T) {
 	err = db.migrator.Exec(migrate.Up, Migrations...)
 	assert.NoError(t, err)
 }
+
+func TestLatestSchema(t *testing.T) {
+	assert.Equal(t, 17, latestSchema())
+}


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/891

This adds a check to the db health check that checks that the schema version matches what the running version of Empire expects. This means:

1. If you're in the process of upgrading to a new version of Empire, once the migrations are complete, older versions of Empire will start failing health checks and get taken out of the load balancer (assuming you have Empire behind a load balancer and are using the `/health` endpoint).
2. If you try to start `empire server` with an incompatible database schema, you'll get an error message:

    ```console
$ ./build/empire server
2016/06/23 12:19:23 Streaming logs are disabled
2016/06/23 12:19:23 Using Stdout run logs backend:
2016/06/23 12:19:23 expected database schema to be at version 17, but was 18. You can resolve this error by running the migrations with `empire migrate` or with the `--automigrate` flag
````