### PR TITLE
Expand list of valid log drivers

### DIFF
--- a/pkg/ecsutil/ecs.go
+++ b/pkg/ecsutil/ecs.go
@@ -240,11 +240,6 @@ func (c *limitedClient) DescribeTasks(ctx context.Context, input *ecs.DescribeTa
 	}, nil
 }
 
-var validLogDrivers = map[string]bool{
-	"json-file": true,
-	"syslog":    true,
-}
-
 func NewLogConfiguration(logDriver string, logOpts []string) *ecs.LogConfiguration {
 	if logDriver == "" {
 		// Default to the docker daemon default logging driver.
@@ -258,11 +253,6 @@ func NewLogConfiguration(logDriver string, logOpts []string) *ecs.LogConfigurati
 		if len(logOpt) == 2 {
 			logOptions[logOpt[0]] = &logOpt[1]
 		}
-	}
-
-	_, ok := validLogDrivers[logDriver]
-	if !ok {
-		logDriver = "json-file"
 	}
 
 	return &ecs.LogConfiguration{


### PR DESCRIPTION
Currently the list of valid log drivers is limited to only `json-file` and `syslog`:

https://github.com/remind101/empire/blob/5facae771b03e976e6d68437f86bdb6f6ef705c1/pkg/ecsutil/ecs.go#L243-L246

This should be at the very least expanded to include all of the valid log drivers in Docker (which I know varies by version).  At the most, this check could be taken out completely and the user can pass anything they want in...I'd expect ECS to blow up if the user passed in something invalid.

I see an argument for removing the check since it'd do away with the need to keep up with the list of valid log drivers in Docker.

Thoughts on expanding the list vs removing it @ejholmes ?