### PR TITLE
Fix extension of message visibility.

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -442,7 +442,8 @@
               "Effect": "Allow",
               "Action": [
                 "sqs:ReceiveMessage",
-                "sqs:DeleteMessage"
+                "sqs:DeleteMessage",
+                "sqs:ChangeMessageVisibility"
               ],
               "Resource": { "Fn::GetAtt": ["CustomResourcesQueue", "Arn"] }
             },
@@ -542,6 +543,7 @@
               "Action": [
                 "route53:ListHostedZonesByName",
                 "route53:ChangeResourceRecordSets",
+                "route53:ListResourceRecordSets",
                 "route53:ListHostedZones",
                 "route53:GetHostedZone"
               ],

--- a/server/cloudformation/queue.go
+++ b/server/cloudformation/queue.go
@@ -1,7 +1,6 @@
 package cloudformation
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -128,6 +127,9 @@ func (q *SQSDispatcher) handle(ctx context.Context, handle func(context.Context,
 
 	var t <-chan time.Time
 	t, err = q.extendMessageVisibilityTimeout(message.ReceiptHandle)
+	if err != nil {
+		return
+	}
 
 	errCh := make(chan error)
 	go func() { errCh <- handle(ctx, message) }()
@@ -159,7 +161,7 @@ func (q *SQSDispatcher) extendMessageVisibilityTimeout(receiptHandle *string) (<
 		VisibilityTimeout: aws.Int64(visibilityTimeout),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error extending message visibility timeout: %v", err)
+		return nil, err
 	}
 
 	return q.after(q.VisibilityHeartbeat / 2), nil

--- a/server/cloudformation/queue_test.go
+++ b/server/cloudformation/queue_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -40,6 +41,35 @@ func TestSQSDispatcher_Handle(t *testing.T) {
 		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
 	})
 	assert.NoError(t, err)
+
+	s.AssertExpectations(t)
+}
+
+func TestSQSDispatcher_Handle_ChangeMessageVisibility(t *testing.T) {
+	s := new(mockSQSClient)
+	q := &SQSDispatcher{
+		VisibilityHeartbeat: defaultVisibilityHeartbeat,
+		QueueURL:            "https://sqs.amazonaws.com",
+		sqs:                 s,
+		after: func(d time.Duration) <-chan time.Time {
+			return nil
+		},
+	}
+
+	awsErr := awserr.New("AccessDenied", "Stack with id acme-inc does not exist", errors.New(""))
+	s.On("ChangeMessageVisibility", &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          aws.String("https://sqs.amazonaws.com"),
+		VisibilityTimeout: aws.Int64(60),
+		ReceiptHandle:     aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	}).Return(&sqs.ChangeMessageVisibilityOutput{}, awsErr).Once()
+
+	handle := func(ctx context.Context, message *sqs.Message) error {
+		return nil
+	}
+	err := q.handle(ctx, handle, &sqs.Message{
+		ReceiptHandle: aws.String("MbZj6wDWli+JvwwJaBV+3dcjk2YW2vA3+STFFljTM8tJJg6HRG6PYSasuWXPJB+CwLj1FjgXUv1uSj1gUPAWV66FU/WeR4mq2OKpEGYWbnLmpRCJVAyeMjeU5ZBdtcQ+QEauMZc8ZRv37sIW2iJKq3M9MFx1YvV11A2x/KSbkJ0="),
+	})
+	assert.Equal(t, awsErr, err)
 
 	s.AssertExpectations(t)
 }


### PR DESCRIPTION
https://github.com/remind101/empire/pull/942 introduced a bug, where if the initial call to extend the message visibility failed (e.g. AccessDenied), the error would not be bubbled up.