### PR TITLE
Tag aws error stats with correct error code

### DIFF
--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -473,8 +473,8 @@ func newConfigProvider(c *Context) client.ConfigProvider {
 			stats.Inc(fmt.Sprintf("aws.request.%s.%s", r.ClientInfo.ServiceName, r.Operation.Name), 1, 1.0, tags)
 		},
 	})
-	s.Handlers.ValidateResponse.PushBackNamed(request.NamedHandler{
-		Name: "empire.ResponseMetrics",
+	s.Handlers.Retry.PushFrontNamed(request.NamedHandler{
+		Name: "empire.ErrorMetrics",
 		Fn: func(r *request.Request) {
 			tags := requestTags(r)
 			if r.Error != nil {


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/960.

Turns out, the `Error` attribute on a `request.Request` isn't actually real until the  `UnmarshalError` handler is called. The `Retry` handlers are called immediately after `UnmarshalError`, so this seems like the best place to put it.