### PR TITLE
Publish RunEvent on command start and finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * The database schema version is now checked at boot, as well as in the http health checks. [#893](https://github.com/remind101/empire/pull/893)
 * The log level within empire can now be configured when starting the service. [#929](https://github.com/remind101/empire/issues/929)
 * The CloudFormation backend now has experimental support for a `Custom::ECSTaskDefinition` resource that greatly reduces the size of generated templates. [#935](https://github.com/remind101/empire/pull/935)
+* `emp run` now publishes an event when it is ran [#954](https://github.com/remind101/empire/pull/954)
 
 **Bugs**
 

--- a/empire.go
+++ b/empire.go
@@ -451,10 +451,15 @@ func (e *Empire) Run(ctx context.Context, opts RunOpts) error {
 		opts.Output = io.MultiWriter(w, opts.Output)
 	}
 
+	if err := e.PublishEvent(event); err != nil {
+		return err
+	}
+
 	if err := e.runner.Run(ctx, opts); err != nil {
 		return err
 	}
 
+	event.Finish()
 	return e.PublishEvent(event)
 }
 

--- a/events.go
+++ b/events.go
@@ -43,7 +43,7 @@ func (e RunEvent) String() string {
 		attachment = "attached"
 	}
 
-	action := "started"
+	action := "started running"
 	if e.Finished {
 		action = "ran"
 	}

--- a/events.go
+++ b/events.go
@@ -16,7 +16,7 @@ func appendCommitMessage(main, commit string) string {
 	return output
 }
 
-// RunEvent is triggered when a user starts a one off process.
+// RunEvent is triggered when a user starts or stops a one off process.
 type RunEvent struct {
 	User     string
 	App      string
@@ -24,6 +24,7 @@ type RunEvent struct {
 	URL      string
 	Attached bool
 	Message  string
+	Finished bool
 
 	app *App
 }
@@ -32,12 +33,21 @@ func (e RunEvent) Event() string {
 	return "run"
 }
 
+func (e *RunEvent) Finish() {
+	e.Finished = true
+}
+
 func (e RunEvent) String() string {
 	attachment := "detached"
 	if e.Attached {
 		attachment = "attached"
 	}
-	msg := fmt.Sprintf("%s ran `%s` (%s) on %s", e.User, e.Command.String(), attachment, e.App)
+
+	action := "started"
+	if e.Finished {
+		action = "ran"
+	}
+	msg := fmt.Sprintf("%s %s `%s` (%s) on %s", e.User, action, e.Command.String(), attachment, e.App)
 	if e.URL != "" {
 		msg = fmt.Sprintf("%s (<%s|logs>)", msg, e.URL)
 	}

--- a/events_test.go
+++ b/events_test.go
@@ -12,13 +12,13 @@ func TestEvents_String(t *testing.T) {
 		out   string
 	}{
 		// RunEvent
-		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}}, "ejholmes started `bash` (detached) on acme-inc"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}}, "ejholmes started running `bash` (detached) on acme-inc"},
 		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}, Finished: true}, "ejholmes ran `bash` (detached) on acme-inc"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}}, "ejholmes started `bash` (attached) on acme-inc"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}}, "ejholmes started `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>)"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}, Message: "commit message"}, "ejholmes started `bash` (detached) on acme-inc: 'commit message'"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes started `bash` (attached) on acme-inc: 'commit message'"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes started `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>): 'commit message'"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}}, "ejholmes started running `bash` (attached) on acme-inc"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}}, "ejholmes started running `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>)"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}, Message: "commit message"}, "ejholmes started running `bash` (detached) on acme-inc: 'commit message'"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes started running `bash` (attached) on acme-inc: 'commit message'"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes started running `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>): 'commit message'"},
 
 		// RestartEvent
 		{RestartEvent{User: "ejholmes", App: "acme-inc"}, "ejholmes restarted acme-inc"},

--- a/events_test.go
+++ b/events_test.go
@@ -12,12 +12,13 @@ func TestEvents_String(t *testing.T) {
 		out   string
 	}{
 		// RunEvent
-		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}}, "ejholmes ran `bash` (detached) on acme-inc"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}}, "ejholmes ran `bash` (attached) on acme-inc"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}}, "ejholmes ran `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>)"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}, Message: "commit message"}, "ejholmes ran `bash` (detached) on acme-inc: 'commit message'"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes ran `bash` (attached) on acme-inc: 'commit message'"},
-		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes ran `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>): 'commit message'"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}}, "ejholmes started `bash` (detached) on acme-inc"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}, Finished: true}, "ejholmes ran `bash` (detached) on acme-inc"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}}, "ejholmes started `bash` (attached) on acme-inc"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}}, "ejholmes started `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>)"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Command: []string{"bash"}, Message: "commit message"}, "ejholmes started `bash` (detached) on acme-inc: 'commit message'"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes started `bash` (attached) on acme-inc: 'commit message'"},
+		{RunEvent{User: "ejholmes", App: "acme-inc", URL: "https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528", Attached: true, Command: []string{"bash"}, Message: "commit message"}, "ejholmes started `bash` (attached) on acme-inc (<https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEvent:group=runs;stream=dac6eaff-6e0b-4708-9277-9f38aea2f528|logs>): 'commit message'"},
 
 		// RestartEvent
 		{RestartEvent{User: "ejholmes", App: "acme-inc"}, "ejholmes restarted acme-inc"},


### PR DESCRIPTION
Fix for https://github.com/remind101/empire/issues/943

Publishes 2 events:
```
"ejholmes started `bash` (detached) on acme-inc"
"ejholmes ran `bash` (detached) on acme-inc"
```