### PR TITLE
Show host the task is running on in `emp ps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## HEAD
+
+**Improvements**
+
+* `emp ps` now displays the task's host. [#983](https://github.com/remind101/empire/pull/983)
+
 ## 0.11.0 (2016-08-22)
 
 **Features**
@@ -24,7 +30,6 @@
 * The Scheduler now has a `Restart` method which will trigger a restart of all the processes within an app. Previously, a "Restart" just re-released the app. Now schedulers like the cloudformation backend can optimize how the restart is handled. [#697](https://github.com/remind101/empire/issues/697)
 * `emp run` now publishes an event when it is ran. [#954](https://github.com/remind101/empire/pull/954)
 * `emp rollback` requires confirmation if rolling back more than 9 versions. [#975](https://github.com/remind101/empire/pull/975)
-* `emp ps` now displays the task's host. [#983](https://github.com/remind101/empire/pull/983)
 
 **Bugs**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * The Scheduler now has a `Restart` method which will trigger a restart of all the processes within an app. Previously, a "Restart" just re-released the app. Now schedulers like the cloudformation backend can optimize how the restart is handled. [#697](https://github.com/remind101/empire/issues/697)
 * `emp run` now publishes an event when it is ran. [#954](https://github.com/remind101/empire/pull/954)
 * `emp rollback` requires confirmation if rolling back more than 9 versions. [#975](https://github.com/remind101/empire/pull/975)
+* `emp ps` now displays the task's host. [#983](https://github.com/remind101/empire/pull/983)
 
 **Bugs**
 

--- a/cmd/emp/dynos.go
+++ b/cmd/emp/dynos.go
@@ -21,7 +21,7 @@ var cmdDynos = &Command{
 	Category: "dyno",
 	Short:    "list processes",
 	Long: `
-Lists processes. Shows the name, size, id, container id, ec2 instance id, state, age, and command.
+Lists processes. Shows the name, size, host, state, age, and command.
 
 Examples:
 
@@ -58,9 +58,7 @@ func listDynos(w io.Writer) {
 func listDyno(w io.Writer, d *heroku.Dyno) {
 	listRec(w,
 		d.Name,
-		d.Id,
-		d.ContainerInstanceID,
-		d.EC2InstanceID,
+		d.Host.Id,
 		d.Size,
 		d.State,
 		prettyDuration{dynoAge(d)},

--- a/cmd/emp/dynos.go
+++ b/cmd/emp/dynos.go
@@ -21,7 +21,7 @@ var cmdDynos = &Command{
 	Category: "dyno",
 	Short:    "list processes",
 	Long: `
-Lists processes. Shows the name, size, state, age, and command.
+Lists processes. Shows the name, size, id, container id, ec2 instance id, state, age, and command.
 
 Examples:
 
@@ -58,6 +58,9 @@ func listDynos(w io.Writer) {
 func listDyno(w io.Writer, d *heroku.Dyno) {
 	listRec(w,
 		d.Name,
+		d.Id,
+		d.ContainerInstanceID,
+		d.EC2InstanceID,
 		d.Size,
 		d.State,
 		prettyDuration{dynoAge(d)},

--- a/pkg/heroku/dyno.go
+++ b/pkg/heroku/dyno.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+// Host describes the host a dyno is running on
+type Host struct {
+	// unique identifier of this host
+	Id string `json:"id"`
+}
+
 // Dynos encapsulate running processes of an app on Heroku.
 type Dyno struct {
 	// a URL to stream output from for attached processes or null for non-attached processes
@@ -22,9 +28,7 @@ type Dyno struct {
 	// unique identifier of this dyno
 	Id string `json:"id"`
 
-	ContainerInstanceID string `json:"container_instance_id"`
-
-	EC2InstanceID string `json:"ec2_instance_id"`
+	Host Host `json:"host"`
 
 	// the name of this process on this dyno
 	Name string `json:"name"`

--- a/pkg/heroku/dyno.go
+++ b/pkg/heroku/dyno.go
@@ -22,6 +22,10 @@ type Dyno struct {
 	// unique identifier of this dyno
 	Id string `json:"id"`
 
+	ContainerInstanceID string `json:"container_instance_id"`
+
+	EC2InstanceID string `json:"ec2_instance_id"`
+
 	// the name of this process on this dyno
 	Name string `json:"name"`
 

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -731,7 +731,7 @@ func (s *Scheduler) Instances(ctx context.Context, app string) ([]*scheduler.Ins
 				return nil, err
 			}
 			for _, f := range resp.Failures {
-				return nil, fmt.Errorf("error describing container instance Arn=%s err=%s", aws.StringValue(f.Arn), aws.StringValue(f.Reason))
+				return nil, fmt.Errorf("error describing container instance %s: %s", aws.StringValue(f.Arn), aws.StringValue(f.Reason))
 			}
 
 			for _, ci := range resp.ContainerInstances {

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -1088,7 +1088,8 @@ func TestScheduler_Instances(t *testing.T) {
 	}).Return(&ecs.DescribeContainerInstancesOutput{
 		ContainerInstances: []*ecs.ContainerInstance{
 			{
-				Ec2InstanceId: aws.String("ec2-instance-id-1"),
+				Ec2InstanceId:        aws.String("ec2-instance-id-1"),
+				ContainerInstanceArn: aws.String("arn:aws:ecs:us-east-1:012345678910:container-instance/container-instance-id-1"),
 			},
 		},
 	}, nil)
@@ -1099,7 +1100,8 @@ func TestScheduler_Instances(t *testing.T) {
 	}).Return(&ecs.DescribeContainerInstancesOutput{
 		ContainerInstances: []*ecs.ContainerInstance{
 			{
-				Ec2InstanceId: aws.String("ec2-instance-id-2"),
+				Ec2InstanceId:        aws.String("ec2-instance-id-2"),
+				ContainerInstanceArn: aws.String("arn:aws:ecs:us-east-1:012345678910:container-instance/container-instance-id-2"),
 			},
 		},
 	}, nil)
@@ -1107,11 +1109,10 @@ func TestScheduler_Instances(t *testing.T) {
 	instances, err := s.Instances(context.Background(), "c9366591-ab68-4d49-a333-95ce5a23df68")
 	assert.NoError(t, err)
 	assert.Equal(t, &scheduler.Instance{
-		ID:                  "0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
-		ContainerInstanceID: "container-instance-id-1",
-		EC2InstanceID:       "ec2-instance-id-1",
-		UpdatedAt:           dt,
-		State:               "RUNNING",
+		ID:        "0b69d5c0-d655-4695-98cd-5d2d526d9d5a",
+		Host:      scheduler.Host{ID: "ec2-instance-id-1"},
+		UpdatedAt: dt,
+		State:     "RUNNING",
 		Process: &scheduler.Process{
 			Type:        "web",
 			MemoryLimit: 256 * bytesize.MB,
@@ -1120,11 +1121,10 @@ func TestScheduler_Instances(t *testing.T) {
 		},
 	}, instances[0])
 	assert.Equal(t, &scheduler.Instance{
-		ID:                  "c09f0188-7f87-4b0f-bfc3-16296622b6fe",
-		ContainerInstanceID: "container-instance-id-2",
-		EC2InstanceID:       "ec2-instance-id-2",
-		UpdatedAt:           dt,
-		State:               "PENDING",
+		ID:        "c09f0188-7f87-4b0f-bfc3-16296622b6fe",
+		Host:      scheduler.Host{ID: "ec2-instance-id-2"},
+		UpdatedAt: dt,
+		State:     "PENDING",
 		Process: &scheduler.Process{
 			Type:        "run",
 			MemoryLimit: 256 * bytesize.MB,

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -61,6 +61,7 @@ func (m *FakeScheduler) Instances(ctx context.Context, appID string) ([]*Instanc
 			for i := uint(1); i <= p.Instances; i++ {
 				instances = append(instances, &Instance{
 					ID:        fmt.Sprintf("%d", i),
+					Host:      Host{ID: "i-aa111aa1"},
 					State:     "running",
 					Process:   &pp,
 					UpdatedAt: timex.Now(),

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -113,6 +113,12 @@ type Instance struct {
 	// The instance ID.
 	ID string
 
+	// The container instance id
+	ContainerInstanceID string
+
+	// The EC2 instance id
+	EC2InstanceID string
+
 	// The State that this Instance is in.
 	State string
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -106,6 +106,12 @@ type HTTPSExposure struct {
 
 func (e *HTTPSExposure) Protocol() string { return "https" }
 
+// Host represents the host of an instance
+type Host struct {
+	// The host ID.
+	ID string
+}
+
 // Instance represents an Instance of a Process.
 type Instance struct {
 	Process *Process
@@ -113,11 +119,8 @@ type Instance struct {
 	// The instance ID.
 	ID string
 
-	// The container instance id
-	ContainerInstanceID string
-
-	// The EC2 instance id
-	EC2InstanceID string
+	// The instance host
+	Host Host
 
 	// The State that this Instance is in.
 	State string

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -18,15 +18,13 @@ type Dyno heroku.Dyno
 
 func newDyno(task *empire.Task) *Dyno {
 	return &Dyno{
-		Command:             task.Command.String(),
-		Type:                task.Type,
-		Name:                task.Name,
-		Id:                  task.ID,
-		ContainerInstanceID: task.ContainerID,
-		EC2InstanceID:       task.EC2InstanceID,
-		State:               task.State,
-		Size:                task.Constraints.String(),
-		UpdatedAt:           task.UpdatedAt,
+		Command:   task.Command.String(),
+		Type:      task.Type,
+		Name:      task.Name,
+		Host:      heroku.Host{Id: task.Host.ID},
+		State:     task.State,
+		Size:      task.Constraints.String(),
+		UpdatedAt: task.UpdatedAt,
 	}
 }
 

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -18,12 +18,15 @@ type Dyno heroku.Dyno
 
 func newDyno(task *empire.Task) *Dyno {
 	return &Dyno{
-		Command:   task.Command.String(),
-		Type:      task.Type,
-		Name:      task.Name,
-		State:     task.State,
-		Size:      task.Constraints.String(),
-		UpdatedAt: task.UpdatedAt,
+		Command:             task.Command.String(),
+		Type:                task.Type,
+		Name:                task.Name,
+		Id:                  task.ID,
+		ContainerInstanceID: task.ContainerID,
+		EC2InstanceID:       task.EC2InstanceID,
+		State:               task.State,
+		Size:                task.Constraints.String(),
+		UpdatedAt:           task.UpdatedAt,
 	}
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -9,6 +9,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Host represents the host of the task
+type Host struct {
+	// the host id
+	ID string
+}
+
 // Task represents a running process.
 type Task struct {
 	// The name of the task.
@@ -20,11 +26,8 @@ type Task struct {
 	// The task id
 	ID string
 
-	// The container id
-	ContainerID string
-
-	// The ec2 instance id
-	EC2InstanceID string
+	// The host of the task
+	Host Host
 
 	// The command that this task is running.
 	Command Command
@@ -68,12 +71,10 @@ func taskFromInstance(i *scheduler.Instance) *Task {
 	}
 
 	return &Task{
-		Name:          fmt.Sprintf("%s.%s.%s", version, i.Process.Type, i.ID),
-		Type:          string(i.Process.Type),
-		ID:            i.ID,
-		ContainerID:   i.ContainerInstanceID,
-		EC2InstanceID: i.EC2InstanceID,
-		Command:       Command(i.Process.Command),
+		Name:    fmt.Sprintf("%s.%s.%s", version, i.Process.Type, i.ID),
+		Type:    string(i.Process.Type),
+		Host:    Host{ID: i.Host.ID},
+		Command: Command(i.Process.Command),
 		Constraints: Constraints{
 			CPUShare: constraints.CPUShare(i.Process.CPUShares),
 			Memory:   constraints.Memory(i.Process.MemoryLimit),

--- a/tasks.go
+++ b/tasks.go
@@ -17,6 +17,15 @@ type Task struct {
 	// The name of the process that this task is for.
 	Type string
 
+	// The task id
+	ID string
+
+	// The container id
+	ContainerID string
+
+	// The ec2 instance id
+	EC2InstanceID string
+
 	// The command that this task is running.
 	Command Command
 
@@ -59,9 +68,12 @@ func taskFromInstance(i *scheduler.Instance) *Task {
 	}
 
 	return &Task{
-		Name:    fmt.Sprintf("%s.%s.%s", version, i.Process.Type, i.ID),
-		Type:    string(i.Process.Type),
-		Command: Command(i.Process.Command),
+		Name:          fmt.Sprintf("%s.%s.%s", version, i.Process.Type, i.ID),
+		Type:          string(i.Process.Type),
+		ID:            i.ID,
+		ContainerID:   i.ContainerInstanceID,
+		EC2InstanceID: i.EC2InstanceID,
+		Command:       Command(i.Process.Command),
 		Constraints: Constraints{
 			CPUShare: constraints.CPUShare(i.Process.CPUShares),
 			Memory:   constraints.Memory(i.Process.MemoryLimit),

--- a/tests/cli/restart_test.go
+++ b/tests/cli/restart_test.go
@@ -17,8 +17,8 @@ func TestRestart(t *testing.T) {
 		},
 		{
 			"dynos -a acme-inc",
-			`v1.web.1  1X  running   5d  "./bin/web"
-v1.web.2  1X  running   5d  "./bin/web"`,
+			`v1.web.1  1      1X  running   5d  "./bin/web"
+v1.web.2  2      1X  running   5d  "./bin/web"`,
 		},
 		{
 			"restart -a acme-inc",

--- a/tests/cli/restart_test.go
+++ b/tests/cli/restart_test.go
@@ -17,8 +17,8 @@ func TestRestart(t *testing.T) {
 		},
 		{
 			"dynos -a acme-inc",
-			`v1.web.1    1X  running   5d  "./bin/web"
-v1.web.2    1X  running   5d  "./bin/web"`,
+			`v1.web.1  i-aa111aa1  1X  running   5d  "./bin/web"
+v1.web.2  i-aa111aa1  1X  running   5d  "./bin/web"`,
 		},
 		{
 			"restart -a acme-inc",

--- a/tests/cli/restart_test.go
+++ b/tests/cli/restart_test.go
@@ -17,8 +17,8 @@ func TestRestart(t *testing.T) {
 		},
 		{
 			"dynos -a acme-inc",
-			`v1.web.1  1      1X  running   5d  "./bin/web"
-v1.web.2  2      1X  running   5d  "./bin/web"`,
+			`v1.web.1    1X  running   5d  "./bin/web"
+v1.web.2    1X  running   5d  "./bin/web"`,
 		},
 		{
 			"restart -a acme-inc",

--- a/tests/cli/scale_test.go
+++ b/tests/cli/scale_test.go
@@ -21,8 +21,8 @@ func TestScale(t *testing.T) {
 		},
 		{
 			"dynos -a acme-inc",
-			`v1.web.1  1X  running   5d  "./bin/web"
-v1.web.2  1X  running   5d  "./bin/web"`,
+			`v1.web.1  1      1X  running   5d  "./bin/web"
+v1.web.2  2      1X  running   5d  "./bin/web"`,
 		},
 
 		{
@@ -31,7 +31,7 @@ v1.web.2  1X  running   5d  "./bin/web"`,
 		},
 		{
 			"dynos -a acme-inc",
-			"v1.web.1  1X  running   5d  \"./bin/web\"",
+			"v1.web.1  1      1X  running   5d  \"./bin/web\"",
 		},
 	})
 }

--- a/tests/cli/scale_test.go
+++ b/tests/cli/scale_test.go
@@ -21,8 +21,8 @@ func TestScale(t *testing.T) {
 		},
 		{
 			"dynos -a acme-inc",
-			`v1.web.1    1X  running   5d  "./bin/web"
-v1.web.2    1X  running   5d  "./bin/web"`,
+			`v1.web.1  i-aa111aa1  1X  running   5d  "./bin/web"
+v1.web.2  i-aa111aa1  1X  running   5d  "./bin/web"`,
 		},
 
 		{
@@ -31,7 +31,7 @@ v1.web.2    1X  running   5d  "./bin/web"`,
 		},
 		{
 			"dynos -a acme-inc",
-			"v1.web.1    1X  running   5d  \"./bin/web\"",
+			"v1.web.1  i-aa111aa1  1X  running   5d  \"./bin/web\"",
 		},
 	})
 }

--- a/tests/cli/scale_test.go
+++ b/tests/cli/scale_test.go
@@ -21,8 +21,8 @@ func TestScale(t *testing.T) {
 		},
 		{
 			"dynos -a acme-inc",
-			`v1.web.1  1      1X  running   5d  "./bin/web"
-v1.web.2  2      1X  running   5d  "./bin/web"`,
+			`v1.web.1    1X  running   5d  "./bin/web"
+v1.web.2    1X  running   5d  "./bin/web"`,
 		},
 
 		{
@@ -31,7 +31,7 @@ v1.web.2  2      1X  running   5d  "./bin/web"`,
 		},
 		{
 			"dynos -a acme-inc",
-			"v1.web.1  1      1X  running   5d  \"./bin/web\"",
+			"v1.web.1    1X  running   5d  \"./bin/web\"",
 		},
 	})
 }


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/976

```bash
$ EMPIRE_API_URL=http://$(docker-machine ip default):8080 ./build/emp ps -a acme-inc
v2.web.1a1a11a1-aaa1-1aaa-a11a-aaa111a1aa1a  1b1b11b1-bbb1-1bbb-b11b-bbb111b1bb1b  1c1c11c1-ccc1-1ccc-c11c-ccc111c1cc1c  i-1111a111  1X  RUNNING   6m  "acme-inc server"
```

Opening this since I'd like some feedback, however I don't think this is the right approach since it requires a request to `DescribeContainerInstances` **for each** process which will quickly rate limit us. Looking into if it is possible to just make one batch request for all of the containers. If not, might need to cache like in https://github.com/remind101/empire/pull/902.

Also, the output is getting pretty wide so I was wondering if maybe this stuff should be only shown if you pass the `-v` flag to `emp ps`. Then we could add other information here like @sanjayprabhu's "commit message" request. https://remind.slack.com/archives/empire/p1471910137001348

### New output
```bash
v2.web.1a1a11a1-aaa1-1aaa-a11a-aaa111a1aa1a  i-aa111aa1  1X  RUNNING  89m  "acme-inc server"
```