### PR TITLE
Adds a DeploymentStream type

### DIFF
--- a/empire.go
+++ b/empire.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/jinzhu/gorm"
 	"github.com/remind101/empire/pkg/dockerutil"
@@ -535,9 +534,9 @@ type DeployOpts struct {
 	// Environment is the environment where the image is being deployed
 	Environment string
 
-	// Output is an io.Writer where deployment output and events will be
-	// streamed in jsonmessage format.
-	Output io.Writer
+	// Output is a DeploymentStream where deployment output and events will
+	// be streamed in jsonmessage format.
+	Output *DeploymentStream
 
 	// Commit message
 	Message string
@@ -708,15 +707,6 @@ type MessageRequiredError struct{}
 
 func (e *MessageRequiredError) Error() string {
 	return "Missing required option: 'Message'"
-}
-
-func newJSONMessageError(err error) jsonmessage.JSONMessage {
-	return jsonmessage.JSONMessage{
-		ErrorMessage: err.Error(),
-		Error: &jsonmessage.JSONError{
-			Message: err.Error(),
-		},
-	}
 }
 
 // PullAndExtract returns a ProcfileExtractor that will pull the image using the

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -3,14 +3,12 @@
 package scheduler
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
 
 	"golang.org/x/net/context"
 
-	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/remind101/empire/pkg/image"
 	"github.com/remind101/pkg/logger"
 )
@@ -199,21 +197,6 @@ func (fn StatusStreamFunc) Publish(status Status) error {
 var NullStatusStream = StatusStreamFunc(func(status Status) error {
 	return nil
 })
-
-// jsonmessageStatusStream implements the StatusStream interface with support
-// for writing jsonmessages to the provided io.Writer
-type jsonmessageStatusStream struct {
-	w io.Writer
-}
-
-// NewJSONMessageStream returns a new instance of the default status stream.
-func NewJSONMessageStream(w io.Writer) StatusStream {
-	return &jsonmessageStatusStream{w: w}
-}
-
-func (s *jsonmessageStatusStream) Publish(status Status) error {
-	return json.NewEncoder(s.w).Encode(jsonmessage.JSONMessage{Status: fmt.Sprintf("Status: %s", status.Message)})
-}
 
 func Publish(ctx context.Context, stream StatusStream, msg string) {
 	if stream != nil {

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -58,7 +58,7 @@ func (d *EmpireDeployer) Deploy(ctx context.Context, event events.Deployment, w 
 
 	_, err = d.empire.Deploy(ctx, empire.DeployOpts{
 		Image:  img,
-		Output: p,
+		Output: empire.NewDeploymentStream(p),
 		User:   &empire.User{Name: event.Deployment.Creator.Login},
 		Stream: true,
 	})

--- a/server/heroku/deployments.go
+++ b/server/heroku/deployments.go
@@ -55,7 +55,7 @@ func newDeployOpts(ctx context.Context, w http.ResponseWriter, req *http.Request
 	opts := empire.DeployOpts{
 		User:    UserFromContext(ctx),
 		Image:   form.Image,
-		Output:  streamhttp.StreamingResponseWriter(w),
+		Output:  empire.NewDeploymentStream(streamhttp.StreamingResponseWriter(w)),
 		Message: m,
 		Stream:  form.Stream,
 	}

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -171,7 +171,7 @@ func TestEmpire_Deploy(t *testing.T) {
 	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
-		Output: ioutil.Discard,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
 		Image:  img,
 	})
 	assert.NoError(t, err)
@@ -191,7 +191,7 @@ func TestEmpire_Deploy_ImageNotFound(t *testing.T) {
 	// app.
 	_, err := e.Deploy(context.Background(), empire.DeployOpts{
 		User:   &empire.User{Name: "ejholmes"},
-		Output: ioutil.Discard,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
 		Image:  image.Image{Repository: "remind101/acme-inc"},
 	})
 	assert.Error(t, err)
@@ -220,7 +220,7 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 	// Create the first release for this app.
 	r, err := e.Deploy(context.Background(), empire.DeployOpts{
 		User:   user,
-		Output: ioutil.Discard,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
 		Image:  image.Image{Repository: "remind101/acme-inc"},
 	})
 	assert.NoError(t, err)
@@ -248,7 +248,7 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 	go func() {
 		r, err := e.Deploy(context.Background(), empire.DeployOpts{
 			User:   user,
-			Output: ioutil.Discard,
+			Output: empire.NewDeploymentStream(ioutil.Discard),
 			Image:  image.Image{Repository: "remind101/acme-inc", Tag: "v2"},
 		})
 		assert.NoError(t, err)
@@ -260,7 +260,7 @@ func TestEmpire_Deploy_Concurrent(t *testing.T) {
 
 	r, err = e.Deploy(context.Background(), empire.DeployOpts{
 		User:   user,
-		Output: ioutil.Discard,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
 		Image:  image.Image{Repository: "remind101/acme-inc", Tag: "v3"},
 	})
 	assert.NoError(t, err)
@@ -286,7 +286,7 @@ func TestEmpire_Run(t *testing.T) {
 	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
-		Output: ioutil.Discard,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
 		Image:  img,
 	})
 	assert.NoError(t, err)
@@ -360,7 +360,7 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
-		Output: ioutil.Discard,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
 		Image:  img,
 	})
 	assert.NoError(t, err)
@@ -495,7 +495,7 @@ func TestEmpire_Set(t *testing.T) {
 	_, err = e.Deploy(context.Background(), empire.DeployOpts{
 		App:    app,
 		User:   user,
-		Output: ioutil.Discard,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
 		Image:  img,
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
The fact that `DeployOpts.Output` was an io.Writer was kind of misleading, because everything that gets written to it needs to be in jsonmessage format.

This changes the type to a `DeploymentStream`, which adds some convenience on top of an io.Writer to encode jsonmessages, and give us static typing to give us a little more assurance that what is going into the stream is in jsonmessage format. This also gives us a good place to implement the `scheduler.StatusStream` interface, so we can just re-use the DeploymentStream and pass it to the scheduler, when streaming is enabled.