### PR TITLE
Send heartbeats to Tugboat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Fixed an issue where Procfile's would not be extracted when Docker 1.12+ was used. [#915](https://github.com/remind101/empire/pull/915)
 * Fixed a bug where the failed creation of a custom resources could cause a CloudFormation stack to fail to rollback. [#938](https://github.com/remind101/empire/pull/938)
 * Fixed a bug where waiting for a deploy to stabilize was failing if you had more than 10 services. [#944](https://github.com/remind101/empire/issues/944)
+* Fixed an issue in the Tugboat integration where the log stream to a Tugboat instance could be closed. [#950](https://github.com/remind101/empire/pull/950)
 
 **Performance**
 

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -3,10 +3,12 @@ package github
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/ejholmes/hookshot/events"
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/pkg/dockerutil"
+	streamhttp "github.com/remind101/empire/pkg/stream/http"
 	"github.com/remind101/pkg/trace"
 	"github.com/remind101/tugboat"
 	"golang.org/x/net/context"
@@ -100,6 +102,8 @@ func (d *TugboatDeployer) Deploy(ctx context.Context, event events.Deployment, o
 	// write hte logs to tugboat and update the deployment status when this
 	// function returns.
 	_, err := d.client.Deploy(ctx, opts, provider(func(ctx context.Context, _ *tugboat.Deployment, w io.Writer) error {
+		defer close(streamhttp.Heartbeat(w, 10*time.Second))
+
 		// Write logs to both tugboat as well as the writer we were
 		// provided (probably stdout).
 		w = io.MultiWriter(w, out)


### PR DESCRIPTION
This fixes an issue in the Tugboat integration where, if Tugboat was hosted on something like Heroku, the log stream to Tugboat could be closed if the deployment stream had a gap where no logs were written. This writes the null character every 10 seconds, to keep the connection open, which [Tugboat already strips out](https://github.com/remind101/tugboat/blob/9655efe1fc24323ec3155fe43e7446dc2264e00c/logs.go#L114).