### PR TITLE
Improve performance of provisioning of custom cloudformation resources

### DIFF
--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -99,13 +99,9 @@ func (c *CustomResourceProvisioner) add(resourceName string, p customresources.P
 
 // Start starts pulling requests from the queue and provisioning them.
 func (c *CustomResourceProvisioner) Start() {
-	for i := 0; i < 10; i++ {
-		go c.worker()
-	}
-}
+	t := time.Tick(10 * time.Second)
 
-func (c *CustomResourceProvisioner) worker() {
-	for {
+	for range t {
 		ctx := c.Context
 
 		resp, err := c.sqs.ReceiveMessage(&sqs.ReceiveMessageInput{

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -239,7 +239,7 @@ type provisioner struct {
 	properties func() properties
 
 	Create func(context.Context, customresources.Request) (string, interface{}, error)
-	Update func(context.Context, customresources.Request) (string, interface{}, error)
+	Update func(context.Context, customresources.Request) (interface{}, error)
 	Delete func(context.Context, customresources.Request) error
 }
 
@@ -267,7 +267,9 @@ func (p *provisioner) Provision(ctx context.Context, req customresources.Request
 			return p.Create(ctx, req)
 		}
 
-		return p.Update(ctx, req)
+		id := req.PhysicalResourceId
+		data, err := p.Update(ctx, req)
+		return id, data, err
 	case customresources.Delete:
 		return req.PhysicalResourceId, nil, p.Delete(ctx, req)
 	default:

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -99,9 +99,13 @@ func (c *CustomResourceProvisioner) add(resourceName string, p customresources.P
 
 // Start starts pulling requests from the queue and provisioning them.
 func (c *CustomResourceProvisioner) Start() {
-	t := time.Tick(10 * time.Second)
+	for i := 0; i < 10; i++ {
+		go c.worker()
+	}
+}
 
-	for range t {
+func (c *CustomResourceProvisioner) worker() {
+	for {
 		ctx := c.Context
 
 		resp, err := c.sqs.ReceiveMessage(&sqs.ReceiveMessageInput{

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -341,7 +341,7 @@ func (p *ECSTaskDefinitionResource) delete(arn string) error {
 // ECSEnvironmentProperties are the properties provided to the
 // Custom::ECSEnvironment custom resource.
 type ECSEnvironmentProperties struct {
-	Environment []*ecs.KeyValuePair
+	Environment []*ecs.KeyValuePair `hash:"set"`
 }
 
 func (p *ECSEnvironmentProperties) ReplacementHash() (uint64, error) {

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -243,10 +243,11 @@ func (p *ECSTaskDefinitionResource) Create(ctx context.Context, req customresour
 	return id, nil, err
 }
 
-func (p *ECSTaskDefinitionResource) Update(ctx context.Context, req customresources.Request) (string, interface{}, error) {
-	properties := req.ResourceProperties.(*ECSTaskDefinitionProperties)
-	id, err := p.register(properties, req.Hash())
-	return id, nil, err
+func (p *ECSTaskDefinitionResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
+	// Updates of ECSTaskDefinition will generate a replacement resource, so
+	// if we've reached this point, it means that the environment is the
+	// same as it was before.
+	return nil, nil
 }
 
 func (p *ECSTaskDefinitionResource) Delete(ctx context.Context, req customresources.Request) error {
@@ -371,11 +372,11 @@ func (p *ECSEnvironmentResource) Create(ctx context.Context, req customresources
 	return id, nil, err
 }
 
-func (p *ECSEnvironmentResource) Update(ctx context.Context, req customresources.Request) (string, interface{}, error) {
+func (p *ECSEnvironmentResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
 	// Updates of ECSEnvironment will generate a replacement resource, so if
 	// we've reached this point, it means that the environment is the same
 	// as it was before.
-	return req.PhysicalResourceId, nil, nil
+	return nil, nil
 }
 
 func (p *ECSEnvironmentResource) Delete(ctx context.Context, req customresources.Request) error {

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -258,10 +258,10 @@ func TestECSServiceResource_Delete_NotActive(t *testing.T) {
 func TestECSTaskDefinition_Create(t *testing.T) {
 	e := new(mockECS)
 	s := new(mockEnvironmentStore)
-	p := &ECSTaskDefinitionResource{
+	p := newECSTaskDefinitionProvisioner(&ECSTaskDefinitionResource{
 		ecs:              e,
 		environmentStore: s,
-	}
+	})
 
 	s.On("fetch", "003483d3-74b8-465d-8c2e-06e005dda776").Return([]*ecs.KeyValuePair{
 		{
@@ -323,9 +323,9 @@ func TestECSTaskDefinition_Create(t *testing.T) {
 
 func TestECSEnvironment_Create(t *testing.T) {
 	s := new(mockEnvironmentStore)
-	p := &ECSEnvironmentResource{
+	p := newECSEnvironmentProvisioner(&ECSEnvironmentResource{
 		environmentStore: s,
-	}
+	})
 
 	s.On("store", []*ecs.KeyValuePair{
 		{
@@ -354,9 +354,9 @@ func TestECSEnvironment_Create(t *testing.T) {
 
 func TestECSEnvironment_Update(t *testing.T) {
 	s := new(mockEnvironmentStore)
-	p := &ECSEnvironmentResource{
+	p := newECSEnvironmentProvisioner(&ECSEnvironmentResource{
 		environmentStore: s,
-	}
+	})
 
 	id, data, err := p.Provision(ctx, customresources.Request{
 		RequestType:        customresources.Update,

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -352,7 +352,40 @@ func TestECSEnvironment_Create(t *testing.T) {
 	s.AssertExpectations(t)
 }
 
-func TestRequiresReplacement(t *testing.T) {
+func TestECSEnvironment_Update(t *testing.T) {
+	s := new(mockEnvironmentStore)
+	p := &ECSEnvironmentResource{
+		environmentStore: s,
+	}
+
+	id, data, err := p.Provision(ctx, customresources.Request{
+		RequestType:        customresources.Update,
+		PhysicalResourceId: "56152438-5fef-4c96-bbe1-9cf92022ae75",
+		ResourceProperties: &ECSEnvironmentProperties{
+			Environment: []*ecs.KeyValuePair{
+				{
+					Name:  aws.String("FOO"),
+					Value: aws.String("bar"),
+				},
+			},
+		},
+		OldResourceProperties: &ECSEnvironmentProperties{
+			Environment: []*ecs.KeyValuePair{
+				{
+					Name:  aws.String("FOO"),
+					Value: aws.String("bar"),
+				},
+			},
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "56152438-5fef-4c96-bbe1-9cf92022ae75", id)
+	assert.Nil(t, data)
+
+	s.AssertExpectations(t)
+}
+
+func TestServiceRequiresReplacement(t *testing.T) {
 	tests := []struct {
 		new, old ECSServiceProperties
 		out      bool
@@ -399,7 +432,7 @@ func TestRequiresReplacement(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		out := requiresReplacement(&tt.new, &tt.old)
+		out := serviceRequiresReplacement(&tt.new, &tt.old)
 		assert.Equal(t, tt.out, out)
 	}
 }

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -444,10 +444,18 @@ func TestECSEnvironment_Update(t *testing.T) {
 					Name:  aws.String("FOO"),
 					Value: aws.String("bar"),
 				},
+				{
+					Name:  aws.String("BAR"),
+					Value: aws.String("foo"),
+				},
 			},
 		},
 		OldResourceProperties: &ECSEnvironmentProperties{
 			Environment: []*ecs.KeyValuePair{
+				{
+					Name:  aws.String("BAR"),
+					Value: aws.String("foo"),
+				},
 				{
 					Name:  aws.String("FOO"),
 					Value: aws.String("bar"),

--- a/vendor/github.com/mitchellh/hashstructure/LICENSE
+++ b/vendor/github.com/mitchellh/hashstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/hashstructure/README.md
+++ b/vendor/github.com/mitchellh/hashstructure/README.md
@@ -1,0 +1,62 @@
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+
+hashstructure is a Go library for creating a unique hash value
+for arbitrary values in Go.
+
+This can be used to key values in a hash (for use in a map, set, etc.)
+that are complex. The most common use case is comparing two values without
+sending data across the network, caching values locally (de-dup), and so on.
+
+## Features
+
+  * Hash any arbitrary Go value, including complex types.
+
+  * Tag a struct field to ignore it and not affect the hash value.
+
+  * Tag a slice type struct field to treat it as a set where ordering
+    doesn't affect the hash code but the field itself is still taken into
+    account to create the hash value.
+
+  * Optionally specify a custom hash function to optimize for speed, collision
+    avoidance for your data set, etc.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/hashstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+
+A quick code example is shown below:
+
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
+
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
+
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
+
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure.go
@@ -1,0 +1,333 @@
+package hashstructure
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"reflect"
+)
+
+// HashOptions are options that are available for hashing.
+type HashOptions struct {
+	// Hasher is the hash function to use. If this isn't set, it will
+	// default to FNV.
+	Hasher hash.Hash64
+
+	// TagName is the struct tag to look at when hashing the structure.
+	// By default this is "hash".
+	TagName string
+
+	// ZeroNil is flag determining if nil pointer should be treated equal
+	// to a zero value of pointed type. By default this is false.
+	ZeroNil bool
+}
+
+// Hash returns the hash value of an arbitrary value.
+//
+// If opts is nil, then default options will be used. See HashOptions
+// for the default values.
+//
+// Notes on the value:
+//
+//   * Unexported fields on structs are ignored and do not affect the
+//     hash value.
+//
+//   * Adding an exported field to a struct with the zero value will change
+//     the hash value.
+//
+// For structs, the hashing can be controlled using tags. For example:
+//
+//    struct {
+//        Name string
+//        UUID string `hash:"ignore"`
+//    }
+//
+// The available tag values are:
+//
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
+//
+//   * "set" - The field will be treated as a set, where ordering doesn't
+//             affect the hash code. This only works for slices.
+//
+func Hash(v interface{}, opts *HashOptions) (uint64, error) {
+	// Create default options
+	if opts == nil {
+		opts = &HashOptions{}
+	}
+	if opts.Hasher == nil {
+		opts.Hasher = fnv.New64()
+	}
+	if opts.TagName == "" {
+		opts.TagName = "hash"
+	}
+
+	// Reset the hash
+	opts.Hasher.Reset()
+
+	// Create our walker and walk the structure
+	w := &walker{
+		h:       opts.Hasher,
+		tag:     opts.TagName,
+		zeronil: opts.ZeroNil,
+	}
+	return w.visit(reflect.ValueOf(v), nil)
+}
+
+type walker struct {
+	h       hash.Hash64
+	tag     string
+	zeronil bool
+}
+
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
+	t := reflect.TypeOf(0)
+
+	// Loop since these can be wrapped in multiple layers of pointers
+	// and interfaces.
+	for {
+		// If we have an interface, dereference it. We have to do this up
+		// here because it might be a nil in there and the check below must
+		// catch that.
+		if v.Kind() == reflect.Interface {
+			v = v.Elem()
+			continue
+		}
+
+		if v.Kind() == reflect.Ptr {
+			if w.zeronil {
+				t = v.Type().Elem()
+			}
+			v = reflect.Indirect(v)
+			continue
+		}
+
+		break
+	}
+
+	// If it is nil, treat it like a zero.
+	if !v.IsValid() {
+		v = reflect.Zero(t)
+	}
+
+	// Binary writing can use raw ints, we have to convert to
+	// a sized-int, we'll choose the largest...
+	switch v.Kind() {
+	case reflect.Int:
+		v = reflect.ValueOf(int64(v.Int()))
+	case reflect.Uint:
+		v = reflect.ValueOf(uint64(v.Uint()))
+	case reflect.Bool:
+		var tmp int8
+		if v.Bool() {
+			tmp = 1
+		}
+		v = reflect.ValueOf(tmp)
+	}
+
+	k := v.Kind()
+
+	// We can shortcut numeric values by directly binary writing them
+	if k >= reflect.Int && k <= reflect.Complex64 {
+		// A direct hash calculation
+		w.h.Reset()
+		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch k {
+	case reflect.Array:
+		var h uint64
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			h = hashUpdateOrdered(w.h, h, current)
+		}
+
+		return h, nil
+
+	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
+		// Build the hash for the map. We do this by XOR-ing all the key
+		// and value hashes. This makes it deterministic despite ordering.
+		var h uint64
+		for _, k := range v.MapKeys() {
+			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return 0, err
+				}
+				if !incl {
+					continue
+				}
+			}
+
+			kh, err := w.visit(k, nil)
+			if err != nil {
+				return 0, err
+			}
+			vh, err := w.visit(v, nil)
+			if err != nil {
+				return 0, err
+			}
+
+			fieldHash := hashUpdateOrdered(w.h, kh, vh)
+			h = hashUpdateUnordered(h, fieldHash)
+		}
+
+		return h, nil
+
+	case reflect.Struct:
+		var include Includable
+		parent := v.Interface()
+		if impl, ok := parent.(Includable); ok {
+			include = impl
+		}
+
+		t := v.Type()
+		h, err := w.visit(reflect.ValueOf(t.Name()), nil)
+		if err != nil {
+			return 0, err
+		}
+
+		l := v.NumField()
+		for i := 0; i < l; i++ {
+			if v := v.Field(i); v.CanSet() || t.Field(i).Name != "_" {
+				var f visitFlag
+				fieldType := t.Field(i)
+				if fieldType.PkgPath != "" {
+					// Unexported
+					continue
+				}
+
+				tag := fieldType.Tag.Get(w.tag)
+				if tag == "ignore" || tag == "-" {
+					// Ignore this field
+					continue
+				}
+
+				// Check if we implement includable and check it
+				if include != nil {
+					incl, err := include.HashInclude(fieldType.Name, v)
+					if err != nil {
+						return 0, err
+					}
+					if !incl {
+						continue
+					}
+				}
+
+				switch tag {
+				case "set":
+					f |= visitFlagSet
+				}
+
+				kh, err := w.visit(reflect.ValueOf(fieldType.Name), nil)
+				if err != nil {
+					return 0, err
+				}
+
+				vh, err := w.visit(v, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
+					return 0, err
+				}
+
+				fieldHash := hashUpdateOrdered(w.h, kh, vh)
+				h = hashUpdateUnordered(h, fieldHash)
+			}
+		}
+
+		return h, nil
+
+	case reflect.Slice:
+		// We have two behaviors here. If it isn't a set, then we just
+		// visit all the elements. If it is a set, then we do a deterministic
+		// hash code.
+		var h uint64
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
+		l := v.Len()
+		for i := 0; i < l; i++ {
+			current, err := w.visit(v.Index(i), nil)
+			if err != nil {
+				return 0, err
+			}
+
+			if set {
+				h = hashUpdateUnordered(h, current)
+			} else {
+				h = hashUpdateOrdered(w.h, h, current)
+			}
+		}
+
+		return h, nil
+
+	case reflect.String:
+		// Directly hash
+		w.h.Reset()
+		_, err := w.h.Write([]byte(v.String()))
+		return w.h.Sum64(), err
+
+	default:
+		return 0, fmt.Errorf("unknown kind to hash: %s", k)
+	}
+
+	return 0, nil
+}
+
+func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
+	// For ordered updates, use a real hash function
+	h.Reset()
+
+	// We just panic if the binary writes fail because we are writing
+	// an int64 which should never be fail-able.
+	e1 := binary.Write(h, binary.LittleEndian, a)
+	e2 := binary.Write(h, binary.LittleEndian, b)
+	if e1 != nil {
+		panic(e1)
+	}
+	if e2 != nil {
+		panic(e2)
+	}
+
+	return h.Sum64()
+}
+
+func hashUpdateUnordered(a, b uint64) uint64 {
+	return a ^ b
+}
+
+// visitFlag is used as a bitmask for affecting visit behavior
+type visitFlag uint
+
+const (
+	visitFlagInvalid visitFlag = iota
+	visitFlagSet               = iota << 1
+)

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure_examples_test.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure_examples_test.go
@@ -1,0 +1,32 @@
+package hashstructure
+
+import (
+	"fmt"
+)
+
+func ExampleHash() {
+	type ComplexStruct struct {
+		Name     string
+		Age      uint
+		Metadata map[string]interface{}
+	}
+
+	v := ComplexStruct{
+		Name: "mitchellh",
+		Age:  64,
+		Metadata: map[string]interface{}{
+			"car":      true,
+			"location": "California",
+			"siblings": []string{"Bob", "John"},
+		},
+	}
+
+	hash, err := Hash(v, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%d", hash)
+	// Output:
+	// 6691276962590150517
+}

--- a/vendor/github.com/mitchellh/hashstructure/hashstructure_test.go
+++ b/vendor/github.com/mitchellh/hashstructure/hashstructure_test.go
@@ -1,0 +1,456 @@
+package hashstructure
+
+import (
+	"testing"
+)
+
+func TestHash_identity(t *testing.T) {
+	cases := []interface{}{
+		nil,
+		"foo",
+		42,
+		true,
+		false,
+		[]string{"foo", "bar"},
+		[]interface{}{1, nil, "foo"},
+		map[string]string{"foo": "bar"},
+		map[interface{}]string{"foo": "bar"},
+		map[interface{}]interface{}{"foo": "bar", "bar": 0},
+		struct {
+			Foo string
+			Bar []interface{}
+		}{
+			Foo: "foo",
+			Bar: []interface{}{nil, nil, nil},
+		},
+		&struct {
+			Foo string
+			Bar []interface{}
+		}{
+			Foo: "foo",
+			Bar: []interface{}{nil, nil, nil},
+		},
+	}
+
+	for _, tc := range cases {
+		// We run the test 100 times to try to tease out variability
+		// in the runtime in terms of ordering.
+		valuelist := make([]uint64, 100)
+		for i, _ := range valuelist {
+			v, err := Hash(tc, nil)
+			if err != nil {
+				t.Fatalf("Error: %s\n\n%#v", err, tc)
+			}
+
+			valuelist[i] = v
+		}
+
+		// Zero is always wrong
+		if valuelist[0] == 0 {
+			t.Fatalf("zero hash: %#v", tc)
+		}
+
+		// Make sure all the values match
+		t.Logf("%#v: %d", tc, valuelist[0])
+		for i := 1; i < len(valuelist); i++ {
+			if valuelist[i] != valuelist[0] {
+				t.Fatalf("non-matching: %d, %d\n\n%#v", i, 0, tc)
+			}
+		}
+	}
+}
+
+func TestHash_equal(t *testing.T) {
+	type testFoo struct{ Name string }
+	type testBar struct{ Name string }
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			map[string]string{"foo": "bar"},
+			map[interface{}]string{"foo": "bar"},
+			true,
+		},
+
+		{
+			map[string]interface{}{"1": "1"},
+			map[string]interface{}{"1": "1", "2": "2"},
+			false,
+		},
+
+		{
+			struct{ Fname, Lname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"bar", "foo"},
+			false,
+		},
+
+		{
+			struct{ Lname, Fname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"foo", "bar"},
+			false,
+		},
+
+		{
+			struct{ Lname, Fname string }{"foo", "bar"},
+			struct{ Fname, Lname string }{"bar", "foo"},
+			true,
+		},
+
+		{
+			testFoo{"foo"},
+			testBar{"foo"},
+			false,
+		},
+
+		{
+			struct {
+				Foo        string
+				unexported string
+			}{
+				Foo:        "bar",
+				unexported: "baz",
+			},
+			struct {
+				Foo        string
+				unexported string
+			}{
+				Foo:        "bar",
+				unexported: "bang",
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Hashing: %#v", tc.One)
+		one, err := Hash(tc.One, nil)
+		t.Logf("Result: %d", one)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		t.Logf("Hashing: %#v", tc.Two)
+		two, err := Hash(tc.Two, nil)
+		t.Logf("Result: %d", two)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_equalIgnore(t *testing.T) {
+	type Test1 struct {
+		Name string
+		UUID string `hash:"ignore"`
+	}
+
+	type Test2 struct {
+		Name string
+		UUID string `hash:"-"`
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "bar"},
+			true,
+		},
+
+		{
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "foo"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "bar"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "foo"},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_equalNil(t *testing.T) {
+	type Test struct {
+		Str   *string
+		Int   *int
+		Map   map[string]string
+		Slice []string
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		ZeroNil  bool
+		Match    bool
+	}{
+		{
+			Test{
+				Str:   nil,
+				Int:   nil,
+				Map:   nil,
+				Slice: nil,
+			},
+			Test{
+				Str:   new(string),
+				Int:   new(int),
+				Map:   make(map[string]string),
+				Slice: make([]string, 0),
+			},
+			true,
+			true,
+		},
+		{
+			Test{
+				Str:   nil,
+				Int:   nil,
+				Map:   nil,
+				Slice: nil,
+			},
+			Test{
+				Str:   new(string),
+				Int:   new(int),
+				Map:   make(map[string]string),
+				Slice: make([]string, 0),
+			},
+			false,
+			false,
+		},
+		{
+			nil,
+			0,
+			true,
+			true,
+		},
+		{
+			nil,
+			0,
+			false,
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, &HashOptions{ZeroNil: tc.ZeroNil})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, &HashOptions{ZeroNil: tc.ZeroNil})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_equalSet(t *testing.T) {
+	type Test struct {
+		Name    string
+		Friends []string `hash:"set"`
+	}
+
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			Test{Name: "foo", Friends: []string{"bar", "foo"}},
+			true,
+		},
+
+		{
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			Test{Name: "foo", Friends: []string{"foo", "bar"}},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_includable(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludable{Value: "foo"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "bar"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+func TestHash_includableMap(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"bar": "baz"}},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+type testIncludable struct {
+	Value  string
+	Ignore string
+}
+
+func (t testIncludable) HashInclude(field string, v interface{}) (bool, error) {
+	return field != "Ignore", nil
+}
+
+type testIncludableMap struct {
+	Map map[string]string
+}
+
+func (t testIncludableMap) HashIncludeMap(field string, k, v interface{}) (bool, error) {
+	if field != "Map" {
+		return true, nil
+	}
+
+	if s, ok := k.(string); ok && s == "ignore" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/mitchellh/hashstructure/include.go
+++ b/vendor/github.com/mitchellh/hashstructure/include.go
@@ -1,0 +1,15 @@
+package hashstructure
+
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -610,6 +610,12 @@
 			"revisionTime": "2013-05-14T23:54:47-07:00"
 		},
 		{
+			"checksumSHA1": "bnhCW1Cu5A402WXhgSEYlFF/v5w=",
+			"path": "github.com/mitchellh/hashstructure",
+			"revision": "b098c52ef6beab8cd82bc4a32422cf54b890e8fa",
+			"revisionTime": "2016-06-09T17:09:29Z"
+		},
+		{
 			"checksumSHA1": "HgqDa4oBBOol5ziacmj/6c55Xtg=",
 			"path": "github.com/opencontainers/runc/libcontainer/user",
 			"revision": "629e35666d31f743090452416c8df207d9fdbd34",


### PR DESCRIPTION
This does a few things, talked about in https://github.com/remind101/empire/pull/935#issuecomment-233507474

1. Removes the self imposed 10 second tick.
2. Starts up multiple worker goroutines pulling messages off of sqs.
3. Makes it so that updates to ECSEnvironment and ECSTaskDefinition don't create a new physical resource when the properties are identical as before

For an app that used to take over 10 minutes to perform the updates, this reduces it down to less than 2 minutes.