### PR TITLE
Custom::ECSTaskDefinition resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * The CloudFormation backend now uses the Custom::ECSService resource instead of AWS::ECS::Service, by default [#877](https://github.com/remind101/empire/pull/877)
 * The database schema version is now checked at boot, as well as in the http health checks. [#893](https://github.com/remind101/empire/pull/893)
 * The log level within empire can now be configured when starting the service. [#929](https://github.com/remind101/empire/issues/929)
+* The CloudFormation backend now has experimental support for a `Custom::ECSTaskDefinition` resource that greatly reduces the size of generated templates. [#935](https://github.com/remind101/empire/pull/935)
 
 **Bugs**
 

--- a/migrations.go
+++ b/migrations.go
@@ -545,6 +545,21 @@ ALTER TABLE apps ADD COLUMN exposure TEXT NOT NULL default 'private'`,
 			`DROP TABLE scheduler_migration`,
 		}),
 	},
+
+	// This migration adds a table that stores environment variables for the
+	// Custom::ECSEnvironment resource.
+	{
+		ID: 18,
+		Up: migrate.Queries([]string{
+			`CREATE TABLE ecs_environment (
+  id uuid NOT NULL DEFAULT uuid_generate_v4() primary key,
+  environment json NOT NULL
+)`,
+		}),
+		Down: migrate.Queries([]string{
+			`DROP TABLE ecs_environment`,
+		}),
+	},
 }
 
 // latestSchema returns the schema version that this version of Empire should be

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -29,5 +29,20 @@ func TestMigrations(t *testing.T) {
 }
 
 func TestLatestSchema(t *testing.T) {
-	assert.Equal(t, 17, latestSchema())
+	assert.Equal(t, 18, latestSchema())
+}
+
+func TestNoDuplicateMigrations(t *testing.T) {
+	visited := make(map[int]bool)
+	expectedID := 1
+	for _, m := range migrations {
+		if visited[m.ID] {
+			t.Fatalf("Migration %d appears more than once", m.ID)
+		}
+		visited[m.ID] = true
+		if m.ID != expectedID {
+			t.Fatalf("Expected migration %d after %d, but got %d", expectedID, expectedID-1, m.ID)
+		}
+		expectedID++
+	}
 }

--- a/pkg/troposphere/functions.go
+++ b/pkg/troposphere/functions.go
@@ -1,13 +1,21 @@
 package troposphere
 
 // Ref provides a helper for the Ref function.
-func Ref(ref string) interface{} {
-	return map[string]string{"Ref": ref}
+func Ref(ref interface{}) interface{} {
+	switch v := ref.(type) {
+	case NamedResource:
+		ref = v.Name
+	}
+	return map[string]interface{}{"Ref": ref}
 }
 
 // GetAtt provides a helper for the GetAtt function.
-func GetAtt(ref, attr string) interface{} {
-	return map[string][]string{"Fn::GetAtt": []string{ref, attr}}
+func GetAtt(ref, attr interface{}) interface{} {
+	switch v := ref.(type) {
+	case NamedResource:
+		ref = v.Name
+	}
+	return map[string][]interface{}{"Fn::GetAtt": []interface{}{ref, attr}}
 }
 
 // Equals is a helper for the Fn::Equals function.

--- a/pkg/troposphere/troposphere.go
+++ b/pkg/troposphere/troposphere.go
@@ -2,6 +2,8 @@
 // primitives for building CloudFormation templates.
 package troposphere
 
+import "fmt"
+
 // Template represents a CloudFormation template that can be built.
 type Template struct {
 	Conditions map[string]interface{}
@@ -18,6 +20,14 @@ func NewTemplate() *Template {
 		Parameters: make(map[string]Parameter),
 		Resources:  make(map[string]Resource),
 	}
+}
+
+// AddResource adds a named resource to the template.
+func (t *Template) AddResource(resource NamedResource) {
+	if _, ok := t.Resources[resource.Name]; ok {
+		panic(fmt.Sprintf("%s is already defined in the template", resource.Name))
+	}
+	t.Resources[resource.Name] = resource.Resource
 }
 
 // Parameter represents a CloudFormation parameter.
@@ -38,4 +48,10 @@ type Resource struct {
 	Properties interface{} `json:"Properties,omitempty"`
 	Type       interface{} `json:"Type,omitempty"`
 	Version    interface{} `json:"Version,omitempty"`
+}
+
+// NamedResource bundles a resource to a name.
+type NamedResource struct {
+	Name     string
+	Resource Resource
 }

--- a/scheduler/cloudformation/resources.go
+++ b/scheduler/cloudformation/resources.go
@@ -1,0 +1,32 @@
+package cloudformation
+
+type PortMappingProperties struct {
+	ContainerPort interface{} `json:",omitempty"`
+	HostPort      interface{} `json:",omitempty"`
+}
+
+type ContainerDefinitionProperties struct {
+	Command          interface{}              `json:",omitempty"`
+	Cpu              interface{}              `json:",omitempty"`
+	DockerLabels     map[string]interface{}   `json:",omitempty"`
+	Environment      interface{}              `json:",omitempty"`
+	Essential        interface{}              `json:",omitempty"`
+	Image            interface{}              `json:",omitempty"`
+	Memory           interface{}              `json:",omitempty"`
+	Name             interface{}              `json:",omitempty"`
+	PortMappings     []*PortMappingProperties `json:",omitempty"`
+	Ulimits          interface{}              `json:",omitempty"`
+	LogConfiguration interface{}              `json:",omitempty"`
+}
+
+type TaskDefinitionProperties struct {
+	ContainerDefinitions []*ContainerDefinitionProperties `json:",omitempty"`
+	Volumes              []interface{}
+}
+
+type CustomTaskDefinitionProperties struct {
+	ContainerDefinitions []*ContainerDefinitionProperties `json:",omitempty"`
+	Family               interface{}                      `json:",omitempty"`
+	ServiceToken         interface{}                      `json:",omitempty"`
+	Volumes              []interface{}
+}

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -95,6 +95,53 @@ func TestEmpireTemplate(t *testing.T) {
 		},
 
 		{
+			"custom.json",
+			&scheduler.App{
+				ID:      "1234",
+				Release: "v1",
+				Name:    "acme-inc",
+				Env: map[string]string{
+					"ECS_TASK_DEFINITION": "custom",
+				},
+				Processes: []*scheduler.Process{
+					{
+						Type:    "web",
+						Image:   image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
+						Command: []string{"./bin/web"},
+						Env: map[string]string{
+							"B":   "foo",
+							"A":   "foo",
+							"FOO": "bar",
+						},
+						Exposure: &scheduler.Exposure{
+							Type: &scheduler.HTTPExposure{},
+						},
+						Labels: map[string]string{
+							"empire.app.process": "web",
+						},
+						MemoryLimit: 128 * bytesize.MB,
+						CPUShares:   256,
+						Instances:   1,
+						Nproc:       256,
+					},
+					{
+						Type:      "vacuum",
+						Image:     image.Image{Repository: "remind101/acme-inc", Tag: "latest"},
+						Command:   []string{"./bin/vacuum"},
+						Schedule:  scheduler.CRONSchedule("* * * * *"),
+						Instances: 1,
+						Labels: map[string]string{
+							"empire.app.process": "vacuum",
+						},
+						MemoryLimit: 128 * bytesize.MB,
+						CPUShares:   256,
+						Nproc:       256,
+					},
+				},
+			},
+		},
+
+		{
 			"cron.json",
 			&scheduler.App{
 				ID:      "1234",
@@ -174,6 +221,7 @@ func TestEmpireTemplate_Large(t *testing.T) {
 	buf := new(bytes.Buffer)
 
 	err := tmpl.Execute(buf, app)
+	t.Logf("Template size: %d bytes", buf.Len())
 	assert.NoError(t, err)
 	assert.Condition(t, func() bool {
 		return buf.Len() < MaxTemplateSize

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -262,7 +262,6 @@
             "Image": "remind101/acme-inc:latest",
             "Memory": 0,
             "Name": "worker",
-            "PortMappings": [],
             "Ulimits": []
           }
         ],

--- a/scheduler/cloudformation/templates/custom.json
+++ b/scheduler/cloudformation/templates/custom.json
@@ -1,0 +1,372 @@
+{
+  "Conditions": {
+    "DNSCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "DNS"
+        },
+        "true"
+      ]
+    }
+  },
+  "Outputs": {
+    "EmpireVersion": {
+      "Value": "x.x.x"
+    },
+    "Release": {
+      "Value": "v1"
+    },
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Ref": "webService"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "DNS": {
+      "Type": "String",
+      "Description": "When set to `true`, CNAME's will be altered",
+      "Default": "true"
+    },
+    "RestartKey": {
+      "Type": "String"
+    },
+    "vacuumScale": {
+      "Type": "String"
+    },
+    "webScale": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "AppEnvironment": {
+      "Properties": {
+        "Environment": [
+          {
+            "Name": "ECS_TASK_DEFINITION",
+            "Value": "custom"
+          }
+        ],
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::ECSEnvironment"
+    },
+    "CNAME": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "acme-inc.empire",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
+          }
+        ],
+        "TTL": 60,
+        "Type": "CNAME"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
+    "RunTaskFunction": {
+      "Properties": {
+        "Code": {
+          "ZipFile": "\nimport boto3\nimport logging\n\nlogger = logging.getLogger()\nlogger.setLevel(logging.INFO)\n\necs = boto3.client('ecs')\n\ndef handler(event, context):\n  logger.info('Request Received')\n  logger.info(event)\n\n  resp = ecs.run_task(\n    cluster=event['cluster'],\n    taskDefinition=event['taskDefinition'],\n    count=event['count'],\n    startedBy=event['startedBy'])\n\n  return map(lambda x: x['taskArn'], resp['tasks'])"
+        },
+        "Description": "Lambda function to run an ECS task",
+        "Handler": "index.handler",
+        "Role": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:iam::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":role/",
+              "ecsServiceRole"
+            ]
+          ]
+        },
+        "Runtime": "python2.7"
+      },
+      "Type": "AWS::Lambda::Function"
+    },
+    "vacuumEnvironment": {
+      "Properties": {
+        "Environment": [],
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::ECSEnvironment"
+    },
+    "vacuumTD": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/vacuum"
+            ],
+            "Cpu": 256,
+            "DockerLabels": {
+              "empire.app.process": "vacuum"
+            },
+            "Environment": [
+              {
+                "Ref": "AppEnvironment"
+              },
+              {
+                "Ref": "vacuumEnvironment"
+              }
+            ],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 128,
+            "Name": "vacuum",
+            "Ulimits": [
+              {
+                "HardLimit": 256,
+                "Name": "nproc",
+                "SoftLimit": 256
+              }
+            ]
+          }
+        ],
+        "Family": "acme-inc-vacuum",
+        "ServiceToken": "sns topic arn",
+        "Volumes": []
+      },
+      "Type": "Custom::ECSTaskDefinition"
+    },
+    "vacuumTrigger": {
+      "Properties": {
+        "Description": "Rule to periodically trigger the `vacuum` scheduled task",
+        "RoleArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:iam::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":role/",
+              "ecsServiceRole"
+            ]
+          ]
+        },
+        "ScheduleExpression": "cron(* * * * *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RunTaskFunction",
+                "Arn"
+              ]
+            },
+            "Id": "f",
+            "Input": {
+              "Fn::Join": [
+                "",
+                [
+                  "{\"taskDefinition\":\"",
+                  {
+                    "Ref": "vacuumTD"
+                  },
+                  "\",\"count\":",
+                  {
+                    "Ref": "vacuumScale"
+                  },
+                  ",\"cluster\":\"",
+                  "cluster",
+                  "\",\"startedBy\": \"",
+                  "1234",
+                  "\"}"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "vacuumTriggerPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RunTaskFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "vacuumTrigger",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
+    },
+    "web8080InstancePort": {
+      "Properties": {
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::InstancePort",
+      "Version": "1.0"
+    },
+    "webEnvironment": {
+      "Properties": {
+        "Environment": [
+          {
+            "Name": "A",
+            "Value": "foo"
+          },
+          {
+            "Name": "B",
+            "Value": "foo"
+          },
+          {
+            "Name": "FOO",
+            "Value": "bar"
+          },
+          {
+            "Name": "PORT",
+            "Value": "8080"
+          }
+        ],
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::ECSEnvironment"
+    },
+    "webLoadBalancer": {
+      "Properties": {
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 30
+        },
+        "CrossZone": true,
+        "Listeners": [
+          {
+            "InstancePort": {
+              "Fn::GetAtt": [
+                "web8080InstancePort",
+                "InstancePort"
+              ]
+            },
+            "InstanceProtocol": "http",
+            "LoadBalancerPort": 80,
+            "Protocol": "http"
+          }
+        ],
+        "Scheme": "internal",
+        "SecurityGroups": [
+          "sg-e7387381"
+        ],
+        "Subnets": [
+          "subnet-bb01c4cd",
+          "subnet-c85f4091"
+        ],
+        "Tags": [
+          {
+            "Key": "empire.app.process",
+            "Value": "web"
+          }
+        ]
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+    },
+    "webService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "webScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "webLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "ServiceName": "acme-inc-web",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "webTD"
+        }
+      },
+      "Type": "Custom::ECSService"
+    },
+    "webTD": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/web"
+            ],
+            "Cpu": 256,
+            "DockerLabels": {
+              "cloudformation.restart-key": {
+                "Ref": "RestartKey"
+              },
+              "empire.app.process": "web"
+            },
+            "Environment": [
+              {
+                "Ref": "AppEnvironment"
+              },
+              {
+                "Ref": "webEnvironment"
+              }
+            ],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 128,
+            "Name": "web",
+            "PortMappings": [
+              {
+                "ContainerPort": 8080,
+                "HostPort": {
+                  "Fn::GetAtt": [
+                    "web8080InstancePort",
+                    "InstancePort"
+                  ]
+                }
+              }
+            ],
+            "Ulimits": [
+              {
+                "HardLimit": 256,
+                "Name": "nproc",
+                "SoftLimit": 256
+              }
+            ]
+          }
+        ],
+        "Family": "acme-inc-web",
+        "ServiceToken": "sns topic arn",
+        "Volumes": []
+      },
+      "Type": "Custom::ECSTaskDefinition"
+    }
+  }
+}

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -1,6 +1,10 @@
 package cloudformation
 
 import (
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -10,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/mitchellh/hashstructure"
 	"github.com/remind101/empire/pkg/cloudformation/customresources"
 	"github.com/remind101/pkg/reporter"
 )
@@ -19,6 +24,8 @@ type ecsClient interface {
 	DeleteService(*ecs.DeleteServiceInput) (*ecs.DeleteServiceOutput, error)
 	UpdateService(*ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error)
 	WaitUntilServicesStable(*ecs.DescribeServicesInput) error
+	RegisterTaskDefinition(*ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
+	DeregisterTaskDefinition(*ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error)
 }
 
 type LoadBalancer struct {
@@ -62,7 +69,8 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.
 	case customresources.Update:
 		id := req.PhysicalResourceId
 
-		if requiresReplacement(properties, oldProperties) {
+		// TODO: Update this to use hashstructure.
+		if serviceRequiresReplacement(properties, oldProperties) {
 			// If we can't update the service, we'll need to create a new
 			// one, and destroy the old one.
 			oldId := id
@@ -174,9 +182,257 @@ func (p *ECSServiceResource) delete(ctx context.Context, service, cluster *strin
 	return nil
 }
 
+type PortMapping struct {
+	ContainerPort *customresources.IntValue
+	HostPort      *customresources.IntValue
+}
+
+type Ulimit struct {
+	Name      *string
+	HardLimit *customresources.IntValue
+	SoftLimit *customresources.IntValue
+}
+
+type ContainerDefinition struct {
+	Name             *string
+	Command          []*string
+	Cpu              *customresources.IntValue
+	Image            *string
+	Essential        *string
+	Memory           *customresources.IntValue
+	PortMappings     []PortMapping
+	DockerLabels     map[string]*string
+	Ulimits          []Ulimit
+	Environment      []string
+	LogConfiguration *ecs.LogConfiguration
+}
+
+// TaskDefinitionProperties are properties passed to the
+// Custom::ECSTaskDefinition custom resource.
+type ECSTaskDefinitionProperties struct {
+	Family               *string
+	TaskRoleArn          *string
+	ContainerDefinitions []ContainerDefinition
+}
+
+func (p *ECSTaskDefinitionProperties) ReplacementHash() (uint64, error) {
+	return hashstructure.Hash(p, nil)
+}
+
+// ECSTaskDefinitionResource is a custom resource that provisions ECS task
+// definitions.
+type ECSTaskDefinitionResource struct {
+	ecs              ecsClient
+	environmentStore environmentStore
+}
+
+func newECSTaskDefinitionProvisioner(resource *ECSTaskDefinitionResource) *provisioner {
+	return &provisioner{
+		properties: func() properties {
+			return &ECSTaskDefinitionProperties{}
+		},
+		Create: resource.Create,
+		Update: resource.Update,
+		Delete: resource.Delete,
+	}
+}
+
+func (p *ECSTaskDefinitionResource) Create(ctx context.Context, req customresources.Request) (string, interface{}, error) {
+	properties := req.ResourceProperties.(*ECSTaskDefinitionProperties)
+	id, err := p.register(properties, req.Hash())
+	return id, nil, err
+}
+
+func (p *ECSTaskDefinitionResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
+	// Updates of ECSTaskDefinition will generate a replacement resource, so
+	// if we've reached this point, it means that the environment is the
+	// same as it was before.
+	return nil, nil
+}
+
+func (p *ECSTaskDefinitionResource) Delete(ctx context.Context, req customresources.Request) error {
+	return p.delete(req.PhysicalResourceId)
+}
+
+func (p *ECSTaskDefinitionResource) resolvedEnvironment(ids ...string) ([]*ecs.KeyValuePair, error) {
+	var env []*ecs.KeyValuePair
+	for _, id := range ids {
+		e, err := p.environmentStore.fetch(id)
+		if err != nil {
+			return nil, err
+		}
+		env = append(env, e...)
+	}
+	return env, nil
+}
+
+func (p *ECSTaskDefinitionResource) register(properties *ECSTaskDefinitionProperties, postfix string) (string, error) {
+	var containerDefinitions []*ecs.ContainerDefinition
+	for _, c := range properties.ContainerDefinitions {
+		var (
+			ulimits      []*ecs.Ulimit
+			portMappings []*ecs.PortMapping
+			essential    *bool
+		)
+
+		env, err := p.resolvedEnvironment(c.Environment...)
+		if err != nil {
+			return "", err
+		}
+
+		for _, u := range c.Ulimits {
+			ulimits = append(ulimits, &ecs.Ulimit{
+				Name:      u.Name,
+				HardLimit: u.HardLimit.Value(),
+				SoftLimit: u.SoftLimit.Value(),
+			})
+		}
+
+		for _, m := range c.PortMappings {
+			portMappings = append(portMappings, &ecs.PortMapping{
+				ContainerPort: m.ContainerPort.Value(),
+				HostPort:      m.HostPort.Value(),
+			})
+		}
+
+		if c.Essential != nil {
+			essential = aws.Bool(*c.Essential == "true")
+		}
+
+		containerDefinitions = append(containerDefinitions, &ecs.ContainerDefinition{
+			Name:             c.Name,
+			Command:          c.Command,
+			Cpu:              c.Cpu.Value(),
+			Image:            c.Image,
+			Essential:        essential,
+			Memory:           c.Memory.Value(),
+			PortMappings:     portMappings,
+			DockerLabels:     c.DockerLabels,
+			Ulimits:          ulimits,
+			LogConfiguration: c.LogConfiguration,
+			Environment:      env,
+		})
+	}
+
+	var family *string
+	if properties.Family != nil {
+		family = aws.String(fmt.Sprintf("%s-%s", *properties.Family, postfix))
+	}
+	resp, err := p.ecs.RegisterTaskDefinition(&ecs.RegisterTaskDefinitionInput{
+		Family:               family,
+		TaskRoleArn:          properties.TaskRoleArn,
+		ContainerDefinitions: containerDefinitions,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error creating task definition: %v", err)
+	}
+	return *resp.TaskDefinition.TaskDefinitionArn, nil
+}
+
+func (p *ECSTaskDefinitionResource) delete(arn string) error {
+	// We're ignoring errors here because we really don't care if this
+	// fails.
+	p.ecs.DeregisterTaskDefinition(&ecs.DeregisterTaskDefinitionInput{
+		TaskDefinition: aws.String(arn),
+	})
+	return nil
+}
+
+// ECSEnvironmentProperties are the properties provided to the
+// Custom::ECSEnvironment custom resource.
+type ECSEnvironmentProperties struct {
+	Environment []*ecs.KeyValuePair `hash:"set"`
+}
+
+func (p *ECSEnvironmentProperties) ReplacementHash() (uint64, error) {
+	return hashstructure.Hash(p, nil)
+}
+
+// ECSEnvironmentResource is a custom resource that takes some environment
+// variables, stores them, then returns a unique identifier to represent the
+// environment, which can be used with the ECSTaskDefinitionResource.
+type ECSEnvironmentResource struct {
+	environmentStore environmentStore
+}
+
+func newECSEnvironmentProvisioner(resource *ECSEnvironmentResource) *provisioner {
+	return &provisioner{
+		properties: func() properties {
+			return &ECSEnvironmentProperties{}
+		},
+		Create: resource.Create,
+		Update: resource.Update,
+		Delete: resource.Delete,
+	}
+}
+
+func (p *ECSEnvironmentResource) Create(ctx context.Context, req customresources.Request) (string, interface{}, error) {
+	properties := req.ResourceProperties.(*ECSEnvironmentProperties)
+	id, err := p.environmentStore.store(properties.Environment)
+	return id, nil, err
+}
+
+func (p *ECSEnvironmentResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
+	// Updates of ECSEnvironment will generate a replacement resource, so if
+	// we've reached this point, it means that the environment is the same
+	// as it was before.
+	return nil, nil
+}
+
+func (p *ECSEnvironmentResource) Delete(ctx context.Context, req customresources.Request) error {
+	return nil
+}
+
+// environmentStore is a storage engine for storing environment variables for
+// the Custom::ECSEnvironment resource.
+type environmentStore interface {
+	store([]*ecs.KeyValuePair) (string, error)
+	fetch(string) ([]*ecs.KeyValuePair, error)
+}
+
+type ecsKeyValuePair []*ecs.KeyValuePair
+
+func (v *ecsKeyValuePair) Scan(src interface{}) error {
+	bytes, ok := src.([]byte)
+	if !ok {
+		return error(errors.New("Scan source was not []bytes"))
+	}
+
+	var kv ecsKeyValuePair
+	if err := json.Unmarshal(bytes, &kv); err != nil {
+		return err
+	}
+	*v = kv
+
+	return nil
+}
+
+func (v ecsKeyValuePair) Value() (driver.Value, error) {
+	return json.Marshal(v)
+}
+
+// dbEnvironmentStore implements environmentStore on top of a sql.DB.
+type dbEnvironmentStore struct {
+	db *sql.DB
+}
+
+func (s *dbEnvironmentStore) store(env []*ecs.KeyValuePair) (string, error) {
+	sql := `INSERT INTO ecs_environment (environment) VALUES ($1) RETURNING id`
+	var id string
+	err := s.db.QueryRow(sql, ecsKeyValuePair(env)).Scan(&id)
+	return id, err
+}
+
+func (s *dbEnvironmentStore) fetch(id string) ([]*ecs.KeyValuePair, error) {
+	sql := `SELECT environment FROM ecs_environment WHERE id = $1 LIMIT 1`
+	var env ecsKeyValuePair
+	err := s.db.QueryRow(sql, id).Scan(&env)
+	return env, err
+}
+
 // Certain parameters cannot be updated on existing services, so we need to
 // create a new physical resource.
-func requiresReplacement(new, old *ECSServiceProperties) bool {
+func serviceRequiresReplacement(new, old *ECSServiceProperties) bool {
 	eq := reflect.DeepEqual
 
 	if !eq(new.Cluster, old.Cluster) {

--- a/vendor/github.com/mitchellh/hashstructure/LICENSE
+++ b/vendor/github.com/mitchellh/hashstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/hashstructure/README.md
+++ b/vendor/github.com/mitchellh/hashstructure/README.md
@@ -1,0 +1,62 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure.go
@@ -1,0 +1,333 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+)
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+}
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+func Hash(v interface{}, opts *HashOptions) (uint64, error) {
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		h:       opts.Hasher,
+		tag:     opts.TagName,
+		zeronil: opts.ZeroNil,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	h       hash.Hash64
+	tag     string
+	zeronil bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		var include Includable
+		parent := v.Interface()
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if v := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, v)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(v, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+	return 0, nil
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure_examples_test.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure_examples_test.go
@@ -1,0 +1,32 @@
+package hashstructure
+
+import (
+	"fmt"
+)
+
+func ExampleHash() {
+	type ComplexStruct struct {
+		Name     string
+		Age      uint
+		Metadata map[string]interface{}
+	}
+
+	v := ComplexStruct{
+		Name: "mitchellh",
+		Age:  64,
+		Metadata: map[string]interface{}{
+			"car":      true,
+			"location": "California",
+			"siblings": []string{"Bob", "John"},
+		},
+	}
+
+	hash, err := Hash(v, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%d", hash)
+	// Output:
+	// 6691276962590150517
+}

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure_test.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure_test.go
@@ -1,0 +1,456 @@
+package hashstructure
+
+import (
+	"testing"
+)
+
+func TestHash_identity(t *testing.T) {
+	cases := []interface{}{
+		nil,
+		"foo",
+		42,
+		true,
+		false,
+		[]string{"foo", "bar"},
+		[]interface{}{1, nil, "foo"},
+		map[string]string{"foo": "bar"},
+		map[interface{}]string{"foo": "bar"},
+		map[interface{}]interface{}{"foo": "bar", "bar": 0},
+		struct {
+			Foo string
+			Bar []interface{}
+		}{
+			Foo: "foo",
+			Bar: []interface{}{nil, nil, nil},
+		},
+		&struct {
+			Foo string
+			Bar []interface{}
+		}{
+			Foo: "foo",
+			Bar: []interface{}{nil, nil, nil},
+		},
+	}
+
+	for _, tc := range cases {
+		// We run the test 100 times to try to tease out variability
+		// in the runtime in terms of ordering.
+		valuelist := make([]uint64, 100)
+		for i, _ := range valuelist {
+			v, err := Hash(tc, nil)
+			if err != nil {
+				t.Fatalf("Error: %s\n\n%#v", err, tc)
+			}
+
+			valuelist[i] = v
+		}
+
+		// Zero is always wrong
+		if valuelist[0] == 0 {
+			t.Fatalf("zero hash: %#v", tc)
+		}
+
+		// Make sure all the values match
+		t.Logf("%#v: %d", tc, valuelist[0])
+		for i := 1; i < len(valuelist); i++ {
+			if valuelist[i] != valuelist[0] {
+				t.Fatalf("non-matching: %d, %d\n\n%#v", i, 0, tc)
+			}
+		}
+	}
+}
+
+func TestHash_equal(t *testing.T) {
+	type testFoo struct{ Name string }
+	type testBar struct{ Name string }
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			map[string]string{"foo": "bar"},
+			map[interface{}]string{"foo": "bar"},
+			true,
+		},
+
+		{
+			map[string]interface{}{"1": "1"},
+			map[string]interface{}{"1": "1", "2": "2"},
+			false,
+		},
+
+		{
+			struct{ Fname, Lname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"bar", "foo"},
+			false,
+		},
+
+		{
+			struct{ Lname, Fname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"foo", "bar"},
+			false,
+		},
+
+		{
+			struct{ Lname, Fname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"bar", "foo"},
+			true,
+		},
+
+		{
+			testFoo{"foo"},
+			testBar{"foo"},
+			false,
+		},
+
+		{
+			struct {
+				Foo        string
+				unexported string
+			}{
+				Foo:        "bar",
+				unexported: "baz",
+			},
+			struct {
+				Foo        string
+				unexported string
+			}{
+				Foo:        "bar",
+				unexported: "bang",
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Hashing: %#v", tc.One)
+		one, err := Hash(tc.One, nil)
+		t.Logf("Result: %d", one)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		t.Logf("Hashing: %#v", tc.Two)
+		two, err := Hash(tc.Two, nil)
+		t.Logf("Result: %d", two)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_equalIgnore(t *testing.T) {
+	type Test1 struct {
+		Name string
+		UUID string `hash:"ignore"`
+	}
+
+	type Test2 struct {
+		Name string
+		UUID string `hash:"-"`
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "bar"},
+			true,
+		},
+
+		{
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "foo"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "bar"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "foo"},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_equalNil(t *testing.T) {
+	type Test struct {
+		Str   *string
+		Int   *int
+		Map   map[string]string
+		Slice []string
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		ZeroNil  bool
+		Match    bool
+	}{
+		{
+			Test{
+				Str:   nil,
+				Int:   nil,
+				Map:   nil,
+				Slice: nil,
+			},
+			Test{
+				Str:   new(string),
+				Int:   new(int),
+				Map:   make(map[string]string),
+				Slice: make([]string, 0),
+			},
+			true,
+			true,
+		},
+		{
+			Test{
+				Str:   nil,
+				Int:   nil,
+				Map:   nil,
+				Slice: nil,
+			},
+			Test{
+				Str:   new(string),
+				Int:   new(int),
+				Map:   make(map[string]string),
+				Slice: make([]string, 0),
+			},
+			false,
+			false,
+		},
+		{
+			nil,
+			0,
+			true,
+			true,
+		},
+		{
+			nil,
+			0,
+			false,
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, &HashOptions{ZeroNil: tc.ZeroNil})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, &HashOptions{ZeroNil: tc.ZeroNil})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_equalSet(t *testing.T) {
+	type Test struct {
+		Name    string
+		Friends []string `hash:"set"`
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			Test{Name: "foo", Friends: []string{"bar", "foo"}},
+			true,
+		},
+
+		{
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_includable(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludable{Value: "foo"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "bar"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_includableMap(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"bar": "baz"}},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+type testIncludable struct {
+	Value  string
+	Ignore string
+}
+
+func (t testIncludable) HashInclude(field string, v interface{}) (bool, error) {
+	return field != "Ignore", nil
+}
+
+type testIncludableMap struct {
+	Map map[string]string
+}
+
+func (t testIncludableMap) HashIncludeMap(field string, k, v interface{}) (bool, error) {
+	if field != "Map" {
+		return true, nil
+	}
+
+	if s, ok := k.(string); ok && s == "ignore" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/mitchellh/hashstructure/include.go
+++ b/vendor/github.com/mitchellh/hashstructure/include.go
@@ -1,0 +1,15 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -610,6 +610,12 @@
 			"revisionTime": "2013-05-14T23:54:47-07:00"
 		},
 		{
+			"checksumSHA1": "bnhCW1Cu5A402WXhgSEYlFF/v5w=",
+			"path": "github.com/mitchellh/hashstructure",
+			"revision": "b098c52ef6beab8cd82bc4a32422cf54b890e8fa",
+			"revisionTime": "2016-06-09T17:09:29Z"
+		},
+		{
 			"checksumSHA1": "HgqDa4oBBOol5ziacmj/6c55Xtg=",
 			"path": "github.com/opencontainers/runc/libcontainer/user",
 			"revision": "629e35666d31f743090452416c8df207d9fdbd34",


### PR DESCRIPTION
Re-opening https://github.com/remind101/empire/pull/859

Now that we have more than 1 app that's running close to the CloudFormation template size limit, probably a good time to tackle this again.

This is enabled only when setting the `ECS_TASK_DEFINITION=custom` environment variable, the default will remain `AWS::ECS::TaskDefinition`.

**TODO**

* [x] More tests
* [ ] Handle `ClientException: TaskDefinition is inactive`
* [ ] Add BoolValue type.