### PR TITLE
Add support for configuring the IAM role used for the application

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -397,11 +397,55 @@
       }
     },
 
+    "DockerPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "docker-cloudwatch-logs",
+        "Roles": [ { "Ref": "InstanceRole" } ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ],
+              "Resource": [
+                { "Fn::Join": ["", ["arn:aws:logs:*:*:log-group:", { "Ref": "ApplicationLogGroup" }, ":log-stream:*"]] },
+                { "Fn::Join": ["", ["arn:aws:logs:*:*:log-group:", { "Ref": "DaemonLogGroup" }, ":log-stream:*"]] },
+                { "Fn::Join": ["", ["arn:aws:logs:*:*:log-group:", { "Ref": "PostgresLogGroup" }, ":log-stream:*"]] }
+              ]
+            }
+          ]
+        }
+      }
+    },
+
+    "EmpireRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "Path": "/",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [ "ecs-tasks.amazonaws.com" ]
+              },
+              "Action": [ "sts:AssumeRole" ]
+            }
+          ]
+        }
+      }
+    },
+
     "EmpirePolicy": {
       "Type": "AWS::IAM::Policy",
       "Properties": {
         "PolicyName": "empire",
-        "Roles": [ { "Ref": "InstanceRole" } ],
+        "Roles": [ { "Ref": "EmpireRole" } ],
         "Groups": [ { "Ref": "Group" } ],
         "PolicyDocument": {
           "Version": "2012-10-17",
@@ -411,7 +455,7 @@
               "Action": [
                 "iam:PassRole"
               ],
-              "Resource": { "Fn::GetAtt": ["ServiceRole", "Arn"] }
+              "Resource": "*"
             },
             {
               "Effect": "Allow",
@@ -546,18 +590,6 @@
                 "route53:GetChange*"
               ],
               "Resource": "arn:aws:route53:::change/*"
-            },
-            {
-              "Effect": "Allow",
-              "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents"
-              ],
-              "Resource": [
-                { "Fn::Join": ["", ["arn:aws:logs:*:*:log-group:", { "Ref": "ApplicationLogGroup" }, ":log-stream:*"]] },
-                { "Fn::Join": ["", ["arn:aws:logs:*:*:log-group:", { "Ref": "DaemonLogGroup" }, ":log-stream:*"]] },
-                { "Fn::Join": ["", ["arn:aws:logs:*:*:log-group:", { "Ref": "PostgresLogGroup" }, ":log-stream:*"]] }
-              ]
             }
           ]
         }
@@ -763,6 +795,7 @@
       "Type": "AWS::ECS::TaskDefinition",
       "Condition": "DemoMode",
       "Properties": {
+        "TaskRoleArn": { "Fn::GetAtt": ["EmpireRole", "Arn"] },
         "ContainerDefinitions": [
           {
             "Name": "empire",

--- a/scheduler/cloudformation/resources.go
+++ b/scheduler/cloudformation/resources.go
@@ -22,6 +22,7 @@ type ContainerDefinitionProperties struct {
 type TaskDefinitionProperties struct {
 	ContainerDefinitions []*ContainerDefinitionProperties `json:",omitempty"`
 	Volumes              []interface{}
+	TaskRoleArn          interface{} `json:",omitempty"`
 }
 
 type CustomTaskDefinitionProperties struct {
@@ -29,4 +30,5 @@ type CustomTaskDefinitionProperties struct {
 	Family               interface{}                      `json:",omitempty"`
 	ServiceToken         interface{}                      `json:",omitempty"`
 	Volumes              []interface{}
+	TaskRoleArn          interface{} `json:",omitempty"`
 }

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -235,6 +235,13 @@ func (t *EmpireTemplate) addTaskDefinition(tmpl *troposphere.Template, app *sche
 	cd := t.ContainerDefinition(app, p)
 	containerDefinition := cloudformationContainerDefinition(cd)
 
+	// If provided in the app environment, this role will be used when
+	// running tasks.
+	var taskRole interface{}
+	if arn, ok := app.Env["TASK_ROLE_ARN"]; ok {
+		taskRole = arn
+	}
+
 	var taskDefinitionProperties interface{}
 	taskDefinitionType := taskDefinitionResourceType(app)
 	if taskDefinitionType == "Custom::ECSTaskDefinition" {
@@ -260,6 +267,7 @@ func (t *EmpireTemplate) addTaskDefinition(tmpl *troposphere.Template, app *sche
 			ContainerDefinitions: []*ContainerDefinitionProperties{
 				containerDefinition,
 			},
+			TaskRoleArn: taskRole,
 		}
 	} else {
 		containerDefinition.Environment = cd.Environment
@@ -268,6 +276,7 @@ func (t *EmpireTemplate) addTaskDefinition(tmpl *troposphere.Template, app *sche
 			ContainerDefinitions: []*ContainerDefinitionProperties{
 				containerDefinition,
 			},
+			TaskRoleArn: taskRole,
 		}
 	}
 


### PR DESCRIPTION
This should be considered experimental for the time being. It allows you to set the IAM role used for an application.

There's still some gotcha's with using this. The primary one being that, if you set the role, attached `emp run's` won't get the role applied, since it's handled by the ECS agent (might work if the ECS agent is running on the host? Need to test).