### PR TITLE
Go 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Improvements**
 
 * `emp ps` now displays the task's host. [#983](https://github.com/remind101/empire/pull/983)
+* The `empire` and `emp` binaries are now built with Go 1.7 [#971](https://github.com/remind101/empire/pull/971)
 
 ## 0.11.0 (2016-08-22)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.7.0
 MAINTAINER Eric Holmes <eric@remind101.com>
 
 LABEL version 0.11.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.5.3
+FROM golang:1.7
 MAINTAINER Eric Holmes <eric@remind101.com>
 
 LABEL version 0.11.0
 
 ADD . /go/src/github.com/remind101/empire
 WORKDIR /go/src/github.com/remind101/empire
-RUN GO15VENDOREXPERIMENT=1 go install ./cmd/empire
+RUN go install ./cmd/empire
 
 ENTRYPOINT ["/go/bin/empire"]
 CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ There is also a `tests` directory that contains integration and functional tests
 To get started, run:
 
 ```console
-$ export GO15VENDOREXPERIMENT=1
 $ make bootstrap
 ```
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,15 @@
 machine:
   environment:
-    GO15VENDOREXPERIMENT: 1
+    GODIST: "go1.7.linux-amd64.tar.gz"
   services:
     - docker
+  post:
+    - mkdir -p download
+    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+    - sudo rm -rf /usr/local/go
+    - sudo tar -C /usr/local -xzf download/$GODIST
+    - sudo ln -s /usr/local/go/bin/go /usr/bin/go
+    - sudo go install -a -race std
 
 checkout:
   post:
@@ -11,10 +18,11 @@ checkout:
     - cp -R ~/empire ~/.go_workspace/src/github.com/remind101/empire
 
 dependencies:
+  cache_directories:
+    - ~/download
   pre:
     - go get github.com/aktau/github-release
     - sudo pip install awscli
-    - go install -a -race std
     - go version
     - cd ~/.go_workspace/src/github.com/remind101/empire && make bootstrap
   override:

--- a/cmd/emp/README.md
+++ b/cmd/emp/README.md
@@ -21,7 +21,6 @@ $ brew install emp
 If you have a working Go 1.5+ environment, you can do the following:
 
 ```console
-$ export GO15VENDOREXPERIMENT=1 # Required for Go 1.5.x
 $ go get -u github.com/remind101/empire/cmd/emp
 ```
 

--- a/cmd/emp/tls.go
+++ b/cmd/emp/tls.go
@@ -61,9 +61,9 @@ func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Con
 	// from the hostname we're connecting to.
 	if config.ServerName == "" {
 		// Make a copy to avoid polluting argument or default.
-		c := *config
+		c := cloneTLSConfig(config)
 		c.ServerName = hostname
-		config = &c
+		config = c
 	}
 
 	conn := tls.Client(rawConn, config)
@@ -90,4 +90,32 @@ func tlsDialWithDialer(dialer *net.Dialer, network, addr string, config *tls.Con
 
 func tlsDial(network, addr string, config *tls.Config) (net.Conn, error) {
 	return tlsDialWithDialer(new(net.Dialer), network, addr, config)
+}
+
+// Copied from https://golang.org/src/crypto/tls/common.go?s=9735:14940#L263,
+// since the stdlib doesn't expose the `clone()` method.
+func cloneTLSConfig(c *tls.Config) *tls.Config {
+	return &tls.Config{
+		Rand:                        c.Rand,
+		Time:                        c.Time,
+		Certificates:                c.Certificates,
+		NameToCertificate:           c.NameToCertificate,
+		GetCertificate:              c.GetCertificate,
+		RootCAs:                     c.RootCAs,
+		NextProtos:                  c.NextProtos,
+		ServerName:                  c.ServerName,
+		ClientAuth:                  c.ClientAuth,
+		ClientCAs:                   c.ClientCAs,
+		InsecureSkipVerify:          c.InsecureSkipVerify,
+		CipherSuites:                c.CipherSuites,
+		PreferServerCipherSuites:    c.PreferServerCipherSuites,
+		SessionTicketsDisabled:      c.SessionTicketsDisabled,
+		SessionTicketKey:            c.SessionTicketKey,
+		ClientSessionCache:          c.ClientSessionCache,
+		MinVersion:                  c.MinVersion,
+		MaxVersion:                  c.MaxVersion,
+		CurvePreferences:            c.CurvePreferences,
+		DynamicRecordSizingDisabled: c.DynamicRecordSizingDisabled,
+		Renegotiation:               c.Renegotiation,
+	}
 }


### PR DESCRIPTION
[Go 1.7 was released today](https://blog.golang.org/go1.7).

Primary improvements will be slightly better performance:

> Programs should run a bit faster due to speedups in the garbage collector and optimizations in the standard library. Programs with many idle goroutines will experience much shorter garbage collection pauses than in Go 1.6.

A smaller binary, and faster compile times:

> The compiler front end uses a new, more compact export data format, and processes import declarations more efficiently. While these changes across the compiler toolchain are mostly invisible, users have observed a significant speedup in compile time and a reduction in binary size by as much as 20–30%.

But most importantly, the net/context package has been moved into the stdlib, which means we can remove the dependency on pkg/httpx and use standard `http.Handler`s.

> Over the past few years, the golang.org/x/net/context package has proven to be essential to many Go applications. Contexts are used to great effect in applications related to networking, infrastructure, and microservices (such as Kubernetes and Docker). They make it easy to enable cancelation, timeouts, and passing request-scoped data. To make use of contexts within the standard library and to encourage more extensive use, the package has been moved from the x/net repository to the standard library as the context package. Support for contexts has been added to the net, net/http, and os/exec packages. For more information about contexts, see the package documentation and the Go blog post Go Concurrency Patterns: Context.

I'll open a separate PR that removes the pkg/httpx depency.
