### PR TITLE
Gracefully handle creation failures of custom resources

### DIFF
--- a/pkg/cloudformation/customresources/customresources.go
+++ b/pkg/cloudformation/customresources/customresources.go
@@ -1,0 +1,237 @@
+// Package customresources provides a Go library for building CloudFormation
+// custom resource handlers.
+package customresources
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/remind101/empire/pkg/base62"
+	"golang.org/x/net/context"
+)
+
+// Possible request types.
+const (
+	Create = "Create"
+	Update = "Update"
+	Delete = "Delete"
+)
+
+// Possible response statuses.
+const (
+	StatusSuccess = "SUCCESS"
+	StatusFailed  = "FAILED"
+)
+
+// Provisioner is something that can provision custom resources.
+type Provisioner interface {
+	// Provision should do the appropriate provisioning, then return:
+	//
+	// 1. The physical id that was created, if any.
+	// 2. The data to return.
+	Provision(context.Context, Request) (string, interface{}, error)
+
+	// Properties should return an instance of a type that the properties
+	// can be json.Unmarshalled into.
+	Properties() interface{}
+}
+
+// Request represents a Custom Resource request.
+//
+// See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
+type Request struct {
+	// The request type is set by the AWS CloudFormation stack operation
+	// (create-stack, update-stack, or delete-stack) that was initiated by
+	// the template developer for the stack that contains the custom
+	// resource.
+	//
+	// Must be one of: Create, Update, or Delete.
+	RequestType string `json:"RequestType"`
+
+	// The response URL identifies a pre-signed Amazon S3 bucket that
+	// receives responses from the custom resource provider to AWS
+	// CloudFormation.
+	ResponseURL string `json:"ResponseURL"`
+
+	// The Amazon Resource Name (ARN) that identifies the stack containing
+	// the custom resource.
+	//
+	// Combining the StackId with the RequestId forms a value that can be
+	// used to uniquely identify a request on a particular custom resource.
+	StackId string `json:"StackId"`
+
+	// A unique ID for the request.
+	//
+	// Combining the StackId with the RequestId forms a value that can be
+	// used to uniquely identify a request on a particular custom resource.
+	RequestId string `json:"RequestId"`
+
+	// The template developer-chosen resource type of the custom resource in
+	// the AWS CloudFormation template. Custom resource type names can be up
+	// to 60 characters long and can include alphanumeric and the following
+	// characters: _@-.
+	ResourceType string `json:"ResourceType"`
+
+	// The template developer-chosen name (logical ID) of the custom
+	// resource in the AWS CloudFormation template. This is provided to
+	// facilitate communication between the custom resource provider and the
+	// template developer.
+	LogicalResourceId string `json:"LogicalResourceId"`
+
+	// A required custom resource provider-defined physical ID that is
+	// unique for that provider.
+	//
+	// Always sent with Update and Delete requests; never sent with Create.
+	PhysicalResourceId string `json:"PhysicalResourceId"`
+
+	// This field contains the contents of the Properties object sent by the
+	// template developer. Its contents are defined by the custom resource
+	// provider.
+	ResourceProperties interface{} `json:"ResourceProperties"`
+
+	// Used only for Update requests. Contains the resource properties that
+	// were declared previous to the update request.
+	OldResourceProperties interface{} `json:"OldResourceProperties"`
+}
+
+// Hash returns a compact unique identifier for the request.
+func (r *Request) Hash() string {
+	h := fnv.New64()
+	h.Write([]byte(fmt.Sprintf("%s.%s", r.StackId, r.RequestId)))
+	return base62.Encode(h.Sum64())
+}
+
+// Response represents the response body we send back to CloudFormation when
+// provisioning is complete.
+//
+// See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html
+type Response struct {
+	// The status value sent by the custom resource provider in response to
+	// an AWS CloudFormation-generated request.
+	//
+	// Must be either SUCCESS or FAILED.
+	Status string `json:"Status"`
+
+	// Describes the reason for a failure response.
+	//
+	// Required if Status is FAILED; optional otherwise.
+	Reason string `json:"Reason"`
+
+	// This value should be an identifier unique to the custom resource
+	// vendor, and can be up to 1Kb in size. The value must be a non-empty
+	// string.
+	PhysicalResourceId string `json:"PhysicalResourceId"`
+
+	// The Amazon Resource Name (ARN) that identifies the stack containing
+	// the custom resource. This response value should be copied verbatim
+	// from the request.
+	StackId string `json:"StackId"`
+
+	// A unique ID for the request. This response value should be copied
+	// verbatim from the request.
+	RequestId string `json:"RequestId"`
+
+	// The template developer-chosen name (logical ID) of the custom
+	// resource in the AWS CloudFormation template. This response value
+	// should be copied verbatim from the request.
+	LogicalResourceId string `json:"LogicalResourceId"`
+
+	// Optional, custom resource provider-defined name-value pairs to send
+	// with the response. The values provided here can be accessed by name
+	// in the template with Fn::GetAtt.
+	Data interface{} `json:"Data"`
+}
+
+// NewResponseFromRequest initializes a new Response from a Request, filling in
+// the required verbatim fields.
+func NewResponseFromRequest(req Request) Response {
+	return Response{
+		StackId:           req.StackId,
+		RequestId:         req.RequestId,
+		LogicalResourceId: req.LogicalResourceId,
+	}
+}
+
+// SendResponse sends the response the Response to the requests response url
+func SendResponse(req Request, response Response) error {
+	return SendResponseWithClient(http.DefaultClient, req, response)
+}
+
+// SendResponseWithClient uploads the response to the requests signed
+// ResponseURL.
+func SendResponseWithClient(client *http.Client, req Request, response Response) error {
+	raw, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+
+	r, err := http.NewRequest("PUT", req.ResponseURL, bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Do(r)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := ioutil.ReadAll(resp.Body)
+
+	if code := resp.StatusCode; code/100 != 2 {
+		return fmt.Errorf("unexpected response from pre-signed url: %v: %v", code, string(body))
+	}
+
+	return nil
+}
+
+// WithTimeout wraps a Provisioner with a context.WithTimeout.
+func WithTimeout(p Provisioner, timeout time.Duration, grace time.Duration) Provisioner {
+	return &timeoutProvisioner{
+		Provisioner: p,
+		timeout:     timeout,
+		grace:       grace,
+	}
+}
+
+type result struct {
+	id   string
+	data interface{}
+	err  error
+}
+
+type timeoutProvisioner struct {
+	Provisioner
+	timeout time.Duration
+	grace   time.Duration
+}
+
+func (p *timeoutProvisioner) Provision(ctx context.Context, r Request) (string, interface{}, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	done := make(chan result)
+	go func() {
+		id, data, err := p.Provisioner.Provision(ctx, r)
+		done <- result{id, data, err}
+	}()
+
+	select {
+	case r := <-done:
+		return r.id, r.data, r.err
+	case <-ctx.Done():
+		// When the context is canceled, give the provisioner
+		// some extra time to cleanup.
+		<-time.After(p.grace)
+		select {
+		case r := <-done:
+			return r.id, r.data, r.err
+		default:
+			return "", nil, ctx.Err()
+		}
+	}
+}

--- a/pkg/cloudformation/customresources/customresources_test.go
+++ b/pkg/cloudformation/customresources/customresources_test.go
@@ -1,6 +1,10 @@
 package customresources
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -45,6 +49,72 @@ func TestWithTimeout_GraceTimeout(t *testing.T) {
 	assert.Equal(t, context.DeadlineExceeded, err)
 }
 
+func TestResponse_MarshalJSON(t *testing.T) {
+	tests := map[Response]string{
+		Response{
+			Status: StatusSuccess,
+		}: `{"Status":"SUCCESS","PhysicalResourceId":"","StackId":"","RequestId":"","LogicalResourceId":""}`,
+
+		Response{
+			Status: StatusFailed,
+			Reason: "errored",
+		}: `{"Status":"FAILED","Reason":"errored","PhysicalResourceId":"","StackId":"","RequestId":"","LogicalResourceId":""}`,
+	}
+
+	for resp, expected := range tests {
+		raw, err := json.Marshal(resp)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expected, string(raw))
+	}
+}
+
+func TestResponseClient(t *testing.T) {
+	c := ResponseClient{http.DefaultClient}
+
+	response := Response{
+		Status:             StatusSuccess,
+		PhysicalResourceId: "9001",
+		StackId:            "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:          "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId:  "webInstancePort",
+		Data:               map[string]int64{"InstancePort": 9001},
+	}
+
+	var called bool
+	check := func(w http.ResponseWriter, r *http.Request) {
+		called = true
+
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6|webInstancePort|daf3f3f9-79a1-4049-823e-09544e582b06", r.URL.Path)
+
+		expectedRaw, err := json.Marshal(response)
+		assert.NoError(t, err)
+		raw, err := ioutil.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, string(expectedRaw), string(raw))
+	}
+	s := httptest.NewServer(http.HandlerFunc(check))
+	defer s.Close()
+
+	req := Request{
+		RequestType:       Create,
+		ResponseURL:       s.URL + "/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
+		StackId:           "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:         "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId: "webInstancePort",
+		ResourceType:      "Custom::InstancePort",
+		ResourceProperties: map[string]interface{}{
+			"ServiceToken": "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
+		},
+	}
+
+	err := c.SendResponse(req, response)
+	assert.NoError(t, err)
+
+	assert.True(t, called)
+}
+
 type mockProvisioner struct {
 	mock.Mock
 }
@@ -56,4 +126,13 @@ func (m *mockProvisioner) Provision(_ context.Context, req Request) (string, int
 
 func (m *mockProvisioner) Properties() interface{} {
 	return nil
+}
+
+type mockHTTPClient struct {
+	mock.Mock
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	args := m.Called(req)
+	return args.Get(0).(*http.Response), args.Error(1)
 }

--- a/pkg/cloudformation/customresources/customresources_test.go
+++ b/pkg/cloudformation/customresources/customresources_test.go
@@ -1,0 +1,59 @@
+package customresources
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/net/context"
+)
+
+var ctx = context.Background()
+
+func TestWithTimeout_NoTimeout(t *testing.T) {
+	m := new(mockProvisioner)
+	p := WithTimeout(m, time.Second, time.Second)
+
+	m.On("Provision", Request{}).Return("id", nil, nil)
+
+	p.Provision(ctx, Request{})
+}
+
+func TestWithTimeout_Timeout_Cleanup(t *testing.T) {
+	m := new(mockProvisioner)
+	p := WithTimeout(m, time.Millisecond*500, time.Millisecond*500)
+
+	m.On("Provision", Request{}).Return("id", nil, nil).Run(func(mock.Arguments) {
+		time.Sleep(time.Millisecond * 750)
+	})
+
+	id, _, err := p.Provision(ctx, Request{})
+	assert.NoError(t, err)
+	assert.Equal(t, "id", id)
+}
+
+func TestWithTimeout_GraceTimeout(t *testing.T) {
+	m := new(mockProvisioner)
+	p := WithTimeout(m, time.Millisecond*500, time.Millisecond*500)
+
+	m.On("Provision", Request{}).Return("id", nil, nil).Run(func(mock.Arguments) {
+		time.Sleep(time.Millisecond * 1500)
+	})
+
+	_, _, err := p.Provision(ctx, Request{})
+	assert.Equal(t, context.DeadlineExceeded, err)
+}
+
+type mockProvisioner struct {
+	mock.Mock
+}
+
+func (m *mockProvisioner) Provision(_ context.Context, req Request) (string, interface{}, error) {
+	args := m.Called(req)
+	return args.String(0), args.Get(1), args.Error(2)
+}
+
+func (m *mockProvisioner) Properties() interface{} {
+	return nil
+}

--- a/pkg/cloudformation/customresources/types.go
+++ b/pkg/cloudformation/customresources/types.go
@@ -1,0 +1,41 @@
+package customresources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// IntValue defines an int64 type that can parse integers as strings from json.
+// It's common to use `Ref`'s inside templates, which means the value of some
+// properties could be a string or an integer.
+type IntValue int64
+
+func Int(v int64) *IntValue {
+	i := IntValue(v)
+	return &i
+}
+
+func (i *IntValue) UnmarshalJSON(b []byte) error {
+	var si int64
+	if err := json.Unmarshal(b, &si); err == nil {
+		*i = IntValue(si)
+		return nil
+	}
+
+	v, err := strconv.Atoi(string(b[1 : len(b)-1]))
+	if err != nil {
+		return fmt.Errorf("error parsing int from string: %v", err)
+	}
+
+	*i = IntValue(v)
+	return nil
+}
+
+func (i *IntValue) Value() *int64 {
+	if i == nil {
+		return nil
+	}
+	p := int64(*i)
+	return &p
+}

--- a/pkg/cloudformation/customresources/types_test.go
+++ b/pkg/cloudformation/customresources/types_test.go
@@ -1,0 +1,29 @@
+package customresources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntValue(t *testing.T) {
+	type foo struct {
+		I IntValue `json:"I"`
+	}
+
+	tests := []struct {
+		in  []byte
+		out foo
+	}{
+		{[]byte(`{"I": 1}`), foo{I: 1}},
+		{[]byte(`{"I": "1"}`), foo{I: 1}},
+	}
+
+	for _, tt := range tests {
+		var i foo
+		err := json.Unmarshal(tt.in, &i)
+		assert.NoError(t, err)
+		assert.Equal(t, tt.out, i)
+	}
+}

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -3,14 +3,10 @@
 package cloudformation
 
 import (
-	"bytes"
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
-	"io/ioutil"
 	"net/http"
-	"strconv"
 	"time"
 
 	"golang.org/x/net/context"
@@ -19,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/remind101/empire/pkg/base62"
+	"github.com/remind101/empire/pkg/cloudformation/customresources"
 	"github.com/remind101/empire/scheduler/ecs/lb"
 	"github.com/remind101/pkg/logger"
 	"github.com/remind101/pkg/reporter"
@@ -34,198 +30,10 @@ var (
 	ProvisioningGraceTimeout = time.Duration(1 * time.Minute)
 )
 
-// Provisioner is something that can provision custom resources.
-type Provisioner interface {
-	// Provision should do the appropriate provisioning, then return:
-	//
-	// 1. The physical id that was created, if any.
-	// 2. The data to return.
-	Provision(context.Context, Request) (string, interface{}, error)
-
-	// Properties should return an instance of a type that the properties
-	// can be json.Unmarshalled into.
-	Properties() interface{}
-}
-
-type ProvisionerFunc func(context.Context, Request) (string, interface{}, error)
-
-func (fn ProvisionerFunc) Provision(ctx context.Context, r Request) (string, interface{}, error) {
-	return fn(ctx, r)
-}
-
-// withTimeout wraps a Provisioner with a context.WithTimeout.
-func withTimeout(p Provisioner, timeout time.Duration, grace time.Duration) Provisioner {
-	return &timeoutProvisioner{
-		Provisioner: p,
-		timeout:     timeout,
-		grace:       grace,
-	}
-}
-
-type result struct {
-	id   string
-	data interface{}
-	err  error
-}
-
-type timeoutProvisioner struct {
-	Provisioner
-	timeout time.Duration
-	grace   time.Duration
-}
-
-func (p *timeoutProvisioner) Provision(ctx context.Context, r Request) (string, interface{}, error) {
-	ctx, cancel := context.WithTimeout(ctx, p.timeout)
-	defer cancel()
-
-	done := make(chan result)
-	go func() {
-		id, data, err := p.Provisioner.Provision(ctx, r)
-		done <- result{id, data, err}
-	}()
-
-	select {
-	case r := <-done:
-		return r.id, r.data, r.err
-	case <-ctx.Done():
-		// When the context is canceled, give the provisioner
-		// some extra time to cleanup.
-		<-time.After(p.grace)
-		select {
-		case r := <-done:
-			return r.id, r.data, r.err
-		default:
-			return "", nil, ctx.Err()
-		}
-	}
-}
-
-// Possible request types.
-const (
-	Create = "Create"
-	Update = "Update"
-	Delete = "Delete"
-)
-
-// Request represents a Custom Resource request.
-//
-// See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html
-type Request struct {
-	// The request type is set by the AWS CloudFormation stack operation
-	// (create-stack, update-stack, or delete-stack) that was initiated by
-	// the template developer for the stack that contains the custom
-	// resource.
-	//
-	// Must be one of: Create, Update, or Delete.
-	RequestType string `json:"RequestType"`
-
-	// The response URL identifies a pre-signed Amazon S3 bucket that
-	// receives responses from the custom resource provider to AWS
-	// CloudFormation.
-	ResponseURL string `json:"ResponseURL"`
-
-	// The Amazon Resource Name (ARN) that identifies the stack containing
-	// the custom resource.
-	//
-	// Combining the StackId with the RequestId forms a value that can be
-	// used to uniquely identify a request on a particular custom resource.
-	StackId string `json:"StackId"`
-
-	// A unique ID for the request.
-	//
-	// Combining the StackId with the RequestId forms a value that can be
-	// used to uniquely identify a request on a particular custom resource.
-	RequestId string `json:"RequestId"`
-
-	// The template developer-chosen resource type of the custom resource in
-	// the AWS CloudFormation template. Custom resource type names can be up
-	// to 60 characters long and can include alphanumeric and the following
-	// characters: _@-.
-	ResourceType string `json:"ResourceType"`
-
-	// The template developer-chosen name (logical ID) of the custom
-	// resource in the AWS CloudFormation template. This is provided to
-	// facilitate communication between the custom resource provider and the
-	// template developer.
-	LogicalResourceId string `json:"LogicalResourceId"`
-
-	// A required custom resource provider-defined physical ID that is
-	// unique for that provider.
-	//
-	// Always sent with Update and Delete requests; never sent with Create.
-	PhysicalResourceId string `json:"PhysicalResourceId"`
-
-	// This field contains the contents of the Properties object sent by the
-	// template developer. Its contents are defined by the custom resource
-	// provider.
-	ResourceProperties interface{} `json:"ResourceProperties"`
-
-	// Used only for Update requests. Contains the resource properties that
-	// were declared previous to the update request.
-	OldResourceProperties interface{} `json:"OldResourceProperties"`
-}
-
-// Possible response statuses.
-const (
-	StatusSuccess = "SUCCESS"
-	StatusFailed  = "FAILED"
-)
-
-// Response represents the response body we send back to CloudFormation when
-// provisioning is complete.
-//
-// See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html
-type Response struct {
-	// The status value sent by the custom resource provider in response to
-	// an AWS CloudFormation-generated request.
-	//
-	// Must be either SUCCESS or FAILED.
-	Status string `json:"Status"`
-
-	// Describes the reason for a failure response.
-	//
-	// Required if Status is FAILED; optional otherwise.
-	Reason string `json:"Reason"`
-
-	// This value should be an identifier unique to the custom resource
-	// vendor, and can be up to 1Kb in size. The value must be a non-empty
-	// string.
-	PhysicalResourceId string `json:"PhysicalResourceId"`
-
-	// The Amazon Resource Name (ARN) that identifies the stack containing
-	// the custom resource. This response value should be copied verbatim
-	// from the request.
-	StackId string `json:"StackId"`
-
-	// A unique ID for the request. This response value should be copied
-	// verbatim from the request.
-	RequestId string `json:"RequestId"`
-
-	// The template developer-chosen name (logical ID) of the custom
-	// resource in the AWS CloudFormation template. This response value
-	// should be copied verbatim from the request.
-	LogicalResourceId string `json:"LogicalResourceId"`
-
-	// Optional, custom resource provider-defined name-value pairs to send
-	// with the response. The values provided here can be accessed by name
-	// in the template with Fn::GetAtt.
-	Data interface{} `json:"Data"`
-}
-
 // Represents the body of the SQS message, which would have been received from
 // SNS.
 type Message struct {
 	Message string `json:"Message"`
-}
-
-// NewResponseFromRequest initializes a new Response from a Request, filling in
-// the required verbatim fields.
-func NewResponseFromRequest(req Request) Response {
-	return Response{
-		StackId:           req.StackId,
-		RequestId:         req.RequestId,
-		LogicalResourceId: req.LogicalResourceId,
-	}
 }
 
 // sqsClient duck types the sqs.SQS interface.
@@ -248,7 +56,7 @@ type CustomResourceProvisioner struct {
 
 	// Provisioners routes a custom resource to the thing that should do the
 	// provisioning.
-	Provisioners map[string]Provisioner
+	Provisioners map[string]customresources.Provisioner
 
 	client interface {
 		Do(*http.Request) (*http.Response, error)
@@ -260,7 +68,7 @@ type CustomResourceProvisioner struct {
 // sqs client configured from config.
 func NewCustomResourceProvisioner(db *sql.DB, config client.ConfigProvider) *CustomResourceProvisioner {
 	p := &CustomResourceProvisioner{
-		Provisioners: make(map[string]Provisioner),
+		Provisioners: make(map[string]customresources.Provisioner),
 		client:       http.DefaultClient,
 		sqs:          sqs.New(config),
 	}
@@ -277,9 +85,9 @@ func NewCustomResourceProvisioner(db *sql.DB, config client.ConfigProvider) *Cus
 }
 
 // add adds a custom resource provisioner.
-func (c *CustomResourceProvisioner) add(resourceName string, p Provisioner) {
+func (c *CustomResourceProvisioner) add(resourceName string, p customresources.Provisioner) {
 	// Wrap the provisioner with timeouts.
-	p = withTimeout(p, ProvisioningTimeout, ProvisioningGraceTimeout)
+	p = customresources.WithTimeout(p, ProvisioningTimeout, ProvisioningGraceTimeout)
 	c.Provisioners[resourceName] = p
 }
 
@@ -328,23 +136,23 @@ func (c *CustomResourceProvisioner) Handle(ctx context.Context, message *sqs.Mes
 		return fmt.Errorf("error unmarshalling sqs message body: %v", err)
 	}
 
-	var req Request
+	var req customresources.Request
 	err = json.Unmarshal([]byte(m.Message), &req)
 	if err != nil {
 		return fmt.Errorf("error unmarshalling to cloudformation request: %v", err)
 	}
 
-	resp := NewResponseFromRequest(req)
+	resp := customresources.NewResponseFromRequest(req)
 	resp.PhysicalResourceId, resp.Data, err = c.provision(ctx, m, req)
 	switch err {
 	case nil:
-		resp.Status = StatusSuccess
+		resp.Status = customresources.StatusSuccess
 		logger.Info(ctx, "cloudformation.provision",
 			"request", req,
 			"response", resp,
 		)
 	default:
-		resp.Status = StatusFailed
+		resp.Status = customresources.StatusFailed
 		resp.Reason = err.Error()
 		logger.Error(ctx, "cloudformation.provision.error",
 			"request", req,
@@ -353,31 +161,10 @@ func (c *CustomResourceProvisioner) Handle(ctx context.Context, message *sqs.Mes
 		)
 	}
 
-	raw, err := json.Marshal(resp)
-	if err != nil {
-		return err
-	}
-
-	r, err := http.NewRequest("PUT", req.ResponseURL, bytes.NewReader(raw))
-	if err != nil {
-		return err
-	}
-
-	httpResp, err := c.client.Do(r)
-	if err != nil {
-		return err
-	}
-	defer httpResp.Body.Close()
-	body, _ := ioutil.ReadAll(httpResp.Body)
-
-	if code := httpResp.StatusCode; code/100 != 2 {
-		return fmt.Errorf("unexpected response from pre-signed url: %v: %v", code, string(body))
-	}
-
-	return nil
+	return customresources.SendResponseWithClient(client, req, resp)
 }
 
-func (c *CustomResourceProvisioner) provision(ctx context.Context, m Message, req Request) (string, interface{}, error) {
+func (c *CustomResourceProvisioner) provision(ctx context.Context, m Message, req customresources.Request) (string, interface{}, error) {
 	p, ok := c.Provisioners[req.ResourceType]
 	if !ok {
 		return "", nil, fmt.Errorf("no provisioner for %v", req.ResourceType)
@@ -393,45 +180,4 @@ func (c *CustomResourceProvisioner) provision(ctx context.Context, m Message, re
 	}
 
 	return p.Provision(ctx, req)
-}
-
-// IntValue defines an int64 type that can parse integers as strings from json.
-// It's common to use `Ref`'s inside templates, which means the value of some
-// properties could be a string or an integer.
-type IntValue int64
-
-func intValue(v int64) *IntValue {
-	i := IntValue(v)
-	return &i
-}
-
-func (i *IntValue) UnmarshalJSON(b []byte) error {
-	var si int64
-	if err := json.Unmarshal(b, &si); err == nil {
-		*i = IntValue(si)
-		return nil
-	}
-
-	v, err := strconv.Atoi(string(b[1 : len(b)-1]))
-	if err != nil {
-		return fmt.Errorf("error parsing int from string: %v", err)
-	}
-
-	*i = IntValue(v)
-	return nil
-}
-
-func (i *IntValue) Value() *int64 {
-	if i == nil {
-		return nil
-	}
-	p := int64(*i)
-	return &p
-}
-
-// hashRequest returns a compact unique identifier for the request.
-func hashRequest(r Request) string {
-	h := fnv.New64()
-	h.Write([]byte(fmt.Sprintf("%s.%s", r.StackId, r.RequestId)))
-	return base62.Encode(h.Sum64())
 }

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -153,6 +153,12 @@ func (c *CustomResourceProvisioner) Handle(ctx context.Context, message *sqs.Mes
 		resp.PhysicalResourceId, resp.Data, err = c.provision(ctx, m, req)
 	}
 
+	// Allow provisioners to just return "" to indicate that the physical
+	// resource id did not change.
+	if resp.PhysicalResourceId == "" && req.PhysicalResourceId != "" {
+		resp.PhysicalResourceId = req.PhysicalResourceId
+	}
+
 	switch err {
 	case nil:
 		resp.Status = customresources.StatusSuccess

--- a/server/cloudformation/cloudformation_test.go
+++ b/server/cloudformation/cloudformation_test.go
@@ -1,10 +1,7 @@
 package cloudformation
 
 import (
-	"bytes"
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
+	"errors"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -20,12 +17,10 @@ var ctx = context.Background()
 
 func TestCustomResourceProvisioner_Handle(t *testing.T) {
 	p := new(mockProvisioner)
-	h := new(mockHTTPClient)
 	c := &CustomResourceProvisioner{
 		Provisioners: map[string]customresources.Provisioner{
 			"Custom::InstancePort": p,
 		},
-		client: h,
 	}
 
 	message := &sqs.Message{
@@ -43,7 +38,7 @@ func TestCustomResourceProvisioner_Handle(t *testing.T) {
 }`),
 	}
 
-	p.On("Provision", customresources.Request{
+	req := customresources.Request{
 		RequestType:       customresources.Create,
 		ResponseURL:       "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
 		StackId:           "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
@@ -53,25 +48,140 @@ func TestCustomResourceProvisioner_Handle(t *testing.T) {
 		ResourceProperties: map[string]interface{}{
 			"ServiceToken": "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
 		},
-	}).Return("9001", map[string]int64{"InstancePort": 9001}, nil)
-
-	raw, err := json.Marshal(customresources.Response{
+	}
+	resp := customresources.Response{
 		Status:             customresources.StatusSuccess,
 		PhysicalResourceId: "9001",
 		StackId:            "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
 		RequestId:          "daf3f3f9-79a1-4049-823e-09544e582b06",
 		LogicalResourceId:  "webInstancePort",
 		Data:               map[string]int64{"InstancePort": 9001},
-	})
+	}
+
+	c.sendResponse = checkSendResponse(t, req, resp)
+
+	p.On("Provision", req).Return("9001", map[string]int64{"InstancePort": 9001}, nil)
+
+	err := c.Handle(context.Background(), message)
 	assert.NoError(t, err)
 
-	req, err := http.NewRequest("PUT", "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D", bytes.NewReader(raw))
+	p.AssertExpectations(t)
+}
+
+func TestCustomResourceProvisioner_Handle_CreateFailed(t *testing.T) {
+	p := new(mockProvisioner)
+	c := &CustomResourceProvisioner{
+		Provisioners: map[string]customresources.Provisioner{
+			"Custom::InstancePort": p,
+		},
+	}
+
+	message := &sqs.Message{
+		Body: aws.String(`{
+  "Type" : "Notification",
+  "MessageId" : "7c72a0bb-c6f6-536b-88b7-ef25c9c6734a",
+  "TopicArn" : "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
+  "Subject" : "AWS CloudFormation custom resource request",
+  "Message" : "{\"RequestType\":\"Create\",\"ServiceToken\":\"arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD\",\"ResponseURL\":\"https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D\",\"StackId\":\"arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6\",\"RequestId\":\"daf3f3f9-79a1-4049-823e-09544e582b06\",\"LogicalResourceId\":\"webInstancePort\",\"ResourceType\":\"Custom::InstancePort\",\"ResourceProperties\":{\"ServiceToken\":\"arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD\"}}",
+  "Timestamp" : "2016-04-30T01:40:00.042Z",
+  "SignatureVersion" : "1",
+  "Signature" : "cZI/3gLQzH7hXmjh6O2FVRGf+rylVCuLieuDjqA+ptQeM+VWXptga8p7+VJGl2tgijqDLOST20ErHxMVeE3Gq5eA2zLtydJcZfbzI/jyBSdM41NalrrLsVENi1N318KJ+5eGgKB9MvUMqQb0/BrbzIEuzmbCRe3P60188J/ME/5CBsRB/jfUbr7+asN5qJIf4B/CluVfoF5n1bbBmLA5YqttisB7Y626Bvr8EM9S/NdlNHfwq3ZIA+OQkTUzVKmwQsE1h7ICNm+UQxZgca+JRuPq7QRstHeuiIjMEn7/Q4UPh2FknqSEu8vtu/kdA8oUhA5WvcN59V5kog9mo3Q1WA==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-bb750dd426d95ee9390147a5624348ee.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD:d369ecb8-031f-40b3-bf8d-37b7cdc30fbe"
+}`),
+	}
+
+	req := customresources.Request{
+		RequestType:       customresources.Create,
+		ResponseURL:       "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
+		StackId:           "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:         "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId: "webInstancePort",
+		ResourceType:      "Custom::InstancePort",
+		ResourceProperties: map[string]interface{}{
+			"ServiceToken": "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
+		},
+	}
+	resp := customresources.Response{
+		Status:             customresources.StatusFailed,
+		PhysicalResourceId: "failed/Create",
+		Reason:             "pq: unique violation",
+		StackId:            "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:          "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId:  "webInstancePort",
+		Data:               nil,
+	}
+
+	c.sendResponse = checkSendResponse(t, req, resp)
+
+	p.On("Provision", req).Return("", nil, errors.New("pq: unique violation"))
+
+	err := c.Handle(context.Background(), message)
 	assert.NoError(t, err)
 
-	h.On("Do", req).Return(&http.Response{StatusCode: 200, Body: ioutil.NopCloser(new(bytes.Buffer))}, nil)
+	p.AssertExpectations(t)
+}
 
-	err = c.Handle(context.Background(), message)
+func TestCustomResourceProvisioner_Handle_DeleteFailedResource(t *testing.T) {
+	p := new(mockProvisioner)
+	c := &CustomResourceProvisioner{
+		Provisioners: map[string]customresources.Provisioner{
+			"Custom::InstancePort": p,
+		},
+	}
+
+	message := &sqs.Message{
+		Body: aws.String(`{
+  "Type" : "Notification",
+  "MessageId" : "7c72a0bb-c6f6-536b-88b7-ef25c9c6734a",
+  "TopicArn" : "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
+  "Subject" : "AWS CloudFormation custom resource request",
+  "Message" : "{\"RequestType\":\"Delete\",\"PhysicalResourceId\":\"failed/Create\",\"ServiceToken\":\"arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD\",\"ResponseURL\":\"https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D\",\"StackId\":\"arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6\",\"RequestId\":\"daf3f3f9-79a1-4049-823e-09544e582b06\",\"LogicalResourceId\":\"webInstancePort\",\"ResourceType\":\"Custom::InstancePort\",\"ResourceProperties\":{\"ServiceToken\":\"arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD\"}}",
+  "Timestamp" : "2016-04-30T01:40:00.042Z",
+  "SignatureVersion" : "1",
+  "Signature" : "cZI/3gLQzH7hXmjh6O2FVRGf+rylVCuLieuDjqA+ptQeM+VWXptga8p7+VJGl2tgijqDLOST20ErHxMVeE3Gq5eA2zLtydJcZfbzI/jyBSdM41NalrrLsVENi1N318KJ+5eGgKB9MvUMqQb0/BrbzIEuzmbCRe3P60188J/ME/5CBsRB/jfUbr7+asN5qJIf4B/CluVfoF5n1bbBmLA5YqttisB7Y626Bvr8EM9S/NdlNHfwq3ZIA+OQkTUzVKmwQsE1h7ICNm+UQxZgca+JRuPq7QRstHeuiIjMEn7/Q4UPh2FknqSEu8vtu/kdA8oUhA5WvcN59V5kog9mo3Q1WA==",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-bb750dd426d95ee9390147a5624348ee.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD:d369ecb8-031f-40b3-bf8d-37b7cdc30fbe"
+}`),
+	}
+
+	req := customresources.Request{
+		RequestType:        customresources.Delete,
+		PhysicalResourceId: "failed/Create",
+		ResponseURL:        "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A066251891493%3Astack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6%7CwebInstancePort%7Cdaf3f3f9-79a1-4049-823e-09544e582b06?AWSAccessKeyId=AKIAJNXHFR7P7YGKLDPQ&Expires=1461987599&Signature=EqV%2BqIUAsZPz5Q%2F%2B75Guvn%2BNREU%3D",
+		StackId:            "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:          "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId:  "webInstancePort",
+		ResourceType:       "Custom::InstancePort",
+		ResourceProperties: map[string]interface{}{
+			"ServiceToken": "arn:aws:sns:us-east-1:066251891493:empire-e01a8fac-CustomResourcesTopic-9KHPNW7WFKBD",
+		},
+	}
+	resp := customresources.Response{
+		Status:             customresources.StatusSuccess,
+		PhysicalResourceId: "failed/Create",
+		StackId:            "arn:aws:cloudformation:us-east-1:066251891493:stack/foo/70213b00-0e74-11e6-b4fb-500c28680ac6",
+		RequestId:          "daf3f3f9-79a1-4049-823e-09544e582b06",
+		LogicalResourceId:  "webInstancePort",
+		Data:               nil,
+	}
+
+	c.sendResponse = checkSendResponse(t, req, resp)
+
+	err := c.Handle(context.Background(), message)
 	assert.NoError(t, err)
+
+	p.AssertExpectations(t)
+}
+
+// checkSendResponse returns a sendResponse func that checks that the req and
+// response match the expected values.
+func checkSendResponse(t testing.TB, expectedReq customresources.Request, expectedResponse customresources.Response) func(customresources.Request, customresources.Response) error {
+	return func(req customresources.Request, response customresources.Response) error {
+		assert.Equal(t, expectedReq, req)
+		assert.Equal(t, expectedResponse, response)
+		return nil
+	}
 }
 
 type mockProvisioner struct {
@@ -85,15 +195,6 @@ func (m *mockProvisioner) Provision(_ context.Context, req customresources.Reque
 
 func (m *mockProvisioner) Properties() interface{} {
 	return nil
-}
-
-type mockHTTPClient struct {
-	mock.Mock
-}
-
-func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	args := m.Called(req)
-	return args.Get(0).(*http.Response), args.Error(1)
 }
 
 type mockSQSClient struct {

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/remind101/empire/pkg/cloudformation/customresources"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -36,14 +37,14 @@ func TestECSServiceResource_Create(t *testing.T) {
 		Services: []*string{aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt")},
 	}).Return(nil)
 
-	id, data, err := p.Provision(ctx, Request{
+	id, data, err := p.Provision(ctx, customresources.Request{
 		StackId:     "arn:aws:cloudformation:us-east-1:012345678901:stack/acme-inc/bc66fd60-32be-11e6-902b-50d501eb4c17",
 		RequestId:   "411f3f38-565f-4216-a711-aeafd5ba635e",
-		RequestType: Create,
+		RequestType: customresources.Create,
 		ResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(1),
+			DesiredCount: customresources.Int(1),
 		},
 		OldResourceProperties: &ECSServiceProperties{},
 	})
@@ -80,14 +81,14 @@ func TestECSServiceResource_Create_Canceled(t *testing.T) {
 		time.Sleep(1 * time.Second)
 	})
 
-	_, data, err := p.Provision(ctx, Request{
+	_, data, err := p.Provision(ctx, customresources.Request{
 		StackId:     "arn:aws:cloudformation:us-east-1:012345678901:stack/acme-inc/bc66fd60-32be-11e6-902b-50d501eb4c17",
 		RequestId:   "411f3f38-565f-4216-a711-aeafd5ba635e",
-		RequestType: Create,
+		RequestType: customresources.Create,
 		ResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(1),
+			DesiredCount: customresources.Int(1),
 		},
 		OldResourceProperties: &ECSServiceProperties{},
 	})
@@ -110,21 +111,21 @@ func TestECSServiceResource_Update(t *testing.T) {
 		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
 	}).Return(&ecs.UpdateServiceOutput{}, nil)
 
-	id, data, err := p.Provision(ctx, Request{
+	id, data, err := p.Provision(ctx, customresources.Request{
 		StackId:            "arn:aws:cloudformation:us-east-1:012345678901:stack/acme-inc/bc66fd60-32be-11e6-902b-50d501eb4c17",
 		RequestId:          "411f3f38-565f-4216-a711-aeafd5ba635e",
-		RequestType:        Update,
+		RequestType:        customresources.Update,
 		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
 		ResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("cluster"),
 			ServiceName:    aws.String("acme-inc-web"),
-			DesiredCount:   intValue(2),
+			DesiredCount:   customresources.Int(2),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("cluster"),
 			ServiceName:    aws.String("acme-inc-web"),
-			DesiredCount:   intValue(1),
+			DesiredCount:   customresources.Int(1),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
 		},
 	})
@@ -158,21 +159,21 @@ func TestECSServiceResource_Update_RequiresReplacement(t *testing.T) {
 		Services: []*string{aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt")},
 	}).Return(nil)
 
-	id, data, err := p.Provision(ctx, Request{
+	id, data, err := p.Provision(ctx, customresources.Request{
 		StackId:            "arn:aws:cloudformation:us-east-1:012345678901:stack/acme-inc/bc66fd60-32be-11e6-902b-50d501eb4c17",
 		RequestId:          "411f3f38-565f-4216-a711-aeafd5ba635e",
-		RequestType:        Update,
+		RequestType:        customresources.Update,
 		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt",
 		ResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("clusterB"),
 			ServiceName:    aws.String("acme-inc-web"),
-			DesiredCount:   intValue(2),
+			DesiredCount:   customresources.Int(2),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("clusterA"),
 			ServiceName:    aws.String("acme-inc-web"),
-			DesiredCount:   intValue(1),
+			DesiredCount:   customresources.Int(1),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
 		},
 	})
@@ -200,18 +201,18 @@ func TestECSServiceResource_Delete(t *testing.T) {
 		Cluster: aws.String("cluster"),
 	}).Return(&ecs.DeleteServiceOutput{}, nil)
 
-	id, data, err := p.Provision(ctx, Request{
-		RequestType:        Delete,
+	id, data, err := p.Provision(ctx, customresources.Request{
+		RequestType:        customresources.Delete,
 		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
 		ResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(1),
+			DesiredCount: customresources.Int(1),
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(1),
+			DesiredCount: customresources.Int(1),
 		},
 	})
 	assert.NoError(t, err)
@@ -233,18 +234,18 @@ func TestECSServiceResource_Delete_NotActive(t *testing.T) {
 		DesiredCount: aws.Int64(0),
 	}).Return(&ecs.UpdateServiceOutput{}, awserr.New("ServiceNotActiveException", "Service was not ACTIVE", errors.New("")))
 
-	id, data, err := p.Provision(ctx, Request{
-		RequestType:        Delete,
+	id, data, err := p.Provision(ctx, customresources.Request{
+		RequestType:        customresources.Delete,
 		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web",
 		ResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(1),
+			DesiredCount: customresources.Int(1),
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
-			DesiredCount: intValue(1),
+			DesiredCount: customresources.Int(1),
 		},
 	})
 	assert.NoError(t, err)
@@ -260,14 +261,14 @@ func TestRequiresReplacement(t *testing.T) {
 		out      bool
 	}{
 		{
-			ECSServiceProperties{Cluster: aws.String("cluster"), TaskDefinition: aws.String("td:2"), DesiredCount: intValue(1)},
-			ECSServiceProperties{Cluster: aws.String("cluster"), TaskDefinition: aws.String("td:1"), DesiredCount: intValue(0)},
+			ECSServiceProperties{Cluster: aws.String("cluster"), TaskDefinition: aws.String("td:2"), DesiredCount: customresources.Int(1)},
+			ECSServiceProperties{Cluster: aws.String("cluster"), TaskDefinition: aws.String("td:1"), DesiredCount: customresources.Int(0)},
 			false,
 		},
 
 		{
-			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elb")}}},
-			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elb")}}},
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: customresources.Int(8080), LoadBalancerName: aws.String("elb")}}},
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: customresources.Int(8080), LoadBalancerName: aws.String("elb")}}},
 			false,
 		},
 
@@ -294,8 +295,8 @@ func TestRequiresReplacement(t *testing.T) {
 
 		// Can't change load balancers
 		{
-			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elbB")}}},
-			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: intValue(8080), LoadBalancerName: aws.String("elbA")}}},
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: customresources.Int(8080), LoadBalancerName: aws.String("elbB")}}},
+			ECSServiceProperties{LoadBalancers: []LoadBalancer{{ContainerName: aws.String("web"), ContainerPort: customresources.Int(8080), LoadBalancerName: aws.String("elbA")}}},
 			true,
 		},
 	}

--- a/server/cloudformation/ports.go
+++ b/server/cloudformation/ports.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/remind101/empire/pkg/cloudformation/customresources"
+
 	"golang.org/x/net/context"
 )
 
@@ -21,9 +23,9 @@ func (p *InstancePortsProvisioner) Properties() interface{} {
 	return nil
 }
 
-func (p *InstancePortsProvisioner) Provision(_ context.Context, req Request) (id string, data interface{}, err error) {
+func (p *InstancePortsProvisioner) Provision(_ context.Context, req customresources.Request) (id string, data interface{}, err error) {
 	switch req.RequestType {
-	case Create:
+	case customresources.Create:
 		var port int64
 		port, err = p.ports.Get()
 		if err != nil {
@@ -31,7 +33,7 @@ func (p *InstancePortsProvisioner) Provision(_ context.Context, req Request) (id
 		}
 		id = fmt.Sprintf("%d", port)
 		data = map[string]int64{"InstancePort": port}
-	case Delete:
+	case customresources.Delete:
 		port, err2 := strconv.Atoi(req.PhysicalResourceId)
 		if err2 != nil {
 			err = fmt.Errorf("physical resource id should have been a port number: %v", err2)


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/918

See https://github.com/remind101/empire/issues/918 for an explanation of what was causing the issue.

This does a few things:

1. Fixes the issue in https://github.com/remind101/empire/issues/918
2. Pulls out some of the custom resources framework in `server/cloudformation`, to `pkg/cloudformation/customresources`.

End result is that, if creating a new resource fails, the correct error will appear in the CloudFormation events, and request to delete it during the rollback will succeed.