### PR TITLE
Add empire.user label to runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Empire now includes experimental support for scheduled tasks [#919](https://github.com/remind101/empire/pull/919)
 * Empire now supports streaming status updates from the scheduler while deploying [#888](https://github.com/remind101/empire/issues/888)
 * Empire now supports sending internal metrics to statsd or dogstatsd [#953](https://github.com/remind101/empire/pull/953)
+* Attached and detached runs now have an `empire.user` label attached to them [#965](https://github.com/remind101/empire/pull/965)
 
 **Improvements**
 

--- a/runner.go
+++ b/runner.go
@@ -73,6 +73,7 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 
 	a := newSchedulerApp(release)
 	p := newSchedulerProcess(release, "run", proc)
+	p.Labels["empire.user"] = opts.User.Name
 
 	// Add additional environment variables to the process.
 	for k, v := range opts.Env {

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -324,6 +324,7 @@ func TestEmpire_Run(t *testing.T) {
 			},
 			Labels: map[string]string{
 				"empire.app.process": "run",
+				"empire.user":        "ejholmes",
 			},
 		}, nil, nil).Return(nil)
 
@@ -398,6 +399,7 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 			},
 			Labels: map[string]string{
 				"empire.app.process": "run",
+				"empire.user":        "ejholmes",
 			},
 		}, nil, nil).Return(nil)
 


### PR DESCRIPTION
Sometimes, it would be helpful to know who started an attached/detached run. This will add an `empire.user` label that can be used with `docker inspect`, or with monitoring tools to determine who started the process.

/cc @phobologic 