### PR TITLE
Only allow whitelisted commands to be run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 **Security**
 
+* Empire now has a new `commands.allowed` flag that controls the behavior of what commands are allowed with `emp run`. This can be set to `procfile` to limit `emp run` to only allow commands defined in the Procfile.
+
 ## 0.10.1 (2016-06-14)
 
 **Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Empire now supports streaming status updates from the scheduler while deploying [#888](https://github.com/remind101/empire/issues/888)
 * Empire now supports sending internal metrics to statsd or dogstatsd [#953](https://github.com/remind101/empire/pull/953)
 * Attached and detached runs now have an `empire.user` label attached to them [#965](https://github.com/remind101/empire/pull/965)
+* You can now provide the name of a process defined in the Procfile when calling `emp run` [#967](https://github.com/remind101/empire/pull/967)
 
 **Improvements**
 

--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -74,7 +74,13 @@ func newEmpire(db *empire.DB, c *Context) (*empire.Empire, error) {
 	e.Environment = c.String(FlagEnvironment)
 	e.RunRecorder = runRecorder
 	e.MessagesRequired = c.Bool(FlagMessagesRequired)
-	e.RequireWhitelistedRuns = c.Bool(FlagRequireWhitelistedRuns)
+
+	switch c.String(FlagAllowedCommands) {
+	case "procfile":
+		e.AllowedCommands = empire.AllowCommandProcfile
+	default:
+	}
+
 	if logs != nil {
 		e.LogsStreamer = logs
 	}

--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -74,6 +74,7 @@ func newEmpire(db *empire.DB, c *Context) (*empire.Empire, error) {
 	e.Environment = c.String(FlagEnvironment)
 	e.RunRecorder = runRecorder
 	e.MessagesRequired = c.Bool(FlagMessagesRequired)
+	e.RequireWhitelistedRuns = c.Bool(FlagRequireWhitelistedRuns)
 	if logs != nil {
 		e.LogsStreamer = logs
 	}

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -10,13 +10,15 @@ import (
 )
 
 const (
-	FlagPort             = "port"
-	FlagAutoMigrate      = "automigrate"
-	FlagScheduler        = "scheduler"
-	FlagEventsBackend    = "events.backend"
-	FlagRunLogsBackend   = "runlogs.backend"
-	FlagMessagesRequired = "messages.required"
-	FlagLogLevel         = "log.level"
+	FlagPort           = "port"
+	FlagAutoMigrate    = "automigrate"
+	FlagScheduler      = "scheduler"
+	FlagEventsBackend  = "events.backend"
+	FlagRunLogsBackend = "runlogs.backend"
+	FlagLogLevel       = "log.level"
+
+	FlagMessagesRequired       = "messages.required"
+	FlagRequireWhitelistedRuns = "runs.whitelist"
 
 	FlagStats = "stats"
 
@@ -346,6 +348,11 @@ var EmpireFlags = []cli.Flag{
 		Name:   FlagMessagesRequired,
 		Usage:  "If true, messages will be required for empire actions that emit events.",
 		EnvVar: "EMPIRE_MESSAGES_REQUIRED",
+	},
+	cli.BoolFlag{
+		Name:   FlagRequireWhitelistedRuns,
+		Usage:  "If true, `emp run` will only run commands that have been whitelisted in the Procfile.",
+		EnvVar: "EMPIRE_REQUIRE_WHITELISTED_RUNS",
 	},
 	cli.BoolFlag{
 		Name:   FlagXShowAttached,

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -17,8 +17,8 @@ const (
 	FlagRunLogsBackend = "runlogs.backend"
 	FlagLogLevel       = "log.level"
 
-	FlagMessagesRequired       = "messages.required"
-	FlagRequireWhitelistedRuns = "runs.whitelist"
+	FlagMessagesRequired = "messages.required"
+	FlagAllowedCommands  = "commands.allowed"
 
 	FlagStats = "stats"
 
@@ -349,10 +349,11 @@ var EmpireFlags = []cli.Flag{
 		Usage:  "If true, messages will be required for empire actions that emit events.",
 		EnvVar: "EMPIRE_MESSAGES_REQUIRED",
 	},
-	cli.BoolFlag{
-		Name:   FlagRequireWhitelistedRuns,
-		Usage:  "If true, `emp run` will only run commands that have been whitelisted in the Procfile.",
-		EnvVar: "EMPIRE_REQUIRE_WHITELISTED_RUNS",
+	cli.StringFlag{
+		Name:   FlagAllowedCommands,
+		Value:  "any",
+		Usage:  "Specifies what commands are allowed when using `emp run`. Can be `any`, or `procfile`.",
+		EnvVar: "EMPIRE_ALLOWED_COMMANDS",
 	},
 	cli.BoolFlag{
 		Name:   FlagXShowAttached,

--- a/docs/deploying_an_application.md
+++ b/docs/deploying_an_application.md
@@ -172,6 +172,37 @@ v54.web.fd130482-675f-4611-a599-eb0da1879a10            1X  RUNNING   9m  "./bin
 
 Refer to http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ScheduledEvents.html for details on the cron expression syntax.
 
+## Run only processes
+
+When using `emp run`, if the command you provide matches a process within the Procfile, it will invoke the command defined inside the process. For example, you might define a `migrate` process inside the Procfile, which users would use to run migrations:
+
+```console
+#!/bin/bash
+
+dir=${1:-up}
+exec bundle exec rake db:migrate:$dir
+```
+
+```yaml
+migrate:
+  command: ./bin/migrate
+```
+
+Now, users can invoke the `migrate` process like so:
+
+```console
+$ emp run migrate up
+$ emp run migrate down
+```
+
+You can add the `noservice: true` flag to tell Empire to not create any AWS resources for the process, for extra re-assurance that the process won't be scaled up.
+
+```yaml
+migrate:
+  command: ./bin/migrate
+  noservice: true
+```
+
 ## Environment variables
 
 TODO

--- a/empire.go
+++ b/empire.go
@@ -32,6 +32,17 @@ var (
 	}
 )
 
+// An error that is returned when RequireWhitelistedRuns is enabled, and
+// the command is not whitelisted in the Procfile.
+type CommandWhitelistError struct {
+	Command Command
+}
+
+// Error implements the error interface.
+func (c *CommandWhitelistError) Error() string {
+	return fmt.Sprintf("command not whitelisted: %v", c.Command)
+}
+
 // Empire provides the core public API for Empire. Refer to the package
 // documentation for details.
 type Empire struct {
@@ -73,6 +84,10 @@ type Empire struct {
 
 	// MessagesRequired is a boolean used to determine if messages should be required for events.
 	MessagesRequired bool
+
+	// If enabled, only commands that are marked as `run: true` in the
+	// Procfile will be allowed with `emp run`.
+	RequireWhitelistedRuns bool
 }
 
 // New returns a new Empire instance.

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -122,8 +122,8 @@ var defaultProcfile = procfile.ExtendedProcfile{
 		}(),
 	},
 	"rake": procfile.Process{
-		Command: "bundle exec rake",
-		Run:     true,
+		Command:   "bundle exec rake",
+		NoService: true,
 	},
 }
 

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -121,6 +121,10 @@ var defaultProcfile = procfile.ExtendedProcfile{
 			return &everyMinute
 		}(),
 	},
+	"rake": procfile.Process{
+		Command: "bundle exec rake",
+		Run:     true,
+	},
 }
 
 // Returns a function that can be used as a Procfile extract for Empire. It

--- a/extractor.go
+++ b/extractor.go
@@ -242,9 +242,9 @@ func formationFromExtendedProcfile(p procfile.ExtendedProcfile) (Formation, erro
 		}
 
 		f[name] = Process{
-			Command: cmd,
-			Cron:    process.Cron,
-			Run:     process.Run,
+			Command:   cmd,
+			Cron:      process.Cron,
+			NoService: process.NoService,
 		}
 	}
 

--- a/extractor.go
+++ b/extractor.go
@@ -244,6 +244,7 @@ func formationFromExtendedProcfile(p procfile.ExtendedProcfile) (Formation, erro
 		f[name] = Process{
 			Command: cmd,
 			Cron:    process.Cron,
+			Run:     process.Run,
 		}
 	}
 

--- a/processes.go
+++ b/processes.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	shellwords "github.com/mattn/go-shellwords"
@@ -72,7 +73,7 @@ type Process struct {
 
 	// Signifies that this is a named one off command and not a long lived
 	// service.
-	Run bool `json:"Run,omitempty"`
+	NoService bool `json:"Run,omitempty"`
 
 	// Quantity is the desired number of instances of this process.
 	Quantity int `json:"Quantity,omitempty"`
@@ -89,6 +90,18 @@ type Process struct {
 	// A cron expression. If provided, the process will be run as a
 	// scheduled task.
 	Cron *string `json:"cron,omitempty"`
+}
+
+// IsValid returns nil if the Process is valid.
+func (p *Process) IsValid() error {
+	// Ensure that processes marked as NoService can't be scaled up.
+	if p.NoService {
+		if p.Quantity != 0 {
+			return errors.New("non-service processes cannot be scaled up")
+		}
+	}
+
+	return nil
 }
 
 // Constraints returns a constraints.Constraints from this Process definition.
@@ -110,6 +123,17 @@ func (p *Process) SetConstraints(c Constraints) {
 
 // Formation represents a collection of named processes and their configuration.
 type Formation map[string]Process
+
+// IsValid returns nil if all of the Processes are valid.
+func (f Formation) IsValid() error {
+	for n, p := range f {
+		if err := p.IsValid(); err != nil {
+			return fmt.Errorf("process %s is not valid: %v", n, err)
+		}
+	}
+
+	return nil
+}
 
 // Scan implements the sql.Scanner interface.
 func (f *Formation) Scan(src interface{}) error {

--- a/processes.go
+++ b/processes.go
@@ -70,6 +70,10 @@ type Process struct {
 	// Command is the command to run.
 	Command Command `json:"Command,omitempty"`
 
+	// Signifies that this is a named one off command and not a long lived
+	// service.
+	Run bool `json:"Run,omitempty"`
+
 	// Quantity is the desired number of instances of this process.
 	Quantity int `json:"Quantity,omitempty"`
 

--- a/procfile/README.md
+++ b/procfile/README.md
@@ -45,12 +45,12 @@ When provided, signifies that the process is a scheduled process. The value shou
 cron: * * * * * * // Run once every minute
 ```
 
-**Run**
+**Noservice**
 
 When provided, signifies that the process is an "operational" one off command. These processes will not get any AWS resources attached to them.
 
 This can be used to alias a common command, or by enforcing whitelisting of commands for `emp run`.
 
 ```yaml
-run: true
+noservice: true
 ```

--- a/procfile/README.md
+++ b/procfile/README.md
@@ -44,3 +44,13 @@ When provided, signifies that the process is a scheduled process. The value shou
 ```yaml
 cron: * * * * * * // Run once every minute
 ```
+
+**Run**
+
+When provided, signifies that the process is an "operational" one off command. These processes will not get any AWS resources attached to them.
+
+This can be used to alias a common command, or by enforcing whitelisting of commands for `emp run`.
+
+```yaml
+run: true
+```

--- a/procfile/procfile.go
+++ b/procfile/procfile.go
@@ -24,6 +24,7 @@ func (e ExtendedProcfile) version() string {
 type Process struct {
 	Command interface{} `yaml:"command"`
 	Cron    *string     `yaml:"cron,omitempty"`
+	Run     bool        `yaml:"run,omitempty"`
 }
 
 // StandardProcfile represents a standard Procfile.

--- a/procfile/procfile.go
+++ b/procfile/procfile.go
@@ -22,9 +22,9 @@ func (e ExtendedProcfile) version() string {
 }
 
 type Process struct {
-	Command interface{} `yaml:"command"`
-	Cron    *string     `yaml:"cron,omitempty"`
-	Run     bool        `yaml:"run,omitempty"`
+	Command   interface{} `yaml:"command"`
+	Cron      *string     `yaml:"cron,omitempty"`
+	NoService bool        `yaml:"noservice,omitempty"`
 }
 
 // StandardProcfile represents a standard Procfile.

--- a/releases.go
+++ b/releases.go
@@ -278,8 +278,7 @@ func newSchedulerApp(release *Release) *scheduler.App {
 	var processes []*scheduler.Process
 
 	for name, p := range release.Formation {
-		// Named "run" processes won't get any services attached.
-		if !p.Run {
+		if !p.NoService {
 			processes = append(processes, newSchedulerProcess(release, name, p))
 		}
 	}

--- a/releases.go
+++ b/releases.go
@@ -278,7 +278,10 @@ func newSchedulerApp(release *Release) *scheduler.App {
 	var processes []*scheduler.Process
 
 	for name, p := range release.Formation {
-		processes = append(processes, newSchedulerProcess(release, name, p))
+		// Named "run" processes won't get any services attached.
+		if !p.Run {
+			processes = append(processes, newSchedulerProcess(release, name, p))
+		}
 	}
 
 	env := environment(release.Config.Vars)

--- a/runner.go
+++ b/runner.go
@@ -62,7 +62,22 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 		return err
 	}
 
-	proc := Process{Command: opts.Command, Quantity: 1}
+	procName := opts.Command[0]
+	proc := Process{
+		Quantity: 1,
+	}
+
+	if cmd, ok := release.Formation[procName]; ok {
+		proc.Command = cmd.Command
+	} else {
+		if r.RequireWhitelistedRuns {
+			return &CommandWhitelistError{Command: opts.Command}
+		}
+
+		// This is an unnamed command, fallback to a generic proc name.
+		procName = "run"
+		proc.Command = opts.Command
+	}
 
 	// Set the size of the process.
 	constraints := DefaultConstraints
@@ -72,7 +87,7 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 	proc.SetConstraints(constraints)
 
 	a := newSchedulerApp(release)
-	p := newSchedulerProcess(release, "run", proc)
+	p := newSchedulerProcess(release, procName, proc)
 	p.Labels["empire.user"] = opts.User.Name
 
 	// Add additional environment variables to the process.

--- a/runner.go
+++ b/runner.go
@@ -68,7 +68,7 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 	}
 
 	if cmd, ok := release.Formation[procName]; ok {
-		proc.Command = cmd.Command
+		proc.Command = append(cmd.Command, opts.Command[1:])
 	} else {
 		if r.RequireWhitelistedRuns {
 			return &CommandWhitelistError{Command: opts.Command}

--- a/runner.go
+++ b/runner.go
@@ -68,10 +68,10 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 	}
 
 	if cmd, ok := release.Formation[procName]; ok {
-		proc.Command = append(cmd.Command, opts.Command[1:])
+		proc.Command = append(cmd.Command, opts.Command[1:]...)
 	} else {
-		if r.RequireWhitelistedRuns {
-			return &CommandWhitelistError{Command: opts.Command}
+		if r.AllowedCommands == AllowCommandProcfile {
+			return commandNotInFormation(Command{procName}, release.Formation)
 		}
 
 		// This is an unnamed command, fallback to a generic proc name.

--- a/tests/cli/scale_test.go
+++ b/tests/cli/scale_test.go
@@ -17,7 +17,7 @@ func TestScale(t *testing.T) {
 		},
 		{
 			"scale -l -a acme-inc",
-			"scheduled=0:1X web=2:1X worker=0:1X",
+			"rake=0:1X scheduled=0:1X web=2:1X worker=0:1X",
 		},
 		{
 			"dynos -a acme-inc",


### PR DESCRIPTION
This is a spike into https://github.com/remind101/empire/issues/966, which adds a configuration option to Empire to require commands to be whitelisted for `emp run` to work.

If a command is not whitelisted, `emp run` will have this behavior:

```console
$ emp run migrate
error: command not whitelisted: migrate
```

To whitelist a command, you add it to the Procfile:

```yaml
migrate: bundle exec rake db:migrate:up
```

It's recommended that you use the extended Procfile and set the `noservice: true` flag to prevent it from being scaled up (and it won't create any AWS resources).

```yaml
migrate:
  command: bundle exec rake db:migrate:up
  noservice: true
```

In this initial spike, it allows any command in the Procfile to be run. For example, if you use the new scheduled tasks, you can spin up a one off of the scheduled task easily like so:

```yaml
scheduled-job:
  command: ./bin/do-work
  cron: * * * * * *
```

```console
$ emp run scheduled-job
doing work
```

Any extra arguments will be appended to the command provided in the procfile. For example:

```yaml
migrate:
  command: ./bin/migrate
  noservice: true
```

```shell
exec bundle exec rake db:migrate:$1
```

```console
$ emp run migrate up
```

**TODO**

* Tests