### PR TITLE
Deployment notifications

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -164,7 +164,7 @@ func (s *appsService) Scale(ctx context.Context, db *gorm.DB, opts ScaleOpts) ([
 		return nil, err
 	}
 
-	err = s.releases.Release(ctx, release)
+	err = s.releases.Release(ctx, release, nil)
 	if err != nil {
 		return ps, err
 	}

--- a/configs.go
+++ b/configs.go
@@ -152,7 +152,7 @@ func (s *configsService) Set(ctx context.Context, db *gorm.DB, opts SetOpts) (*C
 		Config:      c,
 		Slug:        release.Slug,
 		Description: configsApplyReleaseDesc(opts),
-	})
+	}, nil)
 	return c, err
 }
 

--- a/empire.go
+++ b/empire.go
@@ -126,6 +126,16 @@ func (e *Empire) requireMessages(m string) error {
 	return nil
 }
 
+type DoneChan chan error
+
+func NewDoneChan() DoneChan {
+	return make(DoneChan, 1)
+}
+
+func NewEventChan() scheduler.EventChan {
+	return scheduler.NewEventChan()
+}
+
 // CreateOpts are options that are provided when creating a new application.
 type CreateOpts struct {
 	// User performing the action.
@@ -541,6 +551,12 @@ type DeployOpts struct {
 
 	// Commit message
 	Message string
+
+	// Events channel where scheduler events will be published to while deploying
+	Events scheduler.EventChan
+
+	// Done channel which will be published to when the deploy is complete
+	Done DoneChan
 }
 
 func (opts DeployOpts) Event() DeployEvent {

--- a/releases.go
+++ b/releases.go
@@ -152,7 +152,8 @@ func (s *releasesService) Rollback(ctx context.Context, db *gorm.DB, opts Rollba
 // Release submits a release to the scheduler.
 func (s *releasesService) Release(ctx context.Context, release *Release) error {
 	a := newSchedulerApp(release)
-	return s.Scheduler.Submit(ctx, a)
+	status := make(chan string)
+	return s.Scheduler.Submit(ctx, a, status)
 }
 
 // ReleaseApp will find the last release for an app and release it.

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -36,6 +36,8 @@ var newUUID = uuid.New
 // values.
 const servicesOutput = "Services"
 
+const deploymentsOutput = "Deployments"
+
 // Parameter used to trigger a restart of the application.
 const restartParameter = "RestartKey"
 

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -85,7 +85,7 @@ func TestScheduler_Submit_NewStack(t *testing.T) {
 				Instances: 1,
 			},
 		},
-	})
+	}, make(chan string))
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -142,7 +142,7 @@ func TestScheduler_Submit_ExistingStack(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	})
+	}, make(chan string))
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -208,7 +208,7 @@ func TestScheduler_Submit_LockWaitTimeout(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	})
+	}, make(chan string))
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -274,7 +274,7 @@ func TestScheduler_Submit_StackWaitTimeout(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	})
+	}, make(chan string))
 	assert.EqualError(t, err, `timed out waiting for stack operation to complete`)
 
 	c.AssertExpectations(t)
@@ -327,7 +327,7 @@ func TestScheduler_Submit_UpdateError(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	})
+	}, make(chan string))
 	assert.EqualError(t, err, `error updating stack: stack update failed`)
 
 	c.AssertExpectations(t)
@@ -399,7 +399,7 @@ func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
 		Processes: []*scheduler.Process{
 			{Type: "web", Instances: 1},
 		},
-	})
+	}, make(chan string))
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -475,7 +475,7 @@ func TestScheduler_Submit_ExistingStack_ExistingParameterValue(t *testing.T) {
 		Processes: []*scheduler.Process{
 			{Type: "web", Instances: 1},
 		},
-	})
+	}, make(chan string))
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -512,7 +512,7 @@ func TestScheduler_Submit_TemplateTooLarge(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	})
+	}, make(chan string))
 	assert.EqualError(t, err, `TemplateValidationError:
   Template URL: https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f
   Template Size: 2 bytes
@@ -845,9 +845,9 @@ func TestScheduler_Instances_ManyTasks(t *testing.T) {
 	e.AssertExpectations(t)
 }
 
-func TestExtractServices(t *testing.T) {
+func TestExtractProcessData(t *testing.T) {
 	output := "statuses=arn:aws:ecs:us-east-1:897883143566:service/stage-app-statuses-16NM105QFD6UO,statuses_retry=arn:aws:ecs:us-east-1:897883143566:service/stage-app-statusesretry-DKG2XMH75H5N"
-	services := extractServices(output)
+	services := extractProcessData(output)
 	expected := map[string]string{
 		"statuses":       "arn:aws:ecs:us-east-1:897883143566:service/stage-app-statuses-16NM105QFD6UO",
 		"statuses_retry": "arn:aws:ecs:us-east-1:897883143566:service/stage-app-statusesretry-DKG2XMH75H5N",

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -85,7 +85,7 @@ func TestScheduler_Submit_NewStack(t *testing.T) {
 				Instances: 1,
 			},
 		},
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -142,7 +142,7 @@ func TestScheduler_Submit_ExistingStack(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -208,7 +208,7 @@ func TestScheduler_Submit_LockWaitTimeout(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -274,7 +274,7 @@ func TestScheduler_Submit_StackWaitTimeout(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.EqualError(t, err, `timed out waiting for stack operation to complete`)
 
 	c.AssertExpectations(t)
@@ -327,7 +327,7 @@ func TestScheduler_Submit_UpdateError(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.EqualError(t, err, `error updating stack: stack update failed`)
 
 	c.AssertExpectations(t)
@@ -399,7 +399,7 @@ func TestScheduler_Submit_ExistingStack_RemovedProcess(t *testing.T) {
 		Processes: []*scheduler.Process{
 			{Type: "web", Instances: 1},
 		},
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -475,7 +475,7 @@ func TestScheduler_Submit_ExistingStack_ExistingParameterValue(t *testing.T) {
 		Processes: []*scheduler.Process{
 			{Type: "web", Instances: 1},
 		},
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)
@@ -512,7 +512,7 @@ func TestScheduler_Submit_TemplateTooLarge(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
-	}, make(chan string))
+	}, scheduler.NewEventChan())
 	assert.EqualError(t, err, `TemplateValidationError:
   Template URL: https://bucket.s3.amazonaws.com/acme-inc/c9366591-ab68-4d49-a333-95ce5a23df68/bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f
   Template Size: 2 bytes

--- a/scheduler/cloudformation/migration.go
+++ b/scheduler/cloudformation/migration.go
@@ -40,7 +40,7 @@ type MigrationScheduler struct {
 	// The scheduler that we want to migrate to.
 	cloudformation interface {
 		scheduler.Scheduler
-		SubmitWithOptions(context.Context, *scheduler.App, SubmitOptions) error
+		SubmitWithOptions(context.Context, *scheduler.App, chan string, SubmitOptions) error
 	}
 
 	// The scheduler we're migrating from.
@@ -91,7 +91,7 @@ func (s *MigrationScheduler) backend(appID string) (string, error) {
 	return backend, err
 }
 
-func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App) error {
+func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App, status chan string) error {
 	state, err := s.backend(app.ID)
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App) err
 
 	desiredState := app.Env[MigrationEnvVar]
 	if desiredState != "" {
-		if err := s.Migrate(ctx, app, state, desiredState); err != nil {
+		if err := s.Migrate(ctx, app, state, desiredState, status); err != nil {
 			return fmt.Errorf("error migrating app from %s to %s: %v", state, desiredState, err)
 		}
 		return nil
@@ -109,13 +109,13 @@ func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App) err
 	if err != nil {
 		return err
 	}
-	return b.Submit(ctx, app)
+	return b.Submit(ctx, app, status)
 }
 
 // Migrate submits the app to the CloudFormation scheduler, waits for the stack
 // to successfully create, then removes the old API managed resources using the
 // ECS scheduler.
-func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, state, desiredState string) error {
+func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, state, desiredState string, status chan string) error {
 	errTransition := fmt.Errorf("cannot transition from %s to %s", state, desiredState)
 
 	// Whether or not we're re-trying a state transition.
@@ -129,7 +129,7 @@ func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, st
 
 		// Submit to cloudformation and wait for it to complete successfully.
 		// Don't make any DNS changes.
-		if err := s.cloudformation.SubmitWithOptions(ctx, app, SubmitOptions{
+		if err := s.cloudformation.SubmitWithOptions(ctx, app, status, SubmitOptions{
 			NoDNS: aws.Bool(true),
 		}); err != nil {
 			return fmt.Errorf("error creating CloudFormation stack: %v", err)
@@ -149,7 +149,7 @@ func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, st
 
 		// The user may have already manually enabled the DNS change,
 		// but let's make sure.
-		if err := s.cloudformation.SubmitWithOptions(ctx, app, SubmitOptions{
+		if err := s.cloudformation.SubmitWithOptions(ctx, app, status, SubmitOptions{
 			NoDNS: aws.Bool(false),
 		}); err != nil {
 			return fmt.Errorf("error updating CloudFormation stack: %v", err)

--- a/scheduler/cloudformation/migration.go
+++ b/scheduler/cloudformation/migration.go
@@ -40,7 +40,7 @@ type MigrationScheduler struct {
 	// The scheduler that we want to migrate to.
 	cloudformation interface {
 		scheduler.Scheduler
-		SubmitWithOptions(context.Context, *scheduler.App, chan string, SubmitOptions) error
+		SubmitWithOptions(context.Context, *scheduler.App, scheduler.EventChan, SubmitOptions) error
 	}
 
 	// The scheduler we're migrating from.
@@ -91,7 +91,7 @@ func (s *MigrationScheduler) backend(appID string) (string, error) {
 	return backend, err
 }
 
-func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App, status chan string) error {
+func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App, events scheduler.EventChan) error {
 	state, err := s.backend(app.ID)
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App, sta
 
 	desiredState := app.Env[MigrationEnvVar]
 	if desiredState != "" {
-		if err := s.Migrate(ctx, app, state, desiredState, status); err != nil {
+		if err := s.Migrate(ctx, app, state, desiredState, events); err != nil {
 			return fmt.Errorf("error migrating app from %s to %s: %v", state, desiredState, err)
 		}
 		return nil
@@ -109,13 +109,13 @@ func (s *MigrationScheduler) Submit(ctx context.Context, app *scheduler.App, sta
 	if err != nil {
 		return err
 	}
-	return b.Submit(ctx, app, status)
+	return b.Submit(ctx, app, events)
 }
 
 // Migrate submits the app to the CloudFormation scheduler, waits for the stack
 // to successfully create, then removes the old API managed resources using the
 // ECS scheduler.
-func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, state, desiredState string, status chan string) error {
+func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, state, desiredState string, events scheduler.EventChan) error {
 	errTransition := fmt.Errorf("cannot transition from %s to %s", state, desiredState)
 
 	// Whether or not we're re-trying a state transition.
@@ -129,7 +129,7 @@ func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, st
 
 		// Submit to cloudformation and wait for it to complete successfully.
 		// Don't make any DNS changes.
-		if err := s.cloudformation.SubmitWithOptions(ctx, app, status, SubmitOptions{
+		if err := s.cloudformation.SubmitWithOptions(ctx, app, events, SubmitOptions{
 			NoDNS: aws.Bool(true),
 		}); err != nil {
 			return fmt.Errorf("error creating CloudFormation stack: %v", err)
@@ -149,7 +149,7 @@ func (s *MigrationScheduler) Migrate(ctx context.Context, app *scheduler.App, st
 
 		// The user may have already manually enabled the DNS change,
 		// but let's make sure.
-		if err := s.cloudformation.SubmitWithOptions(ctx, app, status, SubmitOptions{
+		if err := s.cloudformation.SubmitWithOptions(ctx, app, events, SubmitOptions{
 			NoDNS: aws.Bool(false),
 		}); err != nil {
 			return fmt.Errorf("error updating CloudFormation stack: %v", err)

--- a/scheduler/cloudformation/migration_test.go
+++ b/scheduler/cloudformation/migration_test.go
@@ -35,7 +35,7 @@ func TestMigrationScheduler_NewApp(t *testing.T) {
 
 	c.On("Submit", app).Return(nil)
 
-	err := s.Submit(context.Background(), app)
+	err := s.Submit(context.Background(), app, make(chan string))
 	assert.NoError(t, err)
 
 	e.AssertExpectations(t)
@@ -68,7 +68,7 @@ func TestMigrationScheduler_OldApp(t *testing.T) {
 
 	e.On("Submit", app).Return(nil)
 
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.NoError(t, err)
 
 	e.AssertExpectations(t)
@@ -108,7 +108,7 @@ func TestMigrationScheduler_Migrate(t *testing.T) {
 		NoDNS: aws.Bool(true),
 	}).Return(nil)
 
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.NoError(t, err)
 
 	e.AssertExpectations(t)
@@ -125,7 +125,7 @@ func TestMigrationScheduler_Migrate(t *testing.T) {
 		NoDNS: true,
 	}).Return(nil)
 
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.NoError(t, err)
 
 	e.AssertExpectations(t)
@@ -136,7 +136,7 @@ func TestMigrationScheduler_Migrate(t *testing.T) {
 
 	c.On("Submit", app).Return(err)
 
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.NoError(t, err)
 
 	e.AssertExpectations(t)
@@ -178,12 +178,12 @@ func TestMigrationScheduler_Migrate_Rollback(t *testing.T) {
 		NoDNS: aws.Bool(true),
 	}).Return(nil).Twice()
 
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.NoError(t, err)
 
 	// Let's assume the the CloudFormation stack that was created got rolled
 	// back, so they manually delete the stack and try again.
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.NoError(t, err)
 
 	e.AssertExpectations(t)
@@ -217,13 +217,13 @@ func TestMigrationScheduler_Migrate_InvalidStateTransitions(t *testing.T) {
 		},
 	}
 
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.Error(t, err)
 	assert.EqualError(t, err, "error migrating app from ecs to step2: cannot transition from ecs to step2")
 
 	app.Env[MigrationEnvVar] = "step3"
 
-	err = s.Submit(context.Background(), app)
+	err = s.Submit(context.Background(), app, make(chan string))
 	assert.Error(t, err)
 	assert.EqualError(t, err, "error migrating app from ecs to step3: cannot transition to step3")
 
@@ -236,7 +236,7 @@ type mockScheduler struct {
 	mock.Mock
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
+func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App, _ chan string) error {
 	args := m.Called(app)
 	return args.Error(0)
 }
@@ -254,7 +254,7 @@ type mockCloudFormationScheduler struct {
 	mockScheduler
 }
 
-func (m *mockCloudFormationScheduler) SubmitWithOptions(_ context.Context, app *scheduler.App, opts SubmitOptions) error {
+func (m *mockCloudFormationScheduler) SubmitWithOptions(_ context.Context, app *scheduler.App, _ chan string, opts SubmitOptions) error {
 	args := m.Called(app, opts)
 	return args.Error(0)
 }

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -156,6 +156,7 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 	}
 
 	serviceMappings := []map[string]interface{}{}
+	deploymentMappings := []map[string]interface{}{}
 
 	// The standard AWS::ECS::Service resource's default behavior is to wait
 	// for services to stabilize when you update them. While this is a
@@ -366,6 +367,17 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 				[]interface{}{p.Type, map[string]string{"Ref": service}},
 			},
 		})
+		deploymentMappings = append(deploymentMappings, map[string]interface{}{
+			"Fn::Join": []interface{}{
+				"=",
+				[]interface{}{p.Type, map[string][]string{
+					"Fn::GetAtt": []string{
+						service,
+						"DeploymentId",
+					},
+				}},
+			},
+		})
 		resources[service] = map[string]interface{}{
 			"Type":       ecsServiceType,
 			"Properties": serviceProperties,
@@ -378,6 +390,14 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (interface{}, error) {
 			"Fn::Join": []interface{}{
 				",",
 				serviceMappings,
+			},
+		},
+	}
+	outputs[deploymentsOutput] = map[string]interface{}{
+		"Value": map[string]interface{}{
+			"Fn::Join": []interface{}{
+				",",
+				deploymentMappings,
 			},
 		},
 	}

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -10,6 +10,43 @@
     }
   },
   "Outputs": {
+    "Deployments": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Fn::GetAtt": [
+                      "webService",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "worker",
+                  {
+                    "Fn::GetAtt": [
+                      "workerService",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    },
     "EmpireVersion": {
       "Value": "0.10.1"
     },

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -10,6 +10,43 @@
     }
   },
   "Outputs": {
+    "Deployments": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Fn::GetAtt": [
+                      "webService",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "api",
+                  {
+                    "Fn::GetAtt": [
+                      "apiService",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    },
     "EmpireVersion": {
       "Value": "0.10.1"
     },

--- a/scheduler/cloudformation/templates/standard.json
+++ b/scheduler/cloudformation/templates/standard.json
@@ -10,6 +10,43 @@
     }
   },
   "Outputs": {
+    "Deployments": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Fn::GetAtt": [
+                      "web",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "worker",
+                  {
+                    "Fn::GetAtt": [
+                      "worker",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    },
     "EmpireVersion": {
       "Value": "0.10.1"
     },

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -186,7 +186,7 @@ func (m *Scheduler) RemoveCNAMEs(ctx context.Context, appID string) error {
 // removed from ECS. For example, if you previously submitted an app with a
 // `web` and `worker` process, then submit an app with the `web` process, the
 // ECS service for the old `worker` process will be removed.
-func (m *Scheduler) Submit(ctx context.Context, app *scheduler.App, status chan string) error {
+func (m *Scheduler) Submit(ctx context.Context, app *scheduler.App, events scheduler.EventChan) error {
 	processes, err := m.Processes(ctx, app.ID)
 	if err != nil {
 		return err

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -186,7 +186,7 @@ func (m *Scheduler) RemoveCNAMEs(ctx context.Context, appID string) error {
 // removed from ECS. For example, if you previously submitted an app with a
 // `web` and `worker` process, then submit an app with the `web` process, the
 // ECS service for the old `worker` process will be removed.
-func (m *Scheduler) Submit(ctx context.Context, app *scheduler.App) error {
+func (m *Scheduler) Submit(ctx context.Context, app *scheduler.App, status chan string) error {
 	processes, err := m.Processes(ctx, app.ID)
 	if err != nil {
 		return err

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -91,7 +91,7 @@ func TestScheduler_Submit(t *testing.T) {
 		{Name: "lb-1234", InstancePort: 8080},
 	}, nil)
 
-	if err := m.Submit(context.Background(), fakeApp); err != nil {
+	if err := m.Submit(context.Background(), fakeApp, make(chan string)); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/scheduler/ecs/ecs_test.go
+++ b/scheduler/ecs/ecs_test.go
@@ -91,7 +91,7 @@ func TestScheduler_Submit(t *testing.T) {
 		{Name: "lb-1234", InstancePort: 8080},
 	}, nil)
 
-	if err := m.Submit(context.Background(), fakeApp, make(chan string)); err != nil {
+	if err := m.Submit(context.Background(), fakeApp, scheduler.NewEventChan()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -18,7 +18,7 @@ func NewFakeScheduler() *FakeScheduler {
 	}
 }
 
-func (m *FakeScheduler) Submit(ctx context.Context, app *App, status chan string) error {
+func (m *FakeScheduler) Submit(ctx context.Context, app *App, events EventChan) error {
 	m.apps[app.ID] = app
 	return nil
 }

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -18,7 +18,7 @@ func NewFakeScheduler() *FakeScheduler {
 	}
 }
 
-func (m *FakeScheduler) Submit(ctx context.Context, app *App) error {
+func (m *FakeScheduler) Submit(ctx context.Context, app *App, status chan string) error {
 	m.apps[app.ID] = app
 	return nil
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -118,7 +118,7 @@ type Scheduler interface {
 	Runner
 
 	// Submit submits an app, creating it or updating it as necessary.
-	Submit(context.Context, *App) error
+	Submit(context.Context, *App, chan string) error
 
 	// Remove removes the App.
 	Remove(ctx context.Context, app string) error

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -118,7 +118,7 @@ type Scheduler interface {
 	Runner
 
 	// Submit submits an app, creating it or updating it as necessary.
-	Submit(context.Context, *App, chan string) error
+	Submit(context.Context, *App, EventChan) error
 
 	// Remove removes the App.
 	Remove(ctx context.Context, app string) error
@@ -151,4 +151,16 @@ func merge(envs ...map[string]string) map[string]string {
 		}
 	}
 	return merged
+}
+
+type Event struct {
+	Error   error
+	Message string
+	Close   bool
+}
+
+type EventChan chan Event
+
+func NewEventChan() EventChan {
+	return make(EventChan)
 }

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -54,7 +54,7 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req Request) (string
 	switch req.RequestType {
 	case Create:
 		id, deploymentId, err := p.create(ctx, hashRequest(req), properties)
-		if err != nil {
+		if err == nil {
 			data["DeploymentId"] = deploymentId
 		}
 		return id, data, err

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -49,11 +49,15 @@ func (p *ECSServiceResource) Properties() interface{} {
 func (p *ECSServiceResource) Provision(ctx context.Context, req Request) (string, interface{}, error) {
 	properties := req.ResourceProperties.(*ECSServiceProperties)
 	oldProperties := req.OldResourceProperties.(*ECSServiceProperties)
+	data := make(map[string]string)
 
 	switch req.RequestType {
 	case Create:
-		id, err := p.create(ctx, hashRequest(req), properties)
-		return id, nil, err
+		id, deploymentId, err := p.create(ctx, hashRequest(req), properties)
+		if err != nil {
+			data["DeploymentId"] = deploymentId
+		}
+		return id, data, err
 	case Delete:
 		id := req.PhysicalResourceId
 		err := p.delete(ctx, aws.String(id), properties.Cluster)
@@ -65,31 +69,38 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req Request) (string
 			// If we can't update the service, we'll need to create a new
 			// one, and destroy the old one.
 			oldId := id
-			id, err := p.create(ctx, hashRequest(req), properties)
+			id, deploymentId, err := p.create(ctx, hashRequest(req), properties)
 			if err != nil {
 				return oldId, nil, err
 			}
+			data["DeploymentId"] = deploymentId
 
 			// There's no need to delete the old service here, since
 			// CloudFormation will send us a DELETE request for the old
 			// service.
 
-			return id, nil, err
+			return id, data, err
 		}
 
-		_, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
+		resp, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
 			Service:        aws.String(id),
 			Cluster:        properties.Cluster,
 			DesiredCount:   properties.DesiredCount.Value(),
 			TaskDefinition: properties.TaskDefinition,
 		})
-		return id, nil, err
+		if err == nil {
+			primary, err := getPrimaryDeployment(resp.Service)
+			if err == nil {
+				data["DeploymentId"] = *primary.Id
+			}
+		}
+		return id, data, err
 	default:
 		return "", nil, fmt.Errorf("%s is not supported", req.RequestType)
 	}
 }
 
-func (p *ECSServiceResource) create(ctx context.Context, clientToken string, properties *ECSServiceProperties) (string, error) {
+func (p *ECSServiceResource) create(ctx context.Context, clientToken string, properties *ECSServiceProperties) (string, string, error) {
 	var loadBalancers []*ecs.LoadBalancer
 	for _, v := range properties.LoadBalancers {
 		loadBalancers = append(loadBalancers, &ecs.LoadBalancer{
@@ -114,7 +125,12 @@ func (p *ECSServiceResource) create(ctx context.Context, clientToken string, pro
 		LoadBalancers:  loadBalancers,
 	})
 	if err != nil {
-		return "", fmt.Errorf("error creating service: %v", err)
+		return "", "", fmt.Errorf("error creating service: %v", err)
+	}
+
+	primaryDeployment, err := getPrimaryDeployment(resp.Service)
+	if err != nil {
+		return "", "", fmt.Errorf("error retrieving primary deployment: %v", err)
 	}
 
 	arn := resp.Service.ServiceArn
@@ -136,10 +152,10 @@ func (p *ECSServiceResource) create(ctx context.Context, clientToken string, pro
 	select {
 	case <-stabilized:
 	case <-ctx.Done():
-		return *arn, ctx.Err()
+		return *arn, *primaryDeployment.Id, ctx.Err()
 	}
 
-	return *arn, nil
+	return *arn, *primaryDeployment.Id, nil
 }
 
 func (p *ECSServiceResource) delete(ctx context.Context, service, cluster *string) error {
@@ -190,4 +206,17 @@ func requiresReplacement(new, old *ECSServiceProperties) bool {
 	}
 
 	return false
+}
+
+func getPrimaryDeployment(service *ecs.Service) (deployment *ecs.Deployment, err error) {
+	for _, d := range service.Deployments {
+		if d.Status != nil && *d.Status == "PRIMARY" {
+			deployment = d
+			break
+		}
+	}
+	if deployment == nil {
+		err = fmt.Errorf("no primary deployment available")
+	}
+	return
 }

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -27,7 +27,8 @@ func TestECSServiceResource_Create(t *testing.T) {
 		DesiredCount: aws.Int64(1),
 	}).Return(&ecs.CreateServiceOutput{
 		Service: &ecs.Service{
-			ServiceArn: aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt"),
+			ServiceArn:  aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt"),
+			Deployments: []*ecs.Deployment{&ecs.Deployment{Id: aws.String("New"), Status: aws.String("PRIMARY")}},
 		},
 	}, nil)
 
@@ -49,7 +50,7 @@ func TestECSServiceResource_Create(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt", id)
-	assert.Nil(t, data)
+	assert.Equal(t, data, map[string]string{"DeploymentId": "New"})
 
 	e.AssertExpectations(t)
 }
@@ -67,7 +68,8 @@ func TestECSServiceResource_Create_Canceled(t *testing.T) {
 		DesiredCount: aws.Int64(1),
 	}).Return(&ecs.CreateServiceOutput{
 		Service: &ecs.Service{
-			ServiceArn: aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt"),
+			ServiceArn:  aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt"),
+			Deployments: []*ecs.Deployment{&ecs.Deployment{Id: aws.String("New"), Status: aws.String("PRIMARY")}},
 		},
 	}, nil)
 
@@ -92,7 +94,7 @@ func TestECSServiceResource_Create_Canceled(t *testing.T) {
 		OldResourceProperties: &ECSServiceProperties{},
 	})
 	assert.Equal(t, context.Canceled, err)
-	assert.Nil(t, data)
+	assert.Equal(t, data, map[string]string{"DeploymentId": "New"})
 
 	e.AssertExpectations(t)
 }
@@ -108,7 +110,17 @@ func TestECSServiceResource_Update(t *testing.T) {
 		Cluster:        aws.String("cluster"),
 		DesiredCount:   aws.Int64(2),
 		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
-	}).Return(&ecs.UpdateServiceOutput{}, nil)
+	}).Return(
+		&ecs.UpdateServiceOutput{
+			Service: &ecs.Service{
+				Deployments: []*ecs.Deployment{
+					&ecs.Deployment{Id: aws.String("New"), Status: aws.String("PRIMARY")},
+					&ecs.Deployment{Id: aws.String("Old"), Status: aws.String("ACTIVE")},
+				},
+			},
+		},
+		nil,
+	)
 
 	id, data, err := p.Provision(ctx, Request{
 		StackId:            "arn:aws:cloudformation:us-east-1:012345678901:stack/acme-inc/bc66fd60-32be-11e6-902b-50d501eb4c17",
@@ -130,7 +142,7 @@ func TestECSServiceResource_Update(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web", id)
-	assert.Nil(t, data)
+	assert.Equal(t, data, map[string]string{"DeploymentId": "New"})
 
 	e.AssertExpectations(t)
 }
@@ -149,7 +161,8 @@ func TestECSServiceResource_Update_RequiresReplacement(t *testing.T) {
 		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
 	}).Return(&ecs.CreateServiceOutput{
 		Service: &ecs.Service{
-			ServiceArn: aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt"),
+			ServiceArn:  aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt"),
+			Deployments: []*ecs.Deployment{&ecs.Deployment{Id: aws.String("New"), Status: aws.String("PRIMARY")}},
 		},
 	}, nil)
 
@@ -178,7 +191,7 @@ func TestECSServiceResource_Update_RequiresReplacement(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt", id)
-	assert.Nil(t, data)
+	assert.Equal(t, data, map[string]string{"DeploymentId": "New"})
 
 	e.AssertExpectations(t)
 }
@@ -193,7 +206,17 @@ func TestECSServiceResource_Delete(t *testing.T) {
 		Service:      aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
 		Cluster:      aws.String("cluster"),
 		DesiredCount: aws.Int64(0),
-	}).Return(&ecs.UpdateServiceOutput{}, nil)
+	}).Return(
+		&ecs.UpdateServiceOutput{
+			Service: &ecs.Service{
+				Deployments: []*ecs.Deployment{
+					&ecs.Deployment{Id: aws.String("New"), Status: aws.String("PRIMARY")},
+					&ecs.Deployment{Id: aws.String("Old"), Status: aws.String("ACTIVE")},
+				},
+			},
+		},
+		nil,
+	)
 
 	e.On("DeleteService", &ecs.DeleteServiceInput{
 		Service: aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -94,7 +94,7 @@ func TestECSServiceResource_Create_Canceled(t *testing.T) {
 		OldResourceProperties: &ECSServiceProperties{},
 	})
 	assert.Equal(t, context.Canceled, err)
-	assert.Equal(t, data, map[string]string{"DeploymentId": "New"})
+	assert.Equal(t, data, map[string]string{})
 
 	e.AssertExpectations(t)
 }

--- a/server/heroku/deployments.go
+++ b/server/heroku/deployments.go
@@ -30,6 +30,9 @@ func (h *PostDeploys) ServeHTTPContext(ctx context.Context, w http.ResponseWrite
 	// We ignore errors here since this is a streaming endpoint,
 	// and the error is handled in the response message
 	_, _ = h.Deploy(ctx, *opts)
+	if err = <-opts.Done; err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -56,6 +59,8 @@ func newDeployOpts(ctx context.Context, w http.ResponseWriter, req *http.Request
 		Image:   form.Image,
 		Output:  streamhttp.StreamingResponseWriter(w),
 		Message: m,
+		Events:  empire.NewEventChan(),
+		Done:    empire.NewDoneChan(),
 	}
 	return &opts, nil
 }

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -518,7 +518,7 @@ type mockScheduler struct {
 	mock.Mock
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App, _ chan string) error {
+func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App, _ scheduler.EventChan) error {
 	args := m.Called(app)
 	return args.Error(0)
 }

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -518,7 +518,7 @@ type mockScheduler struct {
 	mock.Mock
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
+func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App, _ chan string) error {
 	args := m.Called(app)
 	return args.Error(0)
 }

--- a/tests/github/github_test.go
+++ b/tests/github/github_test.go
@@ -77,7 +77,7 @@ type mockScheduler struct {
 	image chan string
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
+func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App, _ chan string) error {
 	m.image <- app.Processes[0].Image.String()
 	return nil
 }

--- a/tests/github/github_test.go
+++ b/tests/github/github_test.go
@@ -77,7 +77,7 @@ type mockScheduler struct {
 	image chan string
 }
 
-func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App, _ chan string) error {
+func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App, _ scheduler.EventChan) error {
 	m.image <- app.Processes[0].Image.String()
 	return nil
 }


### PR DESCRIPTION
Still a WIP but I wanted to publish this for discussion.

Sample output
```
$ emp deploy remind101/acme-inc:master
master: Pulling from remind101/acme-inc

420890c9e918: Already exists
a3ed95caeb02: Already exists
1e14aab0083d: Already exists
4393485f2bb3: Already exists
a2a051cf14f7: Already exists
1f9177248efa: Already exists
Digest: sha256:d05682347b56191a950f55ab06f11a6c6e34041921af32281b01f4a6a9a0f75f
Status: Image is up to date for remind101/acme-inc:master
Status: Created new release v64 for acme-inc
Status: Updating stack "acme-inc"
Status: Stack updated
Status: Deployment in progress for web
Status: Deployment in progress for worker
Status: Deployment stable for web
Status: Deployment stable for worker
Status: Closing event stream for release v64
```

There are issues with these tests: github.com/remind101/empire/tests/api. Relying on the Done channel to be closed via the EventsChan receiving an `Event{Close: true}` is really brittle.