### PR TITLE
Action Confirmations (Duo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * The extended Procfile format now allows you to attach a load balancer to any process in the Procfile. [#800](https://github.com/remind101/empire/pull/800)
 * An ALIAS record is now created for `<process>.<app>.<zone>` [#1005](https://github.com/remind101/empire/pull/1005)
+* Empire now has experimental support for requring third party confirmation for various actions. Currently, the only supported backend is Duo push notifications, and only the `Run` and `Deploy` actions are supported [#989](https://github.com/remind101/empire/pull/989)
 
 **Improvements**
 

--- a/action_confimations.go
+++ b/action_confimations.go
@@ -1,9 +1,11 @@
 package empire
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/url"
+	"text/template"
 
 	"github.com/remind101/empire/pkg/duo"
 )
@@ -19,6 +21,10 @@ type ActionConfirmer interface {
 // DuoActionConfirmer is an ActionConfirmer that will send the user a Duo push
 // notification to confirm the action before continuing.
 type DuoActionConfirmer struct {
+	// A template that will be used to determine the users Duo username. The
+	// template will be executed with a User object.
+	UsernameTemplate *template.Template
+
 	duo *duo.Client
 }
 
@@ -32,8 +38,13 @@ func NewDuoActionConfirmer(key, secret, apiHost string) *DuoActionConfirmer {
 }
 
 func (c *DuoActionConfirmer) Confirm(ctx context.Context, user *User, action string, resource string, params map[string]string) (bool, error) {
+	username, err := c.username(user)
+	if err != nil {
+		return false, err
+	}
+
 	q := url.Values{}
-	q.Add("username", user.Name)
+	q.Add("username", username)
 	q.Add("factor", "push")
 	q.Add("device", "auto")
 	q.Add("type", action)
@@ -45,4 +56,20 @@ func (c *DuoActionConfirmer) Confirm(ctx context.Context, user *User, action str
 	}
 
 	return resp.Response.Result == "allow", nil
+}
+
+var defaultUsernameTemplate = template.Must(template.New("username").Parse(`{{.Name}}`))
+
+func (c *DuoActionConfirmer) username(user *User) (string, error) {
+	t := c.UsernameTemplate
+	if t == nil {
+		t = defaultUsernameTemplate
+	}
+
+	b := new(bytes.Buffer)
+	if err := t.Execute(b, user); err != nil {
+		return "", fmt.Errorf("duo confirmation: error finding username: %v", err)
+	}
+
+	return b.String(), nil
 }

--- a/action_confimations.go
+++ b/action_confimations.go
@@ -1,0 +1,48 @@
+package empire
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/remind101/empire/pkg/duo"
+)
+
+// ActionConfirmer is an interface that can be implemented to confirm that an
+// action is allowed.
+type ActionConfirmer interface {
+	// Confirm should notify the third party of the action being performed,
+	// then block until the action has been confirmed.
+	Confirm(ctx context.Context, user *User, action string, resource string, params map[string]string) (bool, error)
+}
+
+// DuoActionConfirmer is an ActionConfirmer that will send the user a Duo push
+// notification to confirm the action before continuing.
+type DuoActionConfirmer struct {
+	duo *duo.Client
+}
+
+func NewDuoActionConfirmer(key, secret, apiHost string) *DuoActionConfirmer {
+	c := duo.New(nil)
+	c.Key = key
+	c.Secret = secret
+	c.Host = apiHost
+
+	return &DuoActionConfirmer{duo: c}
+}
+
+func (c *DuoActionConfirmer) Confirm(ctx context.Context, user *User, action string, resource string, params map[string]string) (bool, error) {
+	q := url.Values{}
+	q.Add("username", user.Name)
+	q.Add("factor", "push")
+	q.Add("device", "auto")
+	q.Add("type", action)
+	q.Add("pushinfo", fmt.Sprintf("resource=%s", resource))
+
+	resp, err := c.duo.Auth(q)
+	if err != nil {
+		return false, err
+	}
+
+	return resp.Response.Result == "allow", nil
+}

--- a/cmd/emp/run.go
+++ b/cmd/emp/run.go
@@ -76,7 +76,7 @@ func runRun(cmd *Command, args []string) {
 	if err != nil {
 		// If syscall.TIOCGWINSZ is not supported by the device, we're
 		// probably trying to run tests. Set w to some sensible default.
-		if err.Error() == "operation not supported by device" {
+		if err.Error() == "operation not supported by device" || err.Error() == "inappropriate ioctl for device" {
 			w = &term.Winsize{
 				Height: 20,
 				Width:  80,

--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -65,12 +65,18 @@ func newEmpire(db *empire.DB, c *Context) (*empire.Empire, error) {
 		return nil, err
 	}
 
+	confirmations, err := newActionConfirmer(c)
+	if err != nil {
+		return nil, err
+	}
+
 	e := empire.New(db)
 	e.Scheduler = scheduler
 	e.EventStream = empire.AsyncEvents(streams)
 	e.ProcfileExtractor = empire.PullAndExtract(docker)
 	e.Environment = c.String(FlagEnvironment)
 	e.RunRecorder = runRecorder
+	e.ActionConfirmer = confirmations
 	e.MessagesRequired = c.Bool(FlagMessagesRequired)
 
 	switch c.String(FlagAllowedCommands) {
@@ -368,6 +374,32 @@ func newDogstatsdStats(addr string) (stats.Stats, error) {
 		fmt.Sprintf("empire_version:%s", empire.Version),
 	}
 	return s, nil
+}
+
+// ActionConfirmer =====================
+
+func newActionConfirmer(c *Context) (empire.ActionConfirmer, error) {
+	u := c.String(FlagActionConfirmationsBackend)
+	if u == "" {
+		return nil, nil
+	}
+
+	uri, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	switch uri.Scheme {
+	case "duo":
+		q := uri.Query()
+		return newDuoActionConfirmer(uri.Host, q.Get("key"), q.Get("secret"))
+	default:
+		return nil, fmt.Errorf("unknown action confirmer: %s", uri.Scheme)
+	}
+}
+
+func newDuoActionConfirmer(apiHost, key, secret string) (empire.ActionConfirmer, error) {
+	return empire.NewDuoActionConfirmer(key, secret, apiHost), nil
 }
 
 // Auth provider =======================

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -16,6 +16,7 @@ const (
 	FlagEventsBackend              = "events.backend"
 	FlagRunLogsBackend             = "runlogs.backend"
 	FlagActionConfirmationsBackend = "action-confirmations.backend"
+	FlagConfirmActions             = "confirm-actions"
 	FlagLogLevel                   = "log.level"
 
 	FlagMessagesRequired = "messages.required"
@@ -338,6 +339,12 @@ var EmpireFlags = []cli.Flag{
 		Value:  "",
 		Usage:  "Backend to use when confirm actions. (e.g. duo://api-xxxxx.duosecurity.com?key=<key>&secret=<secret>",
 		EnvVar: "EMPIRE_ACTION_CONFIRMATIONS_BACKEND",
+	},
+	cli.StringSliceFlag{
+		Name:   FlagConfirmActions,
+		Value:  &cli.StringSlice{},
+		Usage:  "The Empire actions to require confirmation on.",
+		EnvVar: "EMPIRE_CONFIRM_ACTIONS",
 	},
 	cli.StringFlag{
 		Name:   FlagSNSTopic,

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	FlagPort           = "port"
-	FlagAutoMigrate    = "automigrate"
-	FlagScheduler      = "scheduler"
-	FlagEventsBackend  = "events.backend"
-	FlagRunLogsBackend = "runlogs.backend"
-	FlagLogLevel       = "log.level"
+	FlagPort                       = "port"
+	FlagAutoMigrate                = "automigrate"
+	FlagScheduler                  = "scheduler"
+	FlagEventsBackend              = "events.backend"
+	FlagRunLogsBackend             = "runlogs.backend"
+	FlagActionConfirmationsBackend = "action-confirmations.backend"
+	FlagLogLevel                   = "log.level"
 
 	FlagMessagesRequired = "messages.required"
 	FlagAllowedCommands  = "commands.allowed"
@@ -331,6 +332,12 @@ var EmpireFlags = []cli.Flag{
 		Value:  "stdout",
 		Usage:  "The backend implementation to use to record the logs from interactive runs. Current supports `cloudwatch` and `stdout`",
 		EnvVar: "EMPIRE_RUN_LOGS_BACKEND",
+	},
+	cli.StringFlag{
+		Name:   FlagActionConfirmationsBackend,
+		Value:  "",
+		Usage:  "Backend to use when confirm actions. (e.g. duo://api-xxxxx.duosecurity.com?key=<key>&secret=<secret>",
+		EnvVar: "EMPIRE_ACTION_CONFIRMATIONS_BACKEND",
 	},
 	cli.StringFlag{
 		Name:   FlagSNSTopic,

--- a/empire.go
+++ b/empire.go
@@ -14,6 +14,37 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Various actions that Empire is capable of.
+type Action int
+
+const (
+	ActionDeploy Action = iota
+	ActionRun
+)
+
+func ActionFromString(name string) (action Action, err error) {
+	switch name {
+	case "Deploy":
+		action = ActionDeploy
+	case "Run":
+		action = ActionRun
+	default:
+		err = fmt.Errorf("%s is not a valid Empire action", name)
+	}
+	return
+}
+
+func (action Action) String() string {
+	switch action {
+	case ActionDeploy:
+		return "Deploy"
+	case ActionRun:
+		return "Run"
+	default:
+		return "Unknown Action"
+	}
+}
+
 const (
 	// webProcessType is the process type we assume are web server processes.
 	webProcessType = "web"
@@ -31,6 +62,16 @@ var (
 		errors.New("An app name must be alphanumeric and dashes only, 3-30 chars in length."),
 	}
 )
+
+// ConfirmationError is returned when the request to confirm an action fails.
+type ConfirmationError struct {
+	// The Action that failed confirmation.
+	Action Action
+}
+
+func (e *ConfirmationError) Error() string {
+	return fmt.Sprintf("request to %s was denied", e.Action)
+}
 
 // AllowedCommands specifies what commands are allowed to be Run with Empire.
 type AllowedCommands int
@@ -95,9 +136,8 @@ type Empire struct {
 	// RunRecorder is used to record the logs from interactive runs.
 	RunRecorder RunRecorder
 
-	// ActionConfirmer used to confirm whether and action is authorized or
-	// not.
-	ActionConfirmer ActionConfirmer
+	// A list of actions that require confirmation.
+	ConfirmActions map[Action]ActionConfirmer
 
 	// MessagesRequired is a boolean used to determine if messages should be required for events.
 	MessagesRequired bool
@@ -442,8 +482,9 @@ func (opts RunOpts) Validate(e *Empire) error {
 	return e.requireMessages(opts.Message)
 }
 
-func (e *Empire) confirm(ctx context.Context, user *User, action string, resource string, params map[string]string) error {
-	if e.ActionConfirmer == nil {
+func (e *Empire) confirm(ctx context.Context, user *User, action Action, params map[string]string) error {
+	confirmer := e.ConfirmActions[action]
+	if confirmer == nil {
 		return nil
 	}
 
@@ -457,14 +498,14 @@ func (e *Empire) confirm(ctx context.Context, user *User, action string, resourc
 			err error
 		)
 
-		ok, err = e.ActionConfirmer.Confirm(ctx, user, action, resource, params)
+		ok, err = confirmer.Confirm(ctx, user, action, params)
 		if err != nil {
 			errCh <- err
 			return
 		}
 
 		if !ok {
-			err = errors.New("not authorized")
+			err = &ConfirmationError{Action: action}
 		}
 
 		errCh <- err
@@ -480,14 +521,13 @@ func (e *Empire) confirm(ctx context.Context, user *User, action string, resourc
 
 // Run runs a one-off process for a given App and command.
 func (e *Empire) Run(ctx context.Context, opts RunOpts) error {
-	if err := e.confirm(ctx, opts.User, "Run", opts.App.Name, nil); err != nil {
+	if err := e.confirm(ctx, opts.User, ActionRun, nil); err != nil {
 		// Gross: Fix this.
 		if opts.Output != nil {
-			io.WriteString(opts.Output, fmt.Sprintf("error: %v\n", err))
+			io.WriteString(opts.Output, fmt.Sprintf("%v\r\n", err))
 			return nil
-		} else {
-			return err
 		}
+		return err
 	}
 
 	event := opts.Event()
@@ -638,6 +678,10 @@ func (opts DeployOpts) Validate(e *Empire) error {
 // Deploy deploys an image and streams the output to w.
 func (e *Empire) Deploy(ctx context.Context, opts DeployOpts) (*Release, error) {
 	if err := opts.Validate(e); err != nil {
+		return nil, err
+	}
+
+	if err := e.confirm(ctx, opts.User, ActionDeploy, nil); err != nil {
 		return nil, err
 	}
 

--- a/empire.go
+++ b/empire.go
@@ -95,6 +95,10 @@ type Empire struct {
 	// RunRecorder is used to record the logs from interactive runs.
 	RunRecorder RunRecorder
 
+	// ActionConfirmer used to confirm whether and action is authorized or
+	// not.
+	ActionConfirmer ActionConfirmer
+
 	// MessagesRequired is a boolean used to determine if messages should be required for events.
 	MessagesRequired bool
 
@@ -438,8 +442,54 @@ func (opts RunOpts) Validate(e *Empire) error {
 	return e.requireMessages(opts.Message)
 }
 
+func (e *Empire) confirm(ctx context.Context, user *User, action string, resource string, params map[string]string) error {
+	if e.ActionConfirmer == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		var (
+			ok  bool
+			err error
+		)
+
+		ok, err = e.ActionConfirmer.Confirm(ctx, user, action, resource, params)
+		if err != nil {
+			errCh <- err
+			return
+		}
+
+		if !ok {
+			err = errors.New("not authorized")
+		}
+
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return errors.New("timed out waiting to confirm action")
+	}
+}
+
 // Run runs a one-off process for a given App and command.
 func (e *Empire) Run(ctx context.Context, opts RunOpts) error {
+	if err := e.confirm(ctx, opts.User, "Run", opts.App.Name, nil); err != nil {
+		// Gross: Fix this.
+		if opts.Output != nil {
+			io.WriteString(opts.Output, fmt.Sprintf("error: %v\n", err))
+			return nil
+		} else {
+			return err
+		}
+	}
+
 	event := opts.Event()
 
 	if err := opts.Validate(e); err != nil {

--- a/pkg/duo/duo.go
+++ b/pkg/duo/duo.go
@@ -1,0 +1,58 @@
+package duo
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const rfc2822 = "Mon Jan 02 15:04:05 -0700 2006"
+
+// SignRequest HMAC signs the http.Request, based on the alrgorithm in https://duo.com/docs/authapi
+//
+// The API uses HTTP Basic Authentication to authenticate requests. Use your Duo application’s integration key as the HTTP Username.
+//
+//	Generate the HTTP Password as an HMAC signature of the request. This will be different for each request and must be re-generated each time.
+//
+//	To construct the signature, first build an ASCII string from your request, using the following components:
+//
+//	date
+//		The current time, formatted as RFC 2822. This must be the same string as the “Date” header. | Tue, 21 Aug 2012 17:29:18 -0000
+//	method
+//		The HTTP method (uppercase) | POST
+//	host
+//		Your API hostname (lowercase) | api-xxxxxxxx.duosecurity.com
+//	path
+//		The specific API method's path | /accounts/v1/account/list
+//	params
+//		The URL-encoded list of key=value pairs, lexicographically
+//		sorted by key. These come from the request parameters (the URL
+//		query string for GET and DELETE requests or the request body for
+//		POST requests). If the request does not have any parameters one
+//		must still include a blank line in the string that is signed. Do
+//		not encode unreserved characters. Use upper-case hexadecimal
+//		digits A through F in escape sequences.
+func SignRequest(secret []byte, r *http.Request) string {
+	if r.Header.Get("Date") == "" {
+		r.Header.Set("Date", time.Now().Format(rfc2822))
+	}
+
+	body := signatureBody(r)
+	mac := hmac.New(sha1.New, secret)
+	mac.Write(body)
+	return fmt.Sprintf("%x", mac.Sum(nil))
+}
+
+func signatureBody(r *http.Request) []byte {
+	parts := []string{
+		r.Header.Get("Date"),
+		strings.ToUpper(r.Method),
+		strings.ToLower(r.URL.Host),
+		r.URL.Path,
+		r.URL.RawQuery,
+	}
+	return []byte(strings.Join(parts, "\n"))
+}

--- a/pkg/duo/duo.go
+++ b/pkg/duo/duo.go
@@ -35,15 +35,21 @@ const rfc2822 = "Mon Jan 02 15:04:05 -0700 2006"
 //		must still include a blank line in the string that is signed. Do
 //		not encode unreserved characters. Use upper-case hexadecimal
 //		digits A through F in escape sequences.
-func SignRequest(secret []byte, r *http.Request) string {
+func Signature(secret string, r *http.Request) string {
 	if r.Header.Get("Date") == "" {
 		r.Header.Set("Date", time.Now().Format(rfc2822))
 	}
 
 	body := signatureBody(r)
-	mac := hmac.New(sha1.New, secret)
+	mac := hmac.New(sha1.New, []byte(secret))
 	mac.Write(body)
 	return fmt.Sprintf("%x", mac.Sum(nil))
+}
+
+// SetBasicAuth signs the request, then sets the Authorization header.
+func SetBasicAuth(key, secret string, r *http.Request) {
+	signature := Signature(secret, r)
+	r.SetBasicAuth(key, signature)
 }
 
 func signatureBody(r *http.Request) []byte {

--- a/pkg/duo/duo_test.go
+++ b/pkg/duo/duo_test.go
@@ -14,7 +14,7 @@ const (
 	testIntegrationSecret = "Zh5eGmUq9zpfQnyUIu5OL9iWoMMv5ZNmk3zLJ4Ep"
 )
 
-func TestSignRequest(t *testing.T) {
+func TestSignature(t *testing.T) {
 	tests := []struct {
 		req       *http.Request
 		signature string
@@ -46,8 +46,30 @@ func TestSignRequest(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			signature := SignRequest([]byte(testIntegrationSecret), tt.req)
+			signature := Signature(testIntegrationSecret, tt.req)
 			assert.Equal(t, tt.signature, signature)
+		})
+	}
+}
+
+func TestSetBasicAuth(t *testing.T) {
+	tests := []struct {
+		req           *http.Request
+		authorization string
+	}{
+		{
+			newRequest("POST", "https://api-XXXXXXXX.duosecurity.com/accounts/v1/account/list", func(r *http.Request) {
+				r.URL.RawQuery = "realname=First%20Last&username=root"
+				r.Header.Set("Date", "Tue, 21 Aug 2012 17:29:18 -0000")
+			}),
+			"Basic RElXSjhYNkFFWU9SNU9NQzZUUTE6MmQ5N2Q2MTY2MzE5NzgxYjVhM2EwN2FmMzlkMzY2ZjQ5MTIzNGVkYw==",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			SetBasicAuth(testIntegrationKey, testIntegrationSecret, tt.req)
+			assert.Equal(t, tt.authorization, tt.req.Header.Get("Authorization"))
 		})
 	}
 }

--- a/pkg/duo/duo_test.go
+++ b/pkg/duo/duo_test.go
@@ -1,0 +1,64 @@
+package duo
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testIntegrationKey    = "DIWJ8X6AEYOR5OMC6TQ1"
+	testIntegrationSecret = "Zh5eGmUq9zpfQnyUIu5OL9iWoMMv5ZNmk3zLJ4Ep"
+)
+
+func TestSignRequest(t *testing.T) {
+	tests := []struct {
+		req       *http.Request
+		signature string
+	}{
+		{
+			newRequest("POST", "https://api-XXXXXXXX.duosecurity.com/accounts/v1/account/list", func(r *http.Request) {
+				r.URL.RawQuery = "realname=First%20Last&username=root"
+				r.Header.Set("Date", "Tue, 21 Aug 2012 17:29:18 -0000")
+			}),
+			"2d97d6166319781b5a3a07af39d366f491234edc",
+		},
+		{
+			newRequest("POST", "https://api-XXXXXXXX.duosecurity.com/accounts/v1/account/list", func(r *http.Request) {
+				q := url.Values{}
+				q.Add("realname", "First Last")
+				q.Add("username", "root")
+				r.URL.RawQuery = q.Encode()
+				r.Header.Set("Date", "Tue, 21 Aug 2012 17:29:18 -0000")
+			}),
+			"c423a17fe94ccbf3004533cab496ae06216b90be",
+		},
+		{
+			newRequest("POST", "https://api-XXXXXXXX.duosecurity.com/accounts/v1/account/list", func(r *http.Request) {
+				r.Header.Set("Date", "Tue, 21 Aug 2012 17:29:18 -0000")
+			}),
+			"1f3107d3856797e459d29a440c6e79ead6b7163f",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			signature := SignRequest([]byte(testIntegrationSecret), tt.req)
+			assert.Equal(t, tt.signature, signature)
+		})
+	}
+}
+
+func newRequest(method, path string, f func(r *http.Request)) *http.Request {
+	req, err := http.NewRequest(method, path, nil)
+	if err != nil {
+		panic(err)
+	}
+	if f != nil {
+		f(req)
+	}
+	return req
+}

--- a/tests/cli/deploy_test.go
+++ b/tests/cli/deploy_test.go
@@ -3,6 +3,9 @@ package cli_test
 import (
 	"errors"
 	"testing"
+
+	"github.com/remind101/empire"
+	"golang.org/x/net/context"
 )
 
 func TestDeploy(t *testing.T) {
@@ -106,6 +109,23 @@ Status: Finished processing events for release v1 of acme-inc`,
 		{
 			"releases -a acme-inc",
 			"v1    Dec 31  2014  Deploy remind101/acme-inc:latest (fake: 'commit')",
+		},
+	})
+}
+
+func TestDeploy_WithConfirmation_Failed(t *testing.T) {
+	pre := func(cli *CLI) {
+		cli.Empire.ConfirmActions = map[empire.Action]empire.ActionConfirmer{
+			empire.ActionDeploy: empire.ActionConfirmerFunc(func(ctx context.Context, user *empire.User, action empire.Action, params map[string]string) (bool, error) {
+				return false, nil
+			}),
+		}
+	}
+
+	runWithPre(t, pre, []Command{
+		{
+			"deploy remind101/acme-inc",
+			errors.New("error: unable to confirm Deploy via ActionConfirmerFunc: request denied"),
 		},
 	})
 }

--- a/tests/cli/run_test.go
+++ b/tests/cli/run_test.go
@@ -41,7 +41,7 @@ func TestRunAttached_WithConfirmation_Failed(t *testing.T) {
 		DeployCommand("latest", "v1"),
 		{
 			"run bash -a acme-inc",
-			"request to Run was denied\r",
+			"unable to confirm Run via ActionConfirmerFunc: request denied\r",
 		},
 	})
 }

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -1,6 +1,7 @@
 package empire_test
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -330,6 +331,137 @@ func TestEmpire_Run(t *testing.T) {
 	assert.NoError(t, err)
 
 	s.AssertExpectations(t)
+}
+
+func TestEmpire_Run_WithConfirmation(t *testing.T) {
+	e := empiretest.NewEmpire(t)
+
+	confirmations := make(chan empire.Action, 1)
+	e.ConfirmActions = map[empire.Action]empire.ActionConfirmer{
+		empire.ActionRun: empire.ActionConfirmerFunc(func(ctx context.Context, user *empire.User, action empire.Action, params map[string]string) (bool, error) {
+			confirmations <- action
+			return true, nil
+		}),
+	}
+
+	user := &empire.User{Name: "ejholmes"}
+
+	app, err := e.Create(context.Background(), empire.CreateOpts{
+		User: user,
+		Name: "acme-inc",
+	})
+	assert.NoError(t, err)
+
+	img := image.Image{Repository: "remind101/acme-inc"}
+	_, err = e.Deploy(context.Background(), empire.DeployOpts{
+		App:    app,
+		User:   user,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
+		Image:  img,
+	})
+	assert.NoError(t, err)
+
+	err = e.Run(context.Background(), empire.RunOpts{
+		User:    user,
+		App:     app,
+		Command: empire.MustParseCommand("bundle exec rake db:migrate"),
+
+		// Detached Process
+		Output: nil,
+		Input:  nil,
+
+		Env: map[string]string{
+			"TERM": "xterm",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, empire.ActionRun, <-confirmations)
+}
+
+func TestEmpire_Run_WithConfirmation_NotConfirmed_Attached(t *testing.T) {
+	e := empiretest.NewEmpire(t)
+
+	e.ConfirmActions = map[empire.Action]empire.ActionConfirmer{
+		empire.ActionRun: empire.ActionConfirmerFunc(func(ctx context.Context, user *empire.User, action empire.Action, params map[string]string) (bool, error) {
+			return false, nil
+		}),
+	}
+
+	user := &empire.User{Name: "ejholmes"}
+
+	app, err := e.Create(context.Background(), empire.CreateOpts{
+		User: user,
+		Name: "acme-inc",
+	})
+	assert.NoError(t, err)
+
+	img := image.Image{Repository: "remind101/acme-inc"}
+	_, err = e.Deploy(context.Background(), empire.DeployOpts{
+		App:    app,
+		User:   user,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
+		Image:  img,
+	})
+	assert.NoError(t, err)
+
+	stdout := new(bytes.Buffer)
+	err = e.Run(context.Background(), empire.RunOpts{
+		User:    user,
+		App:     app,
+		Command: empire.MustParseCommand("bundle exec rake db:migrate"),
+
+		// Attached Process
+		Output: stdout,
+		Input:  nil,
+
+		Env: map[string]string{
+			"TERM": "xterm",
+		},
+	})
+	assert.Equal(t, "request to Run was denied\r\n", stdout.String())
+	assert.Equal(t, nil, err)
+}
+
+func TestEmpire_Run_WithConfirmation_NotConfirmed_Detached(t *testing.T) {
+	e := empiretest.NewEmpire(t)
+
+	e.ConfirmActions = map[empire.Action]empire.ActionConfirmer{
+		empire.ActionRun: empire.ActionConfirmerFunc(func(ctx context.Context, user *empire.User, action empire.Action, params map[string]string) (bool, error) {
+			return false, nil
+		}),
+	}
+
+	user := &empire.User{Name: "ejholmes"}
+
+	app, err := e.Create(context.Background(), empire.CreateOpts{
+		User: user,
+		Name: "acme-inc",
+	})
+	assert.NoError(t, err)
+
+	img := image.Image{Repository: "remind101/acme-inc"}
+	_, err = e.Deploy(context.Background(), empire.DeployOpts{
+		App:    app,
+		User:   user,
+		Output: empire.NewDeploymentStream(ioutil.Discard),
+		Image:  img,
+	})
+	assert.NoError(t, err)
+
+	err = e.Run(context.Background(), empire.RunOpts{
+		User:    user,
+		App:     app,
+		Command: empire.MustParseCommand("bundle exec rake db:migrate"),
+
+		// Detached Process
+		Output: nil,
+		Input:  nil,
+
+		Env: map[string]string{
+			"TERM": "xterm",
+		},
+	})
+	assert.Equal(t, &empire.ConfirmationError{Action: empire.ActionRun}, err)
 }
 
 func TestEmpire_Run_WithConstraints(t *testing.T) {

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -418,7 +418,7 @@ func TestEmpire_Run_WithConfirmation_NotConfirmed_Attached(t *testing.T) {
 			"TERM": "xterm",
 		},
 	})
-	assert.Equal(t, "request to Run was denied\r\n", stdout.String())
+	assert.Equal(t, "unable to confirm Run via ActionConfirmerFunc: request denied\r\n", stdout.String())
 	assert.Equal(t, nil, err)
 }
 
@@ -461,7 +461,11 @@ func TestEmpire_Run_WithConfirmation_NotConfirmed_Detached(t *testing.T) {
 			"TERM": "xterm",
 		},
 	})
-	assert.Equal(t, &empire.ConfirmationError{Action: empire.ActionRun}, err)
+	assert.Equal(t, &empire.ConfirmationError{
+		Action:          empire.ActionRun,
+		ActionConfirmer: "ActionConfirmerFunc",
+		Reason:          errors.New("request denied"),
+	}, err)
 }
 
 func TestEmpire_Run_WithConstraints(t *testing.T) {


### PR DESCRIPTION
This is a POC for the [Action Confirmations proposal](https://github.com/remind101/empire/wiki/Action-Confirmations-Proposal)

This will send the user a push notification using Duo, and block until the action is confirmed. How we'll configure what actions require this is still TBD, but might make sense to include in policies in https://github.com/remind101/empire/pull/987.

![](https://dl.dropboxusercontent.com/u/1906634/action_confirmations%401024.gif)

**TODO**
- [ ] Better support in GitHub Deployments.
