### PR TITLE
Move ECSService and InstancePort resources to higher level interface.

### DIFF
--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -54,10 +53,14 @@ type LoadBalancer struct {
 type ECSServiceProperties struct {
 	ServiceName    *string
 	Cluster        *string
-	DesiredCount   *customresources.IntValue
+	DesiredCount   *customresources.IntValue `hash:"ignore"`
 	LoadBalancers  []LoadBalancer
 	Role           *string
-	TaskDefinition *string
+	TaskDefinition *string `hash:"ignore"`
+}
+
+func (p *ECSServiceProperties) ReplacementHash() (uint64, error) {
+	return hashstructure.Hash(p, nil)
 }
 
 // ECSServiceResource is a Provisioner that creates and updates ECS services.
@@ -65,68 +68,22 @@ type ECSServiceResource struct {
 	ecs ecsClient
 }
 
-func (p *ECSServiceResource) Properties() interface{} {
-	return &ECSServiceProperties{}
-}
-
-func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.Request) (string, interface{}, error) {
-	properties := req.ResourceProperties.(*ECSServiceProperties)
-	oldProperties := req.OldResourceProperties.(*ECSServiceProperties)
-	data := make(map[string]string)
-
-	switch req.RequestType {
-	case customresources.Create:
-		id, deploymentId, err := p.create(ctx, req.Hash(), properties)
-		if err == nil {
-			data["DeploymentId"] = deploymentId
-		}
-		return id, data, err
-	case customresources.Delete:
-		id := req.PhysicalResourceId
-		err := p.delete(ctx, aws.String(id), properties.Cluster)
-		return id, nil, err
-	case customresources.Update:
-		id := req.PhysicalResourceId
-
-		// TODO: Update this to use hashstructure.
-		if serviceRequiresReplacement(properties, oldProperties) {
-			// If we can't update the service, we'll need to create a new
-			// one, and destroy the old one.
-			oldId := id
-			id, deploymentId, err := p.create(ctx, req.Hash(), properties)
-			if err != nil {
-				return oldId, nil, err
-			}
-			data["DeploymentId"] = deploymentId
-
-			// There's no need to delete the old service here, since
-			// CloudFormation will send us a DELETE request for the old
-			// service.
-
-			return id, data, err
-		}
-
-		resp, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
-			Service:        aws.String(id),
-			Cluster:        properties.Cluster,
-			DesiredCount:   properties.DesiredCount.Value(),
-			TaskDefinition: properties.TaskDefinition,
-		})
-		if err == nil {
-			d := primaryDeployment(resp.Service)
-			if d != nil {
-				data["DeploymentId"] = *d.Id
-			} else {
-				err = fmt.Errorf("no primary deployment found")
-			}
-		}
-		return id, data, err
-	default:
-		return "", nil, fmt.Errorf("%s is not supported", req.RequestType)
+func newECSServiceProvisioner(resource *ECSServiceResource) *provisioner {
+	return &provisioner{
+		properties: func() properties {
+			return &ECSServiceProperties{}
+		},
+		Create: resource.Create,
+		Update: resource.Update,
+		Delete: resource.Delete,
 	}
 }
 
-func (p *ECSServiceResource) create(ctx context.Context, clientToken string, properties *ECSServiceProperties) (string, string, error) {
+func (p *ECSServiceResource) Create(ctx context.Context, req customresources.Request) (string, interface{}, error) {
+	properties := req.ResourceProperties.(*ECSServiceProperties)
+	clientToken := req.Hash()
+	data := make(map[string]string)
+
 	var loadBalancers []*ecs.LoadBalancer
 	for _, v := range properties.LoadBalancers {
 		loadBalancers = append(loadBalancers, &ecs.LoadBalancer{
@@ -151,13 +108,14 @@ func (p *ECSServiceResource) create(ctx context.Context, clientToken string, pro
 		LoadBalancers:  loadBalancers,
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("error creating service: %v", err)
+		return "", nil, fmt.Errorf("error creating service: %v", err)
 	}
 
 	d := primaryDeployment(resp.Service)
 	if d == nil {
-		return "", "", fmt.Errorf("no primary deployment found")
+		return "", data, fmt.Errorf("no primary deployment found")
 	}
+	data["DeploymentId"] = *d.Id
 
 	arn := resp.Service.ServiceArn
 
@@ -178,13 +136,40 @@ func (p *ECSServiceResource) create(ctx context.Context, clientToken string, pro
 	select {
 	case <-stabilized:
 	case <-ctx.Done():
-		return *arn, *d.Id, ctx.Err()
+		return *arn, data, ctx.Err()
 	}
 
-	return *arn, *d.Id, nil
+	return *arn, data, nil
 }
 
-func (p *ECSServiceResource) delete(ctx context.Context, service, cluster *string) error {
+func (p *ECSServiceResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
+	properties := req.ResourceProperties.(*ECSServiceProperties)
+	data := make(map[string]string)
+
+	resp, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
+		Service:        aws.String(req.PhysicalResourceId),
+		Cluster:        properties.Cluster,
+		DesiredCount:   properties.DesiredCount.Value(),
+		TaskDefinition: properties.TaskDefinition,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	d := primaryDeployment(resp.Service)
+	if d == nil {
+		return nil, fmt.Errorf("no primary deployment found")
+	}
+
+	data["DeploymentId"] = *d.Id
+	return data, nil
+}
+
+func (p *ECSServiceResource) Delete(ctx context.Context, req customresources.Request) error {
+	properties := req.ResourceProperties.(*ECSServiceProperties)
+	service := aws.String(req.PhysicalResourceId)
+	cluster := properties.Cluster
+
 	// We have to scale the service down to 0, before we're able to
 	// destroy it.
 	if _, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
@@ -265,7 +250,6 @@ func newECSTaskDefinitionProvisioner(resource *ECSTaskDefinitionResource) *provi
 			return &ECSTaskDefinitionProperties{}
 		},
 		Create: resource.Create,
-		Update: resource.Update,
 		Delete: resource.Delete,
 	}
 }
@@ -274,13 +258,6 @@ func (p *ECSTaskDefinitionResource) Create(ctx context.Context, req customresour
 	properties := req.ResourceProperties.(*ECSTaskDefinitionProperties)
 	id, err := p.register(properties, req.Hash())
 	return id, nil, err
-}
-
-func (p *ECSTaskDefinitionResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
-	// Updates of ECSTaskDefinition will generate a replacement resource, so
-	// if we've reached this point, it means that the environment is the
-	// same as it was before.
-	return nil, nil
 }
 
 func (p *ECSTaskDefinitionResource) Delete(ctx context.Context, req customresources.Request) error {
@@ -374,7 +351,7 @@ func (p *ECSTaskDefinitionResource) delete(arn string) error {
 // ECSEnvironmentProperties are the properties provided to the
 // Custom::ECSEnvironment custom resource.
 type ECSEnvironmentProperties struct {
-	Environment []*ecs.KeyValuePair `hash:"set"`
+	Environment []*ecs.KeyValuePair
 }
 
 func (p *ECSEnvironmentProperties) ReplacementHash() (uint64, error) {
@@ -394,7 +371,6 @@ func newECSEnvironmentProvisioner(resource *ECSEnvironmentResource) *provisioner
 			return &ECSEnvironmentProperties{}
 		},
 		Create: resource.Create,
-		Update: resource.Update,
 		Delete: resource.Delete,
 	}
 }
@@ -403,13 +379,6 @@ func (p *ECSEnvironmentResource) Create(ctx context.Context, req customresources
 	properties := req.ResourceProperties.(*ECSEnvironmentProperties)
 	id, err := p.environmentStore.store(properties.Environment)
 	return id, nil, err
-}
-
-func (p *ECSEnvironmentResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
-	// Updates of ECSEnvironment will generate a replacement resource, so if
-	// we've reached this point, it means that the environment is the same
-	// as it was before.
-	return nil, nil
 }
 
 func (p *ECSEnvironmentResource) Delete(ctx context.Context, req customresources.Request) error {
@@ -461,30 +430,6 @@ func (s *dbEnvironmentStore) fetch(id string) ([]*ecs.KeyValuePair, error) {
 	var env ecsKeyValuePair
 	err := s.db.QueryRow(sql, id).Scan(&env)
 	return env, err
-}
-
-// Certain parameters cannot be updated on existing services, so we need to
-// create a new physical resource.
-func serviceRequiresReplacement(new, old *ECSServiceProperties) bool {
-	eq := reflect.DeepEqual
-
-	if !eq(new.Cluster, old.Cluster) {
-		return true
-	}
-
-	if !eq(new.Role, old.Role) {
-		return true
-	}
-
-	if !eq(new.ServiceName, old.ServiceName) {
-		return true
-	}
-
-	if !eq(new.LoadBalancers, old.LoadBalancers) {
-		return true
-	}
-
-	return false
 }
 
 func primaryDeployment(service *ecs.Service) *ecs.Deployment {

--- a/server/cloudformation/ports.go
+++ b/server/cloudformation/ports.go
@@ -14,36 +14,34 @@ type portAllocator interface {
 	Put(port int64) error
 }
 
-// InstancePortsProvisioner is a Provisioner that allocates instance ports.
-type InstancePortsProvisioner struct {
+// InstancePortsResource is a Provisioner that allocates instance ports.
+type InstancePortsResource struct {
 	ports portAllocator
 }
 
-func (p *InstancePortsProvisioner) Properties() interface{} {
+func newInstancePortsProvisioner(resource *InstancePortsResource) *provisioner {
+	return &provisioner{
+		Create: resource.Create,
+		Delete: resource.Delete,
+	}
+}
+
+func (p *InstancePortsResource) Properties() interface{} {
 	return nil
 }
 
-func (p *InstancePortsProvisioner) Provision(_ context.Context, req customresources.Request) (id string, data interface{}, err error) {
-	switch req.RequestType {
-	case customresources.Create:
-		var port int64
-		port, err = p.ports.Get()
-		if err != nil {
-			return
-		}
-		id = fmt.Sprintf("%d", port)
-		data = map[string]int64{"InstancePort": port}
-	case customresources.Delete:
-		port, err2 := strconv.Atoi(req.PhysicalResourceId)
-		if err2 != nil {
-			err = fmt.Errorf("physical resource id should have been a port number: %v", err2)
-			return
-		}
-		id = req.PhysicalResourceId
-		err = p.ports.Put(int64(port))
-	default:
-		err = fmt.Errorf("%s is not supported", req.RequestType)
-	}
+func (p *InstancePortsResource) Create(_ context.Context, req customresources.Request) (string, interface{}, error) {
+	var port int64
+	port, err := p.ports.Get()
+	data := map[string]int64{"InstancePort": port}
+	id := fmt.Sprintf("%d", port)
+	return id, data, err
+}
 
-	return
+func (p *InstancePortsResource) Delete(_ context.Context, req customresources.Request) error {
+	port, err := strconv.Atoi(req.PhysicalResourceId)
+	if err != nil {
+		return fmt.Errorf("physical resource id should have been a port number: %v", err)
+	}
+	return p.ports.Put(int64(port))
 }


### PR DESCRIPTION
Follow up from https://github.com/remind101/empire/pull/935

This moves the ECSService and InstancePort custom resources to use the higher level interface.
