### PR TITLE
Switch default scheduler to CloudFormation for new apps.

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -93,7 +93,7 @@ var Commands = []cli.Command{
 			},
 			cli.StringFlag{
 				Name:   FlagScheduler,
-				Value:  "ecs",
+				Value:  "cloudformation-migration",
 				Usage:  "The scheduling backend to use. Current options are `ecs`, `cloudformation-migration`, and `cloudformation`.",
 				EnvVar: "EMPIRE_SCHEDULER",
 			},


### PR DESCRIPTION
This is prep for the 0.11.0 release, [where we'll switch the default scheduling backend for new apps to CloudFormation](https://github.com/remind101/empire/wiki/Scheduler-Deprecation-Plan#0110)

Existing applications will continue to use the legacy ECS backend, but are encouraged to migrate to CloudFormation using the [Scheduler Migration Guide](https://github.com/remind101/empire/wiki/Scheduler-Migration-Guide).