### PR TITLE
Scheduled tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 * Empire now includes experimental support for showing attached runs in `emp ps`. This can be enabled with the `--x.showattached` flag, or `EMPIRE_X_SHOW_ATTACHED` [#911](https://github.com/remind101/empire/pull/911)
+* Empire now includes experimental support for scheduled tasks [#919](https://github.com/remind101/empire/pull/919)
 
 **Improvements**
 

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -406,6 +406,31 @@
             {
               "Effect": "Allow",
               "Action": [
+                "lambda:CreateFunction",
+                "lambda:DeleteFunction",
+                "lambda:UpdateFunctionCode",
+                "lambda:GetFunctionConfiguration",
+                "lambda:AddPermission",
+                "lambda:RemovePermission"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "events:PutRule",
+                "events:DeleteRule",
+                "events:DescribeRule",
+                "events:EnableRule",
+                "events:DisableRule",
+                "events:PutTargets",
+                "events:RemoveTargets"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
                 "sqs:ReceiveMessage",
                 "sqs:DeleteMessage"
               ],
@@ -542,7 +567,11 @@
             {
               "Effect": "Allow",
               "Principal": {
-                "Service": [ "ecs.amazonaws.com" ]
+                "Service": [
+                  "ecs.amazonaws.com",
+                  "events.amazonaws.com",
+                  "lambda.amazonaws.com"
+                ]
               },
               "Action": [ "sts:AssumeRole" ]
             }
@@ -573,6 +602,25 @@
               "Resource": [
                 "*"
               ]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "lambda:InvokeFunction"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "ecs:RunTask"
+              ],
+              "Resource": "*",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": { "Fn::Join": ["", ["arn:aws:ecs:", { "Ref": "AWS::Region" }, ":", { "Ref": "AWS::AccountId" }, ":cluster/", { "Ref": "Cluster" }]] }
+                }
+              }
             }
           ]
         }

--- a/docs/deploying_an_application.md
+++ b/docs/deploying_an_application.md
@@ -124,6 +124,36 @@ ADD . /code/
 web: /code/run.sh
 ```
 
+### Scheduled processes
+
+**NOTE:** This feature is currently experimental, and requires the CloudFormation backend.
+
+Processes that should run at scheduled times can be configured in the extended procfile by setting a `cron` expression:
+
+```
+scheduled-job:
+  command: ./bin/scheduled-job
+  cron: * * * * * * // Run once every minute
+```
+
+Like other non-web processes, scheduled processes are disabled by default. To enable a scheduled job, simply scale it up:
+
+```console
+$ emp scale scheduled-job=1
+```
+
+If you want to run more than 1 instance of the process when the cron expression triggers, you can scale it to a value greater than 1:
+
+```console
+$ emp scale scheduled-job=5 # Run 5 of these every minute
+```
+
+To disable a scheduled job, simply scale it back down to 0:
+
+```console
+$ emp scale scheduled-job=0
+```
+
 ## Environment variables
 
 TODO

--- a/extractor.go
+++ b/extractor.go
@@ -242,6 +242,7 @@ func formationFromExtendedProcfile(p procfile.ExtendedProcfile) (Formation, erro
 
 		f[name] = Process{
 			Command: cmd,
+			Cron:    process.Cron,
 		}
 	}
 

--- a/pkg/troposphere/functions.go
+++ b/pkg/troposphere/functions.go
@@ -1,0 +1,21 @@
+package troposphere
+
+// Ref provides a helper for the Ref function.
+func Ref(ref string) interface{} {
+	return map[string]string{"Ref": ref}
+}
+
+// GetAtt provides a helper for the GetAtt function.
+func GetAtt(ref, attr string) interface{} {
+	return map[string][]string{"Fn::GetAtt": []string{ref, attr}}
+}
+
+// Equals is a helper for the Fn::Equals function.
+func Equals(thing, value interface{}) interface{} {
+	return map[string][]interface{}{"Fn::Equals": []interface{}{thing, value}}
+}
+
+// Join is a helper for the Fn::Join function.
+func Join(delimiter string, things ...interface{}) interface{} {
+	return map[string][]interface{}{"Fn::Join": []interface{}{delimiter, things}}
+}

--- a/pkg/troposphere/troposphere.go
+++ b/pkg/troposphere/troposphere.go
@@ -1,0 +1,41 @@
+// Package troposphere is a Go version of the Python package and provides Go
+// primitives for building CloudFormation templates.
+package troposphere
+
+// Template represents a CloudFormation template that can be built.
+type Template struct {
+	Conditions map[string]interface{}
+	Outputs    map[string]Output
+	Parameters map[string]Parameter
+	Resources  map[string]Resource
+}
+
+// NewTemplate returns an initialized Template.
+func NewTemplate() *Template {
+	return &Template{
+		Conditions: make(map[string]interface{}),
+		Outputs:    make(map[string]Output),
+		Parameters: make(map[string]Parameter),
+		Resources:  make(map[string]Resource),
+	}
+}
+
+// Parameter represents a CloudFormation parameter.
+type Parameter struct {
+	Type        interface{} `json:"Type,omitempty"`
+	Description interface{} `json:"Description,omitempty"`
+	Default     interface{} `json:"Default,omitempty"`
+}
+
+// Output represents an CloudFormation output.
+type Output struct {
+	Value interface{} `json:"Value,omitempty"`
+}
+
+// Resource represents a CloudFormation Resource.
+type Resource struct {
+	Condition  interface{} `json:"Condition,omitempty"`
+	Properties interface{} `json:"Properties,omitempty"`
+	Type       interface{} `json:"Type,omitempty"`
+	Version    interface{} `json:"Version,omitempty"`
+}

--- a/pkg/troposphere/troposphere_test.go
+++ b/pkg/troposphere/troposphere_test.go
@@ -1,0 +1,47 @@
+package troposphere
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplate(t *testing.T) {
+	tests := []struct {
+		in  *Template
+		out string
+	}{
+		{
+			buildTemplate(func(t *Template) {
+				t.Parameters["Cluster"] = Parameter{
+					Type:    "String",
+					Default: "",
+				}
+			}),
+			`{
+  "Conditions": {},
+  "Outputs": {},
+  "Parameters": {
+    "Cluster": {
+      "Type": "String",
+      "Default": ""
+    }
+  },
+  "Resources": {}
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		raw, err := json.MarshalIndent(tt.in, "", "  ")
+		assert.NoError(t, err)
+		assert.Equal(t, tt.out, string(raw))
+	}
+}
+
+func buildTemplate(f func(*Template)) *Template {
+	t := NewTemplate()
+	f(t)
+	return t
+}

--- a/processes.go
+++ b/processes.go
@@ -81,6 +81,10 @@ type Process struct {
 
 	// The allow number of unix processes within the container.
 	Nproc constraints.Nproc `json:"Nproc,omitempty"`
+
+	// A cron expression. If provided, the process will be run as a
+	// scheduled task.
+	Cron *string `json:"cron,omitempty"`
 }
 
 // Constraints returns a constraints.Constraints from this Process definition.

--- a/procfile/README.md
+++ b/procfile/README.md
@@ -37,8 +37,16 @@ worker:
 
 **Command**
 
-Specifies the command that should be run when executing this process 
+Specifies the command that should be run when executing this process.
 
 ```yaml
 command: ./bin/web
+```
+
+**Cron**
+
+When provided, signifies that the process is a scheduled process. The value should be a valid cron expression.
+
+```yaml
+cron: * * * * * * // Run once every minute
 ```

--- a/procfile/procfile.go
+++ b/procfile/procfile.go
@@ -23,6 +23,7 @@ func (e ExtendedProcfile) version() string {
 
 type Process struct {
 	Command interface{} `yaml:"command"`
+	Cron    *string     `yaml:"cron,omitempty"`
 }
 
 // StandardProcfile represents a standard Procfile.

--- a/releases.go
+++ b/releases.go
@@ -317,6 +317,7 @@ func newSchedulerProcess(release *Release, name string, p Process) *scheduler.Pr
 		CPUShares:   uint(p.CPUShare),
 		Nproc:       uint(p.Nproc),
 		Exposure:    processExposure(release.App, name),
+		Schedule:    processSchedule(name, p),
 	}
 }
 
@@ -351,6 +352,14 @@ func processExposure(app *App, process string) *scheduler.Exposure {
 	}
 
 	return exposure
+}
+
+func processSchedule(name string, p Process) scheduler.Schedule {
+	if p.Cron != nil {
+		return scheduler.CRONSchedule(*p.Cron)
+	}
+
+	return nil
 }
 
 func appendMessageToDescription(main string, user *User, message string) string {

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -50,9 +50,9 @@
   },
   "Parameters": {
     "DNS": {
-      "Default": "true",
+      "Type": "String",
       "Description": "When set to `true`, CNAME's will be altered",
-      "Type": "String"
+      "Default": "true"
     },
     "RestartKey": {
       "Type": "String"

--- a/scheduler/cloudformation/templates/cron.json
+++ b/scheduler/cloudformation/templates/cron.json
@@ -1,0 +1,170 @@
+{
+  "Conditions": {
+    "DNSCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "DNS"
+        },
+        "true"
+      ]
+    }
+  },
+  "Outputs": {
+    "EmpireVersion": {
+      "Value": "0.10.1"
+    },
+    "Release": {
+      "Value": "v1"
+    },
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          []
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "DNS": {
+      "Type": "String",
+      "Description": "When set to `true`, CNAME's will be altered",
+      "Default": "true"
+    },
+    "RestartKey": {
+      "Type": "String"
+    },
+    "sendemailsScale": {
+      "Type": "String"
+    },
+    "vacuumScale": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "RunTaskFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "\nimport boto3\nimport logging\n\nlogger = logging.getLogger()\nlogger.setLevel(logging.INFO)\n\necs = boto3.client('ecs')\n\ndef handler(event, context):\n  logger.info('Request Received')\n  logger.info(event)\n\n  resp = ecs.run_task(\n    cluster=event['cluster'],\n    taskDefinition=event['taskDefinition'],\n    count=event['count'],\n    startedBy=event['startedBy'])\n\n  return map(lambda x: x['taskArn'], resp['tasks'])"
+        },
+        "Description": "Lambda function to run an ECS task",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:iam::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":role/",
+              "ecsServiceRole"
+            ]
+          ]
+        },
+        "Runtime": "python2.7"
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "sendemailsTaskDefinition": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/send-emails"
+            ],
+            "Cpu": 256,
+            "DockerLabels": {
+              "empire.app.process": "send-emails"
+            },
+            "Environment": [],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 128,
+            "Name": "send-emails",
+            "Ulimits": [
+              {
+                "HardLimit": 256,
+                "Name": "nproc",
+                "SoftLimit": 256
+              }
+            ]
+          }
+        ],
+        "Volumes": []
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    },
+    "sendemailsTrigger": {
+      "Properties": {
+        "Description": "Rule to periodically trigger the `send-emails` scheduled task",
+        "RoleArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:iam::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":role/",
+              "ecsServiceRole"
+            ]
+          ]
+        },
+        "ScheduleExpression": "cron(* * * * *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RunTaskFunction",
+                "Arn"
+              ]
+            },
+            "Id": "f",
+            "Input": {
+              "Fn::Join": [
+                "",
+                [
+                  "{\"taskDefinition\":\"",
+                  {
+                    "Ref": "sendemailsTaskDefinition"
+                  },
+                  "\",\"count\":",
+                  {
+                    "Ref": "sendemailsScale"
+                  },
+                  ",\"cluster\":\"",
+                  "cluster",
+                  "\",\"startedBy\": \"",
+                  "1234",
+                  "\"}"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "sendemailsTriggerPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RunTaskFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "sendemailsTrigger",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    }
+  }
+}

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -50,9 +50,9 @@
   },
   "Parameters": {
     "DNS": {
-      "Default": "true",
+      "Type": "String",
       "Description": "When set to `true`, CNAME's will be altered",
-      "Type": "String"
+      "Default": "true"
     },
     "RestartKey": {
       "Type": "String"

--- a/scheduler/cloudformation/templates/standard.json
+++ b/scheduler/cloudformation/templates/standard.json
@@ -50,9 +50,9 @@
   },
   "Parameters": {
     "DNS": {
-      "Default": "true",
+      "Type": "String",
       "Description": "When set to `true`, CNAME's will be altered",
-      "Type": "String"
+      "Default": "true"
     },
     "RestartKey": {
       "Type": "String"

--- a/scheduler/ecs/ecs.go
+++ b/scheduler/ecs/ecs.go
@@ -324,6 +324,10 @@ func (m *Scheduler) Stop(ctx context.Context, instanceID string) error {
 
 // CreateProcess creates an ECS service for the process.
 func (m *Scheduler) CreateProcess(ctx context.Context, app *scheduler.App, p *scheduler.Process) error {
+	if p.Schedule != nil {
+		return errors.New("%s: scheduled processes are not supported by this backend")
+	}
+
 	loadBalancer, err := m.loadBalancer(ctx, app, p)
 	if err != nil {
 		return err

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -46,12 +46,6 @@ type Process struct {
 	// Labels to set on the container.
 	Labels map[string]string
 
-	// Exposure is the level of exposure for this process.
-	Exposure *Exposure
-
-	// Instances is the desired instances of this service to run.
-	Instances uint
-
 	// The amount of RAM to allocate to this process in bytes.
 	MemoryLimit uint
 
@@ -61,7 +55,22 @@ type Process struct {
 
 	// ulimit -u
 	Nproc uint
+
+	// Instances is the desired instances of this service to run.
+	Instances uint
+
+	// Exposure is the level of exposure for this process.
+	Exposure *Exposure
+
+	// Can be used to setup a CRON schedule to run this task periodically.
+	Schedule Schedule
 }
+
+// Schedule represents a Schedule for scheduled tasks that run periodically.
+type Schedule interface{}
+
+// CRONSchedule is a Schedule implementation that represents a CRON expression.
+type CRONSchedule string
 
 // Exposure controls the exposure settings for a process.
 type Exposure struct {

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -155,6 +155,11 @@ func (p *ECSServiceResource) delete(ctx context.Context, service, cluster *strin
 			// removed already.
 			return nil
 		}
+		if err, ok := err.(awserr.Error); ok && strings.Contains(err.Message(), "Service not found") {
+			// If the service is not active, it was probably manually
+			// removed already.
+			return nil
+		}
 		return fmt.Errorf("error scaling service to 0: %v", err)
 	}
 

--- a/tests/cli/scale_test.go
+++ b/tests/cli/scale_test.go
@@ -17,7 +17,7 @@ func TestScale(t *testing.T) {
 		},
 		{
 			"scale -l -a acme-inc",
-			"web=2:1X",
+			"scheduled=0:1X web=2:1X worker=0:1X",
 		},
 		{
 			"dynos -a acme-inc",

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"sort"
 	"testing"
 	"time"
 
@@ -113,6 +114,23 @@ func TestEmpire_Deploy(t *testing.T) {
 		},
 		Processes: []*scheduler.Process{
 			{
+				Type:        "scheduled",
+				Image:       img,
+				Command:     []string{"./bin/scheduled"},
+				Schedule:    scheduler.CRONSchedule("* * * * * *"),
+				Instances:   0,
+				MemoryLimit: 536870912,
+				CPUShares:   256,
+				Nproc:       256,
+				Env: map[string]string{
+					"EMPIRE_PROCESS": "scheduled",
+					"SOURCE":         "acme-inc.scheduled.v1",
+				},
+				Labels: map[string]string{
+					"empire.app.process": "scheduled",
+				},
+			},
+			{
 				Type:    "web",
 				Image:   img,
 				Command: []string{"./bin/web"},
@@ -129,6 +147,22 @@ func TestEmpire_Deploy(t *testing.T) {
 				},
 				Labels: map[string]string{
 					"empire.app.process": "web",
+				},
+			},
+			{
+				Type:        "worker",
+				Image:       img,
+				Command:     []string{"./bin/worker"},
+				Instances:   0,
+				MemoryLimit: 536870912,
+				CPUShares:   256,
+				Nproc:       256,
+				Env: map[string]string{
+					"EMPIRE_PROCESS": "worker",
+					"SOURCE":         "acme-inc.worker.v1",
+				},
+				Labels: map[string]string{
+					"empire.app.process": "worker",
 				},
 			},
 		},
@@ -175,12 +209,10 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 	e := empiretest.NewEmpire(t)
 	s := new(mockScheduler)
 	e.Scheduler = scheduler.NewFakeScheduler()
-	e.ProcfileExtractor = empire.ProcfileExtractorFunc(func(ctx context.Context, img image.Image, w io.Writer) ([]byte, error) {
-		return procfile.Marshal(procfile.ExtendedProcfile{
-			"web": procfile.Process{
-				Command: []string{"./bin/web"},
-			},
-		})
+	e.ProcfileExtractor = empiretest.ExtractProcfile(procfile.ExtendedProcfile{
+		"web": procfile.Process{
+			Command: []string{"./bin/web"},
+		},
 	})
 
 	user := &empire.User{Name: "ejholmes"}
@@ -394,6 +426,11 @@ func TestEmpire_Set(t *testing.T) {
 	e := empiretest.NewEmpire(t)
 	s := new(mockScheduler)
 	e.Scheduler = s
+	e.ProcfileExtractor = empiretest.ExtractProcfile(procfile.ExtendedProcfile{
+		"web": procfile.Process{
+			Command: []string{"./bin/web"},
+		},
+	})
 
 	user := &empire.User{Name: "ejholmes"}
 
@@ -518,7 +555,18 @@ type mockScheduler struct {
 	mock.Mock
 }
 
+type processesByType []*scheduler.Process
+
+func (e processesByType) Len() int           { return len(e) }
+func (e processesByType) Less(i, j int) bool { return e[i].Type < e[j].Type }
+func (e processesByType) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
+
 func (m *mockScheduler) Submit(_ context.Context, app *scheduler.App) error {
+	// mock.Mock checks the order of slices, so sort by process name.
+	p := processesByType(app.Processes)
+	sort.Sort(p)
+	app.Processes = p
+
 	args := m.Called(app)
 	return args.Error(0)
 }


### PR DESCRIPTION
https://github.com/remind101/empire/wiki/Roadmap#scheduled-tasks

Closes https://github.com/remind101/empire/issues/300. 

This adds first class support for scheduled tasks. It uses a combination of CloudWatch events, lambda, and ECS to run scheduled jobs in separate containers.

Lots of advantages to this, over doing some kind of in process cron:

1. Memory/CPU constraints can be controlled for each scheduled task, since the jobs run in a short lived ecs tasks.
2. `emp restarts` won't affect the scheduled tasks. Scheduled tasks that are already running will continue to run.
3. Scheduled tasks will show up in `emp ps`:

   ```console
$ emp deploy remind101/acme-inc:scheduled-job
$ emp scale scheduled-job=1
$ emp ps
v54.scheduled-job.9b649d34-b4f5-4fb7-bfe2-889d80dbd3c9  1X  RUNNING  11s  "sleep 60"
v54.web.fd130482-675f-4611-a599-eb0da1879a10            1X  RUNNING   9m  "acme-inc server"
$ sleep 60
$ emp ps
v54.scheduled-job.0aec4323-e518-400c-9c50-e2b0cbd5babf  1X  RUNNING  12s  "sleep 60"
v54.web.fd130482-675f-4611-a599-eb0da1879a10            1X  RUNNING  15m  "acme-inc server"
   ```

Scheduled tasks are configured in the Procfile, using the new extended Procfile format. To mark a process as a scheduled job, you add a `cron:` field to the process, with a cron expression for when it should run:

```yaml
web:
  command: ./bin/web
scheduled-job:
  command: ./bin/scheduled-job
  cron: * * * * * # Run once every minute
```

By default, scheduled processes are disabled by default (like other processes), and need to be scaled up to run:

```console
$ emp scale scheduled-job=1
```

You can scale past 1 to run multiple tasks at once when the cron event triggers:

```console
$ emp scale scheduled-job=2 # run 2 of these when triggered
$ emp ps
v56.scheduled-job.16d9458f-99d8-4c7b-8631-da2d16b45676  1X  RUNNING  39s  "sleep 60"
v56.scheduled-job.28edbe42-3b2d-4cb6-8434-8f9331ad1ccf  1X  RUNNING  39s  "sleep 60"
v56.web.1507b937-529d-4179-aaef-63fa18f073f0            1X  RUNNING   9m  "acme-inc server"
```

And you can scale back down to 0 to disable the scheduled process:

```console
$ emp scale scheduled-job=0
```

**TODO**

* [x] Throw errors in legacy ECS backend.
* [ ] Validate cron expression.
* [x] Dedup the lambda function?
* [x] More tests
* [x] Docs