### PR TITLE
support newlines in parsing env files

### DIFF
--- a/cmd/emp/env.go
+++ b/cmd/emp/env.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"log"
 	"os"
 	"sort"
 	"strings"
+	"github.com/joho/godotenv"
 )
 
 var cmdEnv = &Command{
@@ -161,81 +161,15 @@ func runEnvLoad(cmd *Command, args []string) {
 		os.Exit(2)
 	}
 
-	parsedVars, err := ParseEnvFile(args[0])
+	parsedVars, err := godotenv.Read(args[0])
 	must(err)
 
 	config := make(map[string]*string)
-	for _, value := range parsedVars {
-		kv := strings.SplitN(value, "=", 2)
-		if len(kv) == 1 {
-			config[kv[0]] = new(string)
-		} else {
-			config[kv[0]] = &kv[1]
-		}
+	for key, value := range parsedVars {
+		config[key] = &value
 	}
 
 	_, err = client.ConfigVarUpdate(appname, config, message)
 	must(err)
 	log.Printf("Updated env vars from %s and restarted %s.", args[0], appname)
-}
-
-// Stripped from https://github.com/docker/docker/blob/3d13fddd2bc4d679f0eaa68b0be877e5a816ad53/runconfig/opts/envfile.go
-//
-// ParseEnvFile reads a file with environment variables enumerated by lines
-//
-// ``Environment variable names used by the utilities in the Shell and
-// Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase
-// letters, digits, and the '_' (underscore) from the characters defined in
-// Portable Character Set and do not begin with a digit. *But*, other
-// characters may be permitted by an implementation; applications shall
-// tolerate the presence of such names.''
-// -- http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html
-//
-// As of #16585, it's up to application inside docker to validate or not
-// environment variables, that's why we just strip leading whitespace and
-// nothing more.
-func ParseEnvFile(filename string) ([]string, error) {
-	fh, err := os.Open(filename)
-	if err != nil {
-		return []string{}, err
-	}
-	defer fh.Close()
-
-	lines := []string{}
-	scanner := bufio.NewScanner(fh)
-	for scanner.Scan() {
-		// trim the line from all leading whitespace first
-		line := strings.TrimLeft(scanner.Text(), whiteSpaces)
-		// line is not empty, and not starting with '#'
-		if len(line) > 0 && !strings.HasPrefix(line, "#") {
-			data := strings.SplitN(line, "=", 2)
-
-			// trim the front of a variable, but nothing else
-			variable := strings.TrimLeft(data[0], whiteSpaces)
-			if strings.ContainsAny(variable, whiteSpaces) {
-				return []string{}, ErrBadEnvVariable{fmt.Sprintf("variable '%s' has white spaces", variable)}
-			}
-
-			if len(data) > 1 {
-
-				// pass the value through, no trimming
-				lines = append(lines, fmt.Sprintf("%s=%s", variable, data[1]))
-			} else {
-				// if only a pass-through variable is given, clean it up.
-				lines = append(lines, fmt.Sprintf("%s=%s", strings.TrimSpace(line), os.Getenv(line)))
-			}
-		}
-	}
-	return lines, scanner.Err()
-}
-
-var whiteSpaces = " \t"
-
-// ErrBadEnvVariable typed error for bad environment variable
-type ErrBadEnvVariable struct {
-	msg string
-}
-
-func (e ErrBadEnvVariable) Error() string {
-	return fmt.Sprintf("poorly formatted environment: %s", e.msg)
 }

--- a/tests/cli/env_test.go
+++ b/tests/cli/env_test.go
@@ -3,6 +3,9 @@ package cli_test
 import (
 	"testing"
 	"time"
+	"io/ioutil"
+	"os"
+	"fmt"
 )
 
 func TestConfig(t *testing.T) {
@@ -112,4 +115,22 @@ func TestConfigConsistency(t *testing.T) {
 			"FOO1=foo1\nFOO2=foo2\nFOO3=foo3",
 		},
 	})
+}
+
+func TestEnvConfig(t *testing.T) {
+	file, err := ioutil.TempFile(os.TempDir(), "acme-inc.env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("FOO=bar\\nmoarbar\n")
+	file.Write(content)
+
+	run(t, []Command{
+		DeployCommand("latest", "v1"),
+		{
+			fmt.Sprintf("env-load %s -a acme-inc", file.Name()),
+			fmt.Sprintf("Updated env vars from %s and restarted acme-inc.", file.Name()),
+		},
+	})
+	defer os.Remove(file.Name())
 }

--- a/vendor/github.com/joho/godotenv/LICENCE
+++ b/vendor/github.com/joho/godotenv/LICENCE
@@ -1,0 +1,23 @@
+Copyright (c) 2013 John Barton
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/joho/godotenv/README.md
+++ b/vendor/github.com/joho/godotenv/README.md
@@ -1,0 +1,127 @@
+# GoDotEnv [![wercker status](https://app.wercker.com/status/507594c2ec7e60f19403a568dfea0f78 "wercker status")](https://app.wercker.com/project/bykey/507594c2ec7e60f19403a568dfea0f78)
+
+A Go (golang) port of the Ruby dotenv project (which loads env vars from a .env file)
+
+From the original Library:
+
+> Storing configuration in the environment is one of the tenets of a twelve-factor app. Anything that is likely to change between deployment environments–such as resource handles for databases or credentials for external services–should be extracted from the code into environment variables.
+>
+> But it is not always practical to set environment variables on development machines or continuous integration servers where multiple projects are run. Dotenv load variables from a .env file into ENV when the environment is bootstrapped.
+
+It can be used as a library (for loading in env for your own daemons etc) or as a bin command.
+
+There is test coverage and CI for both linuxish and windows environments, but I make no guarantees about the bin version working on windows.
+
+## Installation
+
+As a library
+
+```shell
+go get github.com/joho/godotenv
+```
+
+or if you want to use it as a bin command
+```shell
+go get github.com/joho/godotenv/cmd/godotenv
+```
+
+## Usage
+
+Add your application configuration to your `.env` file in the root of your project:
+
+```shell
+S3_BUCKET=YOURS3BUCKET
+SECRET_KEY=YOURSECRETKEYGOESHERE
+```
+
+Then in your Go app you can do something like
+
+```go
+package main
+
+import (
+    "github.com/joho/godotenv"
+    "log"
+    "os"
+)
+
+func main() {
+  err := godotenv.Load()
+  if err != nil {
+    log.Fatal("Error loading .env file")
+  }
+
+  s3Bucket := os.Getenv("S3_BUCKET")
+  secretKey := os.Getenv("SECRET_KEY")
+
+  // now do something with s3 or whatever
+}
+```
+
+If you're even lazier than that, you can just take advantage of the autoload package which will read in `.env` on import
+
+```go
+import _ "github.com/joho/godotenv/autoload"
+```
+
+While `.env` in the project root is the default, you don't have to be constrained, both examples below are 100% legit
+
+```go
+_ = godotenv.Load("somerandomfile")
+_ = godotenv.Load("filenumberone.env", "filenumbertwo.env")
+```
+
+If you want to be really fancy with your env file you can do comments and exports (below is a valid env file)
+
+```shell
+# I am a comment and that is OK
+SOME_VAR=someval
+FOO=BAR # comments at line end are OK too
+export BAR=BAZ
+```
+
+Or finally you can do YAML(ish) style
+
+```yaml
+FOO: bar
+BAR: baz
+```
+
+as a final aside, if you don't want godotenv munging your env you can just get a map back instead
+
+```go
+var myEnv map[string]string
+myEnv, err := godotenv.Read()
+
+s3Bucket := myEnv["S3_BUCKET"]
+```
+
+### Command Mode
+
+Assuming you've installed the command as above and you've got `$GOPATH/bin` in your `$PATH`
+
+```
+godotenv -f /some/path/to/.env some_command with some args
+```
+
+If you don't specify `-f` it will fall back on the default of loading `.env` in `PWD`
+
+## Contributing
+
+Contributions are most welcome! The parser itself is pretty stupidly naive and I wouldn't be surprised if it breaks with edge cases.
+
+*code changes without tests will not be accepted*
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## CI
+
+Linux: [![wercker status](https://app.wercker.com/status/507594c2ec7e60f19403a568dfea0f78/m "wercker status")](https://app.wercker.com/project/bykey/507594c2ec7e60f19403a568dfea0f78) Windows: [![Build status](https://ci.appveyor.com/api/projects/status/9v40vnfvvgde64u4)](https://ci.appveyor.com/project/joho/godotenv)
+
+## Who?
+
+The original library [dotenv](https://github.com/bkeepers/dotenv) was written by [Brandon Keepers](http://opensoul.org/), and this port was done by [John Barton](http://whoisjohnbarton.com) based off the tests/fixtures in the original library.

--- a/vendor/github.com/joho/godotenv/godotenv.go
+++ b/vendor/github.com/joho/godotenv/godotenv.go
@@ -1,0 +1,229 @@
+// Package godotenv is a go port of the ruby dotenv library (https://github.com/bkeepers/dotenv)
+//
+// Examples/readme can be found on the github page at https://github.com/joho/godotenv
+//
+// The TL;DR is that you make a .env file that looks something like
+//
+// 		SOME_ENV_VAR=somevalue
+//
+// and then in your go code you can call
+//
+// 		godotenv.Load()
+//
+// and all the env vars declared in .env will be avaiable through os.Getenv("SOME_ENV_VAR")
+package godotenv
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Load will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// If you call Load without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.Load("fileone", "filetwo")
+//
+// It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults
+func Load(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, false)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Overload will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main)
+//
+// If you call Overload without any args it will default to loading .env in the current path
+//
+// You can otherwise tell it which files to load (there can be more than one) like
+//
+//		godotenv.Overload("fileone", "filetwo")
+//
+// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefilly set all vars.
+func Overload(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, true)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Read all env (with same file loading semantics as Load) but return values as
+// a map rather than automatically writing values into env
+func Read(filenames ...string) (envMap map[string]string, err error) {
+	filenames = filenamesOrDefault(filenames)
+	envMap = make(map[string]string)
+
+	for _, filename := range filenames {
+		individualEnvMap, individualErr := readFile(filename)
+
+		if individualErr != nil {
+			err = individualErr
+			return // return early on a spazout
+		}
+
+		for key, value := range individualEnvMap {
+			envMap[key] = value
+		}
+	}
+
+	return
+}
+
+// Exec loads env vars from the specified filenames (empty map falls back to default)
+// then executes the cmd specified.
+//
+// Simply hooks up os.Stdin/err/out to the command and calls Run()
+//
+// If you want more fine grained control over your command it's recommended
+// that you use `Load()` or `Read()` and the `os/exec` package yourself.
+func Exec(filenames []string, cmd string, cmdArgs []string) error {
+	Load(filenames...)
+
+	command := exec.Command(cmd, cmdArgs...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+func filenamesOrDefault(filenames []string) []string {
+	if len(filenames) == 0 {
+		return []string{".env"}
+	}
+	return filenames
+}
+
+func loadFile(filename string, overload bool) error {
+	envMap, err := readFile(filename)
+	if err != nil {
+		return err
+	}
+
+	for key, value := range envMap {
+		if os.Getenv(key) == "" || overload {
+			os.Setenv(key, value)
+		}
+	}
+
+	return nil
+}
+
+func readFile(filename string) (envMap map[string]string, err error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	envMap = make(map[string]string)
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	for _, fullLine := range lines {
+		if !isIgnoredLine(fullLine) {
+			key, value, err := parseLine(fullLine)
+
+			if err == nil {
+				envMap[key] = value
+			}
+		}
+	}
+	return
+}
+
+func parseLine(line string) (key string, value string, err error) {
+	if len(line) == 0 {
+		err = errors.New("zero length string")
+		return
+	}
+
+	// ditch the comments (but keep quoted hashes)
+	if strings.Contains(line, "#") {
+		segmentsBetweenHashes := strings.Split(line, "#")
+		quotesAreOpen := false
+		var segmentsToKeep []string
+		for _, segment := range segmentsBetweenHashes {
+			if strings.Count(segment, "\"") == 1 || strings.Count(segment, "'") == 1 {
+				if quotesAreOpen {
+					quotesAreOpen = false
+					segmentsToKeep = append(segmentsToKeep, segment)
+				} else {
+					quotesAreOpen = true
+				}
+			}
+
+			if len(segmentsToKeep) == 0 || quotesAreOpen {
+				segmentsToKeep = append(segmentsToKeep, segment)
+			}
+		}
+
+		line = strings.Join(segmentsToKeep, "#")
+	}
+
+	// now split key from value
+	splitString := strings.SplitN(line, "=", 2)
+
+	if len(splitString) != 2 {
+		// try yaml mode!
+		splitString = strings.SplitN(line, ":", 2)
+	}
+
+	if len(splitString) != 2 {
+		err = errors.New("Can't separate key from value")
+		return
+	}
+
+	// Parse the key
+	key = splitString[0]
+	if strings.HasPrefix(key, "export") {
+		key = strings.TrimPrefix(key, "export")
+	}
+	key = strings.Trim(key, " ")
+
+	// Parse the value
+	value = splitString[1]
+	// trim
+	value = strings.Trim(value, " ")
+
+	// check if we've got quoted values
+	if strings.Count(value, "\"") == 2 || strings.Count(value, "'") == 2 {
+		// pull the quotes off the edges
+		value = strings.Trim(value, "\"'")
+
+		// expand quotes
+		value = strings.Replace(value, "\\\"", "\"", -1)
+		// expand newlines
+		value = strings.Replace(value, "\\n", "\n", -1)
+	}
+
+	return
+}
+
+func isIgnoredLine(line string) bool {
+	trimmedLine := strings.Trim(line, " \n\t")
+	return len(trimmedLine) == 0 || strings.HasPrefix(trimmedLine, "#")
+}

--- a/vendor/github.com/joho/godotenv/godotenv_test.go
+++ b/vendor/github.com/joho/godotenv/godotenv_test.go
@@ -1,0 +1,271 @@
+package godotenv
+
+import (
+	"os"
+	"testing"
+)
+
+var noopPresets = make(map[string]string)
+
+func parseAndCompare(t *testing.T, rawEnvLine string, expectedKey string, expectedValue string) {
+	key, value, _ := parseLine(rawEnvLine)
+	if key != expectedKey || value != expectedValue {
+		t.Errorf("Expected '%v' to parse as '%v' => '%v', got '%v' => '%v' instead", rawEnvLine, expectedKey, expectedValue, key, value)
+	}
+}
+
+func loadEnvAndCompareValues(t *testing.T, loader func(files ...string) error, envFileName string, expectedValues map[string]string, presets map[string]string) {
+	// first up, clear the env
+	os.Clearenv()
+
+	for k, v := range presets {
+		os.Setenv(k, v)
+	}
+
+	err := loader(envFileName)
+	if err != nil {
+		t.Fatalf("Error loading %v", envFileName)
+	}
+
+	for k := range expectedValues {
+		envValue := os.Getenv(k)
+		v := expectedValues[k]
+		if envValue != v {
+			t.Errorf("Mismatch for key '%v': expected '%v' got '%v'", k, v, envValue)
+		}
+	}
+}
+
+func TestLoadWithNoArgsLoadsDotEnv(t *testing.T) {
+	err := Load()
+	pathError := err.(*os.PathError)
+	if pathError == nil || pathError.Op != "open" || pathError.Path != ".env" {
+		t.Errorf("Didn't try and open .env by default")
+	}
+}
+
+func TestOverloadWithNoArgsOverloadsDotEnv(t *testing.T) {
+	err := Overload()
+	pathError := err.(*os.PathError)
+	if pathError == nil || pathError.Op != "open" || pathError.Path != ".env" {
+		t.Errorf("Didn't try and open .env by default")
+	}
+}
+
+func TestLoadFileNotFound(t *testing.T) {
+	err := Load("somefilethatwillneverexistever.env")
+	if err == nil {
+		t.Error("File wasn't found but Load didn't return an error")
+	}
+}
+
+func TestOverloadFileNotFound(t *testing.T) {
+	err := Overload("somefilethatwillneverexistever.env")
+	if err == nil {
+		t.Error("File wasn't found but Overload didn't return an error")
+	}
+}
+
+func TestReadPlainEnv(t *testing.T) {
+	envFileName := "fixtures/plain.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "1",
+		"OPTION_B": "2",
+		"OPTION_C": "3",
+		"OPTION_D": "4",
+		"OPTION_E": "5",
+	}
+
+	envMap, err := Read(envFileName)
+	if err != nil {
+		t.Error("Error reading file")
+	}
+
+	if len(envMap) != len(expectedValues) {
+		t.Error("Didn't get the right size map back")
+	}
+
+	for key, value := range expectedValues {
+		if envMap[key] != value {
+			t.Error("Read got one of the keys wrong")
+		}
+	}
+}
+
+func TestLoadDoesNotOverride(t *testing.T) {
+	envFileName := "fixtures/plain.env"
+
+	// ensure NO overload
+	presets := map[string]string{
+		"OPTION_A": "do_not_override",
+	}
+
+	expectedValues := map[string]string{
+		"OPTION_A": "do_not_override",
+	}
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, presets)
+}
+
+func TestOveroadDoesOverride(t *testing.T) {
+	envFileName := "fixtures/plain.env"
+
+	// ensure NO overload
+	presets := map[string]string{
+		"OPTION_A": "do_not_override",
+	}
+
+	expectedValues := map[string]string{
+		"OPTION_A": "1",
+	}
+	loadEnvAndCompareValues(t, Overload, envFileName, expectedValues, presets)
+}
+
+func TestLoadPlainEnv(t *testing.T) {
+	envFileName := "fixtures/plain.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "1",
+		"OPTION_B": "2",
+		"OPTION_C": "3",
+		"OPTION_D": "4",
+		"OPTION_E": "5",
+	}
+
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
+func TestLoadExportedEnv(t *testing.T) {
+	envFileName := "fixtures/exported.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "2",
+		"OPTION_B": "\n",
+	}
+
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
+func TestLoadEqualsEnv(t *testing.T) {
+	envFileName := "fixtures/equals.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "postgres://localhost:5432/database?sslmode=disable",
+	}
+
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
+func TestLoadQuotedEnv(t *testing.T) {
+	envFileName := "fixtures/quoted.env"
+	expectedValues := map[string]string{
+		"OPTION_A": "1",
+		"OPTION_B": "2",
+		"OPTION_C": "",
+		"OPTION_D": "\n",
+		"OPTION_E": "1",
+		"OPTION_F": "2",
+		"OPTION_G": "",
+		"OPTION_H": "\n",
+	}
+
+	loadEnvAndCompareValues(t, Load, envFileName, expectedValues, noopPresets)
+}
+
+func TestActualEnvVarsAreLeftAlone(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("OPTION_A", "actualenv")
+	_ = Load("fixtures/plain.env")
+
+	if os.Getenv("OPTION_A") != "actualenv" {
+		t.Error("An ENV var set earlier was overwritten")
+	}
+}
+
+func TestParsing(t *testing.T) {
+	// unquoted values
+	parseAndCompare(t, "FOO=bar", "FOO", "bar")
+
+	// parses values with spaces around equal sign
+	parseAndCompare(t, "FOO =bar", "FOO", "bar")
+	parseAndCompare(t, "FOO= bar", "FOO", "bar")
+
+	// parses double quoted values
+	parseAndCompare(t, "FOO=\"bar\"", "FOO", "bar")
+
+	// parses single quoted values
+	parseAndCompare(t, "FOO='bar'", "FOO", "bar")
+
+	// parses escaped double quotes
+	parseAndCompare(t, "FOO=escaped\\\"bar\"", "FOO", "escaped\"bar")
+
+	// parses yaml style options
+	parseAndCompare(t, "OPTION_A: 1", "OPTION_A", "1")
+
+	// parses export keyword
+	parseAndCompare(t, "export OPTION_A=2", "OPTION_A", "2")
+	parseAndCompare(t, "export OPTION_B='\\n'", "OPTION_B", "\n")
+
+	// it 'expands newlines in quoted strings' do
+	// expect(env('FOO="bar\nbaz"')).to eql('FOO' => "bar\nbaz")
+	parseAndCompare(t, "FOO=\"bar\\nbaz\"", "FOO", "bar\nbaz")
+
+	// it 'parses varibales with "." in the name' do
+	// expect(env('FOO.BAR=foobar')).to eql('FOO.BAR' => 'foobar')
+	parseAndCompare(t, "FOO.BAR=foobar", "FOO.BAR", "foobar")
+
+	// it 'parses varibales with several "=" in the value' do
+	// expect(env('FOO=foobar=')).to eql('FOO' => 'foobar=')
+	parseAndCompare(t, "FOO=foobar=", "FOO", "foobar=")
+
+	// it 'strips unquoted values' do
+	// expect(env('foo=bar ')).to eql('foo' => 'bar') # not 'bar '
+	parseAndCompare(t, "FOO=bar ", "FOO", "bar")
+
+	// it 'ignores inline comments' do
+	// expect(env("foo=bar # this is foo")).to eql('foo' => 'bar')
+	parseAndCompare(t, "FOO=bar # this is foo", "FOO", "bar")
+
+	// it 'allows # in quoted value' do
+	// expect(env('foo="bar#baz" # comment')).to eql('foo' => 'bar#baz')
+	parseAndCompare(t, "FOO=\"bar#baz\" # comment", "FOO", "bar#baz")
+	parseAndCompare(t, "FOO='bar#baz' # comment", "FOO", "bar#baz")
+	parseAndCompare(t, "FOO=\"bar#baz#bang\" # comment", "FOO", "bar#baz#bang")
+
+	// it 'parses # in quoted values' do
+	// expect(env('foo="ba#r"')).to eql('foo' => 'ba#r')
+	// expect(env("foo='ba#r'")).to eql('foo' => 'ba#r')
+	parseAndCompare(t, "FOO=\"ba#r\"", "FOO", "ba#r")
+	parseAndCompare(t, "FOO='ba#r'", "FOO", "ba#r")
+
+	// it 'throws an error if line format is incorrect' do
+	// expect{env('lol$wut')}.to raise_error(Dotenv::FormatError)
+	badlyFormattedLine := "lol$wut"
+	_, _, err := parseLine(badlyFormattedLine)
+	if err == nil {
+		t.Errorf("Expected \"%v\" to return error, but it didn't", badlyFormattedLine)
+	}
+}
+
+func TestLinesToIgnore(t *testing.T) {
+	// it 'ignores empty lines' do
+	// expect(env("\n \t  \nfoo=bar\n \nfizz=buzz")).to eql('foo' => 'bar', 'fizz' => 'buzz')
+	if !isIgnoredLine("\n") {
+		t.Error("Line with nothing but line break wasn't ignored")
+	}
+
+	if !isIgnoredLine("\t\t ") {
+		t.Error("Line full of whitespace wasn't ignored")
+	}
+
+	// it 'ignores comment lines' do
+	// expect(env("\n\n\n # HERE GOES FOO \nfoo=bar")).to eql('foo' => 'bar')
+	if !isIgnoredLine("# comment") {
+		t.Error("Comment wasn't ignored")
+	}
+
+	if !isIgnoredLine("\t#comment") {
+		t.Error("Indented comment wasn't ignored")
+	}
+
+	// make sure we're not getting false positives
+	if isIgnoredLine("export OPTION_B='\\n'") {
+		t.Error("ignoring a perfectly valid line to parse")
+	}
+}

--- a/vendor/github.com/joho/godotenv/wercker.yml
+++ b/vendor/github.com/joho/godotenv/wercker.yml
@@ -1,0 +1,1 @@
+box: pjvds/golang

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -563,6 +563,12 @@
 			"revisionTime": "2016-02-02T10:50:14-08:00"
 		},
 		{
+			"checksumSHA1": "DlFx4rpLWZMTSnzJtteYngCy0U4=",
+			"path": "github.com/joho/godotenv",
+			"revision": "4ed13390c0acd2ff4e371e64d8b97c8954138243",
+			"revisionTime": "2015-09-07T01:02:28Z"
+		},
+		{
 			"path": "github.com/joshk/pusher",
 			"revision": "011114c803b3adb8dab3c66f3d4648e8b9513bd9"
 		},


### PR DESCRIPTION
This is to fix #988 ; Uses/vendors `github.com/joho/godotenv` to parse env files. Added a test for loading an env file.