### PR TITLE
Stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * The Custom::ECSService custom resource now waits for newly created ECS services to stabilize [#878](https://github.com/remind101/empire/pull/878)
 * The CloudFormation backend now uses the Custom::ECSService resource instead of AWS::ECS::Service, by default [#877](https://github.com/remind101/empire/pull/877)
 * The database schema version is now checked at boot, as well as in the http health checks. [#893](https://github.com/remind101/empire/pull/893)
+* An `emp stop` command has been added. [#914](https://github.com/remind101/empire/pull/914)
 
 **Bugs**
 

--- a/cmd/emp/main.go
+++ b/cmd/emp/main.go
@@ -113,6 +113,7 @@ var commands = []*Command{
 	cmdRollback,
 	cmdScale,
 	cmdRestart,
+	cmdStop,
 	cmdEnvLoad,
 	cmdSet,
 	cmdUnset,

--- a/cmd/emp/stop.go
+++ b/cmd/emp/stop.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+var cmdStop = &Command{
+	Run:             maybeMessage(runStop),
+	Usage:           "stop <id>",
+	NeedsApp:        true,
+	OptionalMessage: true,
+	Category:        "dyno",
+	Short:           "stop processes",
+	Long: `
+Stops a given process by its id. The id of the process can be found in the output of ` + "`emp ps`" + `
+
+Examples:
+
+    $ emp stop 56bece28-f2fd-47b5-9f39-fbeaaf0d6fea -a <app>
+    Stopped ` + "`56bece28-f2fd-47b5-9f39-fbeaaf0d6fe`" + `
+`,
+}
+
+func runStop(cmd *Command, args []string) {
+	appname := mustApp()
+	if len(args) > 2 || len(args) < 1 {
+		cmd.PrintUsage()
+		os.Exit(2)
+	}
+	message := getMessage()
+
+	target := args[0]
+	must(client.DynoRestart(appname, target, message))
+
+	log.Printf("Stopped `%s`.", target)
+}

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -18,9 +18,10 @@ type Dyno heroku.Dyno
 
 func newDyno(task *empire.Task) *Dyno {
 	return &Dyno{
+		Id:        task.ID,
 		Command:   task.Command.String(),
 		Type:      task.Type,
-		Name:      task.Name,
+		Name:      fmt.Sprintf("%s.%s.%s", task.Release, task.Type, task.ID),
 		State:     task.State,
 		Size:      task.Constraints.String(),
 		UpdatedAt: task.UpdatedAt,

--- a/tasks.go
+++ b/tasks.go
@@ -1,7 +1,6 @@
 package empire
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/remind101/empire/pkg/constraints"
@@ -11,8 +10,11 @@ import (
 
 // Task represents a running process.
 type Task struct {
-	// The name of the task.
-	Name string
+	// The id of the task.
+	ID string
+
+	// The release that this task relates to.
+	Release string
 
 	// The name of the process that this task is for.
 	Type string
@@ -59,7 +61,8 @@ func taskFromInstance(i *scheduler.Instance) *Task {
 	}
 
 	return &Task{
-		Name:    fmt.Sprintf("%s.%s.%s", version, i.Process.Type, i.ID),
+		ID:      i.ID,
+		Release: version,
 		Type:    string(i.Process.Type),
 		Command: Command(i.Process.Command),
 		Constraints: Constraints{


### PR DESCRIPTION
It's pretty confusing that you use the `emp restart` command to stop a single task/process. This adds an `emp stop` command to help make this more intuitive.

Also does a little cleanup to move the "friendly" name into server/heroku and adds the ID of the task to the API response.