### PR TITLE
Cache task definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 **Performance**
 
 * Performance of creating/updating/deleting custom resources in the CloudFormation backend has been improved. [#942](https://github.com/remind101/empire/pull/942)
+* ECS Task Definitions are now cached in memory for improved `emp ps` performance. [#902](https://github.com/remind101/empire/pull/902)
 
 **Security**
 

--- a/scheduler/cloudformation/clients.go
+++ b/scheduler/cloudformation/clients.go
@@ -1,0 +1,61 @@
+package cloudformation
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/pmylund/go-cache"
+	"github.com/remind101/empire/pkg/arn"
+)
+
+var (
+	defaultExpiration = 30 * time.Minute
+	defaultPurge      = 30 * time.Second // Purge items every 30 seconds.
+)
+
+// cacher duck types the go-cache interface.
+type cacher interface {
+	Set(k string, x interface{}, d time.Duration)
+	Get(k string) (interface{}, bool)
+}
+
+// cachingECSClient wraps an ecsClient to perform some performance
+// optimizations, by taking advantage of the fact that task definitions are
+// essentially immutable and can be cached forever.
+type cachingECSClient struct {
+	ecsClient
+
+	// cache of task definitions
+	taskDefinitions cacher
+}
+
+// ecsWithCaching wraps an ecs.ECS client with caching.
+func ecsWithCaching(ecs *ecs.ECS) *cachingECSClient {
+	return &cachingECSClient{
+		ecsClient:       ecs,
+		taskDefinitions: cache.New(defaultExpiration, defaultPurge),
+	}
+}
+
+// DescribeTaskDefinition will use the task definition from cache if provided
+// with a task definition ARN.
+func (c *cachingECSClient) DescribeTaskDefinition(input *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
+	if _, err := arn.Parse(*input.TaskDefinition); err != nil {
+		return c.ecsClient.DescribeTaskDefinition(input)
+	}
+
+	if v, ok := c.taskDefinitions.Get(*input.TaskDefinition); ok {
+		return &ecs.DescribeTaskDefinitionOutput{
+			TaskDefinition: v.(*ecs.TaskDefinition),
+		}, nil
+	}
+
+	resp, err := c.ecsClient.DescribeTaskDefinition(input)
+	if err != nil {
+		return resp, err
+	}
+
+	c.taskDefinitions.Set(*resp.TaskDefinition.TaskDefinitionArn, resp.TaskDefinition, 0)
+
+	return resp, err
+}

--- a/scheduler/cloudformation/clients_test.go
+++ b/scheduler/cloudformation/clients_test.go
@@ -1,0 +1,83 @@
+package cloudformation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCachingECSClient_DescribeTaskDefiniton_WithArn(t *testing.T) {
+	cache := newMockCacher()
+	e := new(mockECSClient)
+	c := &cachingECSClient{
+		ecsClient:       e,
+		taskDefinitions: cache,
+	}
+
+	e.On("DescribeTaskDefinition", &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10"),
+	}).Return(&ecs.DescribeTaskDefinitionOutput{
+		TaskDefinition: &ecs.TaskDefinition{
+			TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10"),
+		},
+	}, nil).Once()
+
+	resp, err := c.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10", *resp.TaskDefinition.TaskDefinitionArn)
+
+	resp, err = c.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10", *resp.TaskDefinition.TaskDefinitionArn)
+}
+
+func TestCachingECSClient_DescribeTaskDefiniton_WithoutArn(t *testing.T) {
+	e := new(mockECSClient)
+	c := &cachingECSClient{
+		ecsClient: e,
+	}
+
+	e.On("DescribeTaskDefinition", &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("hello_world"),
+	}).Return(&ecs.DescribeTaskDefinitionOutput{
+		TaskDefinition: &ecs.TaskDefinition{
+			TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10"),
+		},
+	}, nil).Twice()
+
+	resp, err := c.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("hello_world"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10", *resp.TaskDefinition.TaskDefinitionArn)
+
+	resp, err = c.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String("hello_world"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678910:task-definition/hello_world:10", *resp.TaskDefinition.TaskDefinitionArn)
+}
+
+type mockCacher struct {
+	m map[string]interface{}
+}
+
+func newMockCacher() *mockCacher {
+	return &mockCacher{make(map[string]interface{})}
+}
+
+func (m *mockCacher) Set(k string, x interface{}, d time.Duration) {
+	m.m[k] = x
+}
+
+func (m *mockCacher) Get(k string) (interface{}, bool) {
+	x, ok := m.m[k]
+	return x, ok
+}

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -158,7 +158,7 @@ type Scheduler struct {
 func NewScheduler(db *sql.DB, config client.ConfigProvider) *Scheduler {
 	return &Scheduler{
 		cloudformation: cloudformation.New(config),
-		ecs:            ecs.New(config),
+		ecs:            ecsWithCaching(ecs.New(config)),
 		s3:             s3.New(config),
 		db:             db,
 		after:          time.After,


### PR DESCRIPTION
This is a small performance optimization that takes into account the fact that task definitions can essentially be treated as immutable, when keying off the ARN.

Describing task definitions is a pretty expensive call, both in time (it's N+1, and slow) and in throttling. This should help quite a bit with `emp ps` performance, once the cache is filled.

**TODO**

* [x] Tests
* [x] Don't cache if the TaskDefinition is not an ARN.