### PR TITLE
Enable race detector (and fix flaky test)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build: Dockerfile
 ci: cmds test vet
 
 test: build/emp
-	go test $(shell go list ./... | grep -v /vendor/)
+	go test -race $(shell go list ./... | grep -v /vendor/)
 
 vet:
 	go vet $(shell go list ./... | grep -v /vendor/)

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -214,7 +214,7 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 
 	v2Done := make(chan struct{})
 	go func() {
-		r, err = e.Deploy(context.Background(), empire.DeployOpts{
+		r, err := e.Deploy(context.Background(), empire.DeployOpts{
 			User:   user,
 			Output: ioutil.Discard,
 			Image:  image.Image{Repository: "remind101/acme-inc", Tag: "v2"},


### PR DESCRIPTION
I could have sworn we enabled this a long time ago, but I guess not. Anyway, it caught the concurrent deployment test, which has been flaky in the past.