### PR TITLE
Require confirmation if rolling back more than 9 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 * The log level within empire can now be configured when starting the service. [#929](https://github.com/remind101/empire/issues/929)
 * The CloudFormation backend now has experimental support for a `Custom::ECSTaskDefinition` resource that greatly reduces the size of generated templates. [#935](https://github.com/remind101/empire/pull/935)
 * The Scheduler now has a `Restart` method which will trigger a restart of all the processes within an app. Previously, a "Restart" just re-released the app. Now schedulers like the cloudformation backend can optimize how the restart is handled. [#697](https://github.com/remind101/empire/issues/697)
-* `emp run` now publishes an event when it is ran [#954](https://github.com/remind101/empire/pull/954)
+* `emp run` now publishes an event when it is ran. [#954](https://github.com/remind101/empire/pull/954)
+* `emp rollback` requires confirmation if rolling back more than 9 versions. [#975](https://github.com/remind101/empire/pull/975)
 
 **Bugs**
 

--- a/cmd/emp/releases.go
+++ b/cmd/emp/releases.go
@@ -249,14 +249,7 @@ func rollbackSafetyCheck(verStr, appname string) {
 
 	diff := currVer - verNum
 	if diff >= 10 {
-		var vconfirmation string
-		fmt.Printf("WARNING. Attempting to rollback %d versions from v%d to v%d.\n", diff, currVer, verNum)
-		fmt.Printf("To proceed, type v%d: ", verNum)
-		fmt.Scanln(&vconfirmation)
-		vconfirmation = strings.TrimPrefix(vconfirmation, "v")
-		if vconfirmation != verStr {
-			fmt.Println("Rollback confirmation did not match.")
-			os.Exit(2)
-		}
+		warning := fmt.Sprintf("Attempting to rollback %d versions from v%d to v%d. Type v%d to continue:", diff, currVer, verNum, verNum)
+		mustConfirm(warning, fmt.Sprintf("v%s", verStr))
 	}
 }

--- a/cmd/emp/releases.go
+++ b/cmd/emp/releases.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -226,7 +227,36 @@ func runRollback(cmd *Command, args []string) {
 		os.Exit(2)
 	}
 	ver := strings.TrimPrefix(args[0], "v")
+	rollbackSafetyCheck(ver, appname)
+
 	rel, err := client.ReleaseRollback(appname, ver, message)
 	must(err)
 	log.Printf("Rolled back %s to v%s as v%d.\n", appname, ver, rel.Version)
+}
+
+func rollbackSafetyCheck(verStr, appname string) {
+	// Grab head release to get the current version
+	hrels, err := client.ReleaseList(appname, &heroku.ListRange{
+		Field:      "version",
+		Max:        1,
+		Descending: true,
+	})
+	must(err)
+
+	currVer := hrels[0].Version
+	verNum, err := strconv.Atoi(verStr)
+	must(err)
+
+	diff := currVer - verNum
+	if diff >= 10 {
+		var vconfirmation string
+		fmt.Printf("WARNING. Attempting to rollback %d versions from v%d to v%d.\n", diff, currVer, verNum)
+		fmt.Printf("To proceed, type v%d: ", verNum)
+		fmt.Scanln(&vconfirmation)
+		vconfirmation = strings.TrimPrefix(vconfirmation, "v")
+		if vconfirmation != verStr {
+			fmt.Println("Rollback confirmation did not match.")
+			os.Exit(2)
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/881

```bash
$ EMPIRE_API_URL=http://$(docker-machine ip default):8080 ./build/emp rollback v1 -a acme-inc
WARNING. Attempting to rollback 18 versions from v19 to v1.
To proceed, type v1: v1
Rolled back acme-inc to v1 as v20.
```

```bash
$ EMPIRE_API_URL=http://$(docker-machine ip default):8080 ./build/emp rollback v1 -a acme-inc
WARNING. Attempting to rollback 19 versions from v20 to v1.
To proceed, type v1: v19
Rollback confirmation did not match.
```