### PR TITLE
Set deployment message from GitHub deployments.

### DIFF
--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/ejholmes/hookshot/events"
@@ -56,11 +57,16 @@ func (d *EmpireDeployer) Deploy(ctx context.Context, event events.Deployment, w 
 	// stream.
 	p := dockerutil.DecodeJSONMessageStream(w)
 
+	message := event.Deployment.Description
+	if message == "" {
+		message = fmt.Sprintf("GitHub deployment #%d of %s", event.Deployment.ID, event.Repository.FullName)
+	}
 	_, err = d.empire.Deploy(ctx, empire.DeployOpts{
-		Image:  img,
-		Output: empire.NewDeploymentStream(p),
-		User:   &empire.User{Name: event.Deployment.Creator.Login},
-		Stream: true,
+		Image:   img,
+		Output:  empire.NewDeploymentStream(p),
+		User:    &empire.User{Name: event.Deployment.Creator.Login},
+		Stream:  true,
+		Message: message,
 	})
 	if err != nil {
 		return err

--- a/server/github/deployer_test.go
+++ b/server/github/deployer_test.go
@@ -25,6 +25,7 @@ func TestEmpireDeployer_Deploy(t *testing.T) {
 	event.Repository.FullName = "remind101/acme-inc"
 	event.Deployment.Sha = "abcd123"
 	event.Deployment.Creator.Login = "ejholmes"
+	event.Deployment.ID = 53252
 
 	b := new(bytes.Buffer)
 
@@ -34,7 +35,8 @@ func TestEmpireDeployer_Deploy(t *testing.T) {
 			Repository: "remind101/acme-inc",
 			Tag:        "abcd123",
 		},
-		Stream: true,
+		Stream:  true,
+		Message: "GitHub deployment #53252 of remind101/acme-inc",
 	}).Return(nil)
 
 	err := d.Deploy(context.Background(), event, b)


### PR DESCRIPTION
Before this change, requiring messages would cause GitHub deployments to fail. This will add the description from the GitHub deployment as the message, if it's provided, otherwise it'll default to a message including the GitHub deployment id.