### PR TITLE
Improve performance of custom resource provisioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 **Performance**
 
+* Performance of creating/updating/deleting custom resources in the CloudFormation backend has been improved. [#942](https://github.com/remind101/empire/pull/942)
+
 **Security**
 
 ## 0.10.1 (2016-06-14)

--- a/server/cloudformation/cloudformation_test.go
+++ b/server/cloudformation/cloudformation_test.go
@@ -210,3 +210,8 @@ func (m *mockSQSClient) DeleteMessage(input *sqs.DeleteMessageInput) (*sqs.Delet
 	args := m.Called(input)
 	return args.Get(0).(*sqs.DeleteMessageOutput), args.Error(1)
 }
+
+func (m *mockSQSClient) ChangeMessageVisibility(input *sqs.ChangeMessageVisibilityInput) (*sqs.ChangeMessageVisibilityOutput, error) {
+	args := m.Called(input)
+	return args.Get(0).(*sqs.ChangeMessageVisibilityOutput), args.Error(1)
+}

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/mitchellh/hashstructure"
 	"github.com/remind101/empire/pkg/cloudformation/customresources"
@@ -26,6 +27,20 @@ type ecsClient interface {
 	WaitUntilServicesStable(*ecs.DescribeServicesInput) error
 	RegisterTaskDefinition(*ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error)
 	DeregisterTaskDefinition(*ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error)
+}
+
+// newECSClient returns a new ecs.ECS instance, that has more relaxed retry
+// timeouts.
+func newECSClient(config client.ConfigProvider) *ecs.ECS {
+	return ecs.New(config, &aws.Config{
+		Retryer: newRetryer(),
+	})
+}
+
+func newRetryer() client.DefaultRetryer {
+	return client.DefaultRetryer{
+		NumMaxRetries: 10,
+	}
 }
 
 type LoadBalancer struct {

--- a/server/cloudformation/queue.go
+++ b/server/cloudformation/queue.go
@@ -1,6 +1,8 @@
 package cloudformation
 
 import (
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -11,8 +13,8 @@ import (
 )
 
 var (
-	DefaultVisibilityHeartbeat = 1 * time.Minute
-	DefaultNumWorkers          = 10
+	defaultVisibilityHeartbeat = 1 * time.Minute
+	defaultNumWorkers          = 10
 )
 
 // sqsClient duck types the sqs.SQS interface.
@@ -42,49 +44,74 @@ type SQSDispatcher struct {
 	// Number of worker goroutines to start for receiving messages.
 	NumWorkers int
 
-	sqs sqsClient
+	stopped chan struct{}
+	after   func(time.Duration) <-chan time.Time
+	sqs     sqsClient
 }
 
 func newSQSDispatcher(config client.ConfigProvider) *SQSDispatcher {
 	return &SQSDispatcher{
-		VisibilityHeartbeat: DefaultVisibilityHeartbeat,
-		NumWorkers:          DefaultNumWorkers,
+		VisibilityHeartbeat: defaultVisibilityHeartbeat,
+		NumWorkers:          defaultNumWorkers,
+		after:               time.After,
 		sqs:                 sqs.New(config),
 	}
 }
 
 // Start starts multiple goroutines pulling messages off of the queue.
 func (q *SQSDispatcher) Start(handle func(context.Context, *sqs.Message) error) {
+	var wg sync.WaitGroup
 	for i := 0; i < q.NumWorkers; i++ {
-		go q.start(handle)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			q.start(handle)
+		}()
 	}
+
+	wg.Wait()
+}
+
+func (q *SQSDispatcher) Stop() {
+	close(q.stopped)
 }
 
 // start starts a pulling messages off of the queue and passing them to the
 // handler.
 func (q *SQSDispatcher) start(handle func(context.Context, *sqs.Message) error) {
+	var wg sync.WaitGroup
 	for {
-		ctx := q.Context
+		select {
+		case <-q.stopped:
+			wg.Wait()
+			return
+		default:
+			ctx := q.Context
 
-		resp, err := q.sqs.ReceiveMessage(&sqs.ReceiveMessageInput{
-			QueueUrl: aws.String(q.QueueURL),
-		})
-		if err != nil {
-			reporter.Report(ctx, err)
-			continue
-		}
+			resp, err := q.sqs.ReceiveMessage(&sqs.ReceiveMessageInput{
+				QueueUrl: aws.String(q.QueueURL),
+			})
+			if err != nil {
+				reporter.Report(ctx, err)
+				continue
+			}
 
-		for _, m := range resp.Messages {
-			go func(m *sqs.Message) {
-				if err := q.handle(ctx, handle, m); err != nil {
-					reporter.Report(ctx, err)
-				}
-			}(m)
+			for _, m := range resp.Messages {
+				wg.Add(1)
+				go func(m *sqs.Message) {
+					defer wg.Done()
+					if err := q.handle(ctx, handle, m); err != nil {
+						reporter.Report(ctx, err)
+					}
+				}(m)
+			}
 		}
 	}
 }
 
 func (q *SQSDispatcher) handle(ctx context.Context, handle func(context.Context, *sqs.Message) error, message *sqs.Message) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+
 	defer func() {
 		if err == nil {
 			_, err = q.sqs.DeleteMessage(&sqs.DeleteMessageInput{
@@ -94,34 +121,41 @@ func (q *SQSDispatcher) handle(ctx context.Context, handle func(context.Context,
 		}
 	}()
 
-	visibilityTimeout := int64(float64(q.VisibilityHeartbeat) / float64(time.Second))
-
-	_, err = q.sqs.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
-		QueueUrl:          aws.String(q.QueueURL),
-		ReceiptHandle:     message.ReceiptHandle,
-		VisibilityTimeout: aws.Int64(visibilityTimeout),
-	})
+	var t <-chan time.Time
+	t, err = q.extendMessageVisibilityTimeout(message.ReceiptHandle)
 
 	errCh := make(chan error)
-	go func() {
-		errCh <- handle(ctx, message)
-	}()
-
-	tick := time.Tick(q.VisibilityHeartbeat / 2)
+	go func() { errCh <- handle(ctx, message) }()
 
 	for {
 		select {
 		case err = <-errCh:
 			return
-		case <-tick:
-			_, err = q.sqs.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
-				QueueUrl:          aws.String(q.QueueURL),
-				ReceiptHandle:     message.ReceiptHandle,
-				VisibilityTimeout: aws.Int64(visibilityTimeout),
-			})
+		case <-q.stopped:
+			cancel()
+		case <-t:
+			t, err = q.extendMessageVisibilityTimeout(message.ReceiptHandle)
 			if err != nil {
 				return
 			}
 		}
 	}
+}
+
+// extendMessageVisibilityTimeout extends the messages visibility timeout
+// extends the timeout by VisibilityHeartbeat, and returns a channel that will
+// receive after half of VisibilityTimeout has elapsed.
+func (q *SQSDispatcher) extendMessageVisibilityTimeout(receiptHandle *string) (<-chan time.Time, error) {
+	visibilityTimeout := int64(float64(q.VisibilityHeartbeat) / float64(time.Second))
+
+	_, err := q.sqs.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String(q.QueueURL),
+		ReceiptHandle:     receiptHandle,
+		VisibilityTimeout: aws.Int64(visibilityTimeout),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error extending message visibility timeout: %v", err)
+	}
+
+	return q.after(q.VisibilityHeartbeat / 2), nil
 }

--- a/server/cloudformation/queue.go
+++ b/server/cloudformation/queue.go
@@ -1,0 +1,127 @@
+package cloudformation
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/remind101/pkg/reporter"
+	"golang.org/x/net/context"
+)
+
+var (
+	DefaultVisibilityHeartbeat = 1 * time.Minute
+	DefaultNumWorkers          = 10
+)
+
+// sqsClient duck types the sqs.SQS interface.
+type sqsClient interface {
+	ReceiveMessage(*sqs.ReceiveMessageInput) (*sqs.ReceiveMessageOutput, error)
+	DeleteMessage(*sqs.DeleteMessageInput) (*sqs.DeleteMessageOutput, error)
+	ChangeMessageVisibility(*sqs.ChangeMessageVisibilityInput) (*sqs.ChangeMessageVisibilityOutput, error)
+}
+
+// SQSDispatcher pulls messages from SQS, and dispatches them to a handler.
+type SQSDispatcher struct {
+	// Root context.Context to use. If a reporter.Reporter is embedded,
+	// errors generated will be reporter there. If a logger.Logger is
+	// embedded, logging will be logged there.
+	Context context.Context
+
+	// The SQS queue url to listen for CloudFormation Custom Resource
+	// requests.
+	QueueURL string
+
+	// When a message is pulled off of sqs, the visibility timeout will be
+	// extended by this much, and periodically extended while the handler
+	// performs it's work. If this process crashes, then the sqs message
+	// will be redelivered later.
+	VisibilityHeartbeat time.Duration
+
+	// Number of worker goroutines to start for receiving messages.
+	NumWorkers int
+
+	sqs sqsClient
+}
+
+func newSQSDispatcher(config client.ConfigProvider) *SQSDispatcher {
+	return &SQSDispatcher{
+		VisibilityHeartbeat: DefaultVisibilityHeartbeat,
+		NumWorkers:          DefaultNumWorkers,
+		sqs:                 sqs.New(config),
+	}
+}
+
+// Start starts multiple goroutines pulling messages off of the queue.
+func (q *SQSDispatcher) Start(handle func(context.Context, *sqs.Message) error) {
+	for i := 0; i < q.NumWorkers; i++ {
+		go q.start(handle)
+	}
+}
+
+// start starts a pulling messages off of the queue and passing them to the
+// handler.
+func (q *SQSDispatcher) start(handle func(context.Context, *sqs.Message) error) {
+	for {
+		ctx := q.Context
+
+		resp, err := q.sqs.ReceiveMessage(&sqs.ReceiveMessageInput{
+			QueueUrl: aws.String(q.QueueURL),
+		})
+		if err != nil {
+			reporter.Report(ctx, err)
+			continue
+		}
+
+		for _, m := range resp.Messages {
+			go func(m *sqs.Message) {
+				if err := q.handle(ctx, handle, m); err != nil {
+					reporter.Report(ctx, err)
+				}
+			}(m)
+		}
+	}
+}
+
+func (q *SQSDispatcher) handle(ctx context.Context, handle func(context.Context, *sqs.Message) error, message *sqs.Message) (err error) {
+	defer func() {
+		if err == nil {
+			_, err = q.sqs.DeleteMessage(&sqs.DeleteMessageInput{
+				QueueUrl:      aws.String(q.QueueURL),
+				ReceiptHandle: message.ReceiptHandle,
+			})
+		}
+	}()
+
+	visibilityTimeout := int64(float64(q.VisibilityHeartbeat) / float64(time.Second))
+
+	_, err = q.sqs.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String(q.QueueURL),
+		ReceiptHandle:     message.ReceiptHandle,
+		VisibilityTimeout: aws.Int64(visibilityTimeout),
+	})
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- handle(ctx, message)
+	}()
+
+	tick := time.Tick(q.VisibilityHeartbeat / 2)
+
+	for {
+		select {
+		case err = <-errCh:
+			return
+		case <-tick:
+			_, err = q.sqs.ChangeMessageVisibility(&sqs.ChangeMessageVisibilityInput{
+				QueueUrl:          aws.String(q.QueueURL),
+				ReceiptHandle:     message.ReceiptHandle,
+				VisibilityTimeout: aws.Int64(visibilityTimeout),
+			})
+			if err != nil {
+				return
+			}
+		}
+	}
+}

--- a/server/cloudformation/queue.go
+++ b/server/cloudformation/queue.go
@@ -142,9 +142,9 @@ func (q *SQSDispatcher) handle(ctx context.Context, handle func(context.Context,
 	}
 }
 
-// extendMessageVisibilityTimeout extends the messages visibility timeout
-// extends the timeout by VisibilityHeartbeat, and returns a channel that will
-// receive after half of VisibilityTimeout has elapsed.
+// extendMessageVisibilityTimeout extends the messages visibility timeout by
+// VisibilityHeartbeat, and returns a channel that will receive after half of
+// VisibilityTimeout has elapsed.
 func (q *SQSDispatcher) extendMessageVisibilityTimeout(receiptHandle *string) (<-chan time.Time, error) {
 	visibilityTimeout := int64(float64(q.VisibilityHeartbeat) / float64(time.Second))
 

--- a/server/cloudformation/queue_test.go
+++ b/server/cloudformation/queue_test.go
@@ -1,0 +1,139 @@
+package cloudformation
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+func TestSQSDispatcher_Handle(t *testing.T) {
+	s := new(mockSQSClient)
+	q := &SQSDispatcher{
+		VisibilityHeartbeat: defaultVisibilityHeartbeat,
+		QueueURL:            "https://sqs.amazonaws.com",
+		sqs:                 s,
+		after: func(d time.Duration) <-chan time.Time {
+			return nil
+		},
+	}
+
+	s.On("ChangeMessageVisibility", &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String("https://sqs.amazonaws.com"),
+		VisibilityTimeout: aws.Int64(60),
+		ReceiptHandle:     aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	}).Return(&sqs.ChangeMessageVisibilityOutput{}, nil).Once()
+
+	s.On("DeleteMessage", &sqs.DeleteMessageInput{
+		QueueUrl:      aws.String("https://sqs.amazonaws.com"),
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	}).Return(&sqs.DeleteMessageOutput{}, nil)
+
+	handle := func(ctx context.Context, message *sqs.Message) error {
+		return nil
+	}
+	err := q.handle(ctx, handle, &sqs.Message{
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	})
+	assert.NoError(t, err)
+
+	s.AssertExpectations(t)
+}
+
+func TestSQSDispatcher_Handle_Long(t *testing.T) {
+	timeout := make(chan time.Time)
+	s := new(mockSQSClient)
+	q := &SQSDispatcher{
+		VisibilityHeartbeat: defaultVisibilityHeartbeat,
+		QueueURL:            "https://sqs.amazonaws.com",
+		sqs:                 s,
+		after: func(d time.Duration) <-chan time.Time {
+			return timeout
+		},
+	}
+
+	s.On("ChangeMessageVisibility", &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String("https://sqs.amazonaws.com"),
+		VisibilityTimeout: aws.Int64(60),
+		ReceiptHandle:     aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	}).Return(&sqs.ChangeMessageVisibilityOutput{}, nil).Twice()
+
+	s.On("DeleteMessage", &sqs.DeleteMessageInput{
+		QueueUrl:      aws.String("https://sqs.amazonaws.com"),
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	}).Return(&sqs.DeleteMessageOutput{}, nil)
+
+	handle := func(ctx context.Context, message *sqs.Message) error {
+		timeout <- time.Now()
+		return nil
+	}
+	err := q.handle(ctx, handle, &sqs.Message{
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	})
+	assert.NoError(t, err)
+
+	s.AssertExpectations(t)
+}
+
+func TestSQSDispatcher_Handle_Error(t *testing.T) {
+	s := new(mockSQSClient)
+	q := &SQSDispatcher{
+		VisibilityHeartbeat: defaultVisibilityHeartbeat,
+		QueueURL:            "https://sqs.amazonaws.com",
+		sqs:                 s,
+		after: func(d time.Duration) <-chan time.Time {
+			return nil
+		},
+	}
+
+	s.On("ChangeMessageVisibility", &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String("https://sqs.amazonaws.com"),
+		VisibilityTimeout: aws.Int64(60),
+		ReceiptHandle:     aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	}).Return(&sqs.ChangeMessageVisibilityOutput{}, nil).Once()
+
+	handle := func(ctx context.Context, message *sqs.Message) error {
+		return errors.New("error uploading response")
+	}
+	err := q.handle(ctx, handle, &sqs.Message{
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	})
+	assert.Error(t, err)
+
+	s.AssertExpectations(t)
+}
+
+func TestSQSDispatcher_Handle_Stopped(t *testing.T) {
+	s := new(mockSQSClient)
+	q := &SQSDispatcher{
+		VisibilityHeartbeat: defaultVisibilityHeartbeat,
+		QueueURL:            "https://sqs.amazonaws.com",
+		sqs:                 s,
+		stopped:             make(chan struct{}),
+		after: func(d time.Duration) <-chan time.Time {
+			return nil
+		},
+	}
+	q.Stop()
+
+	s.On("ChangeMessageVisibility", &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String("https://sqs.amazonaws.com"),
+		VisibilityTimeout: aws.Int64(60),
+		ReceiptHandle:     aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	}).Return(&sqs.ChangeMessageVisibilityOutput{}, nil).Once()
+
+	handle := func(ctx context.Context, message *sqs.Message) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	err := q.handle(ctx, handle, &sqs.Message{
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	})
+	assert.Equal(t, context.Canceled, err)
+
+	s.AssertExpectations(t)
+}


### PR DESCRIPTION
This does the following to improve performance of custom resource provisioning:

1. Multiple goroutines pulling messages off of sqs are started.
2. The self imposed 10 second tick was removed.

Because of this, there's an increased probability of hitting rate limits. To counteract that, the following was done:

1. The ECS client that the `ECS*` custom resources use has a more lenient request retryer, retrying up to 10 times (default of 3).
2. Because throttling retries with exponential backoff could make a request take longer than the default queue visibility timeout, the sqs dispatcher now periodically extends the visibility timeout of received messages.

The ECS client will retry throttled requests, up to maximum wait time of ~13 minutes (previously, ~3 seconds). The backoff of a request, that retried up to 10 times, would look like this:


```
        ecs_test.go:41: delay(0): 873ms
        ecs_test.go:41: delay(1): 1.364s
        ecs_test.go:41: delay(2): 2.252s
        ecs_test.go:41: delay(3): 4.896s
        ecs_test.go:41: delay(4): 12.352s
        ecs_test.go:41: delay(5): 30.56s
        ecs_test.go:41: delay(6): 35.648s
        ecs_test.go:41: delay(7): 1m43.808s
        ecs_test.go:41: delay(8): 3m21.216s
        ecs_test.go:41: delay(9): 2m12.352s
        ecs_test.go:43: total(min): 6m23.5s
        ecs_test.go:44: total(max): 12m47s
        ecs_test.go:45: total(real): 8m45.321s
```