### PR TITLE
Stack tags on ALB/TargetGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * The `empire` and `emp` binaries are now built with Go 1.7 [#971](https://github.com/remind101/empire/pull/971)
 * `emp env-load` now handles multi-line environment variables. [#990](https://github.com/remind101/empire/pull/990)
 * In preparation for the 0.12 release, the legacy ECS scheduler has been removed. [#1001](https://github.com/remind101/empire/pull/1001)
+* All application labels are set on the CloudFormation stack, rather than just `empire.app.id` and `empire.app.name`. In addition, ALB's will get stack tags applied to them. [#1004](https://github.com/remind101/empire/pull/1004)
 
 ## 0.11.0 (2016-08-22)
 

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -117,6 +117,12 @@ type s3Client interface {
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
 }
 
+// Data handed to template generators.
+type TemplateData struct {
+	*scheduler.App
+	StackTags []*cloudformation.Tag
+}
+
 // Template represents something that can generate a stack body. Conveniently
 // the same interface as text/template.Template.
 type Template interface {
@@ -245,7 +251,9 @@ func (s *Scheduler) submit(ctx context.Context, tx *sql.Tx, app *scheduler.App, 
 		return err
 	}
 
-	t, err := s.createTemplate(ctx, app)
+	stackTags := append(s.Tags, tagsFromLabels(app.Labels)...)
+
+	t, err := s.createTemplate(ctx, app, stackTags)
 	if err != nil {
 		return err
 	}
@@ -255,8 +263,6 @@ func (s *Scheduler) submit(ctx context.Context, tx *sql.Tx, app *scheduler.App, 
 	})
 
 	scheduler.Publish(ctx, ss, fmt.Sprintf("Created cloudformation template: %v (%d/%d bytes)", *t.URL, t.Size, MaxTemplateSize))
-
-	stackTags := append(s.Tags, tagsFromLabels(app.Labels)...)
 
 	var parameters []*cloudformation.Parameter
 	if opts.NoDNS != nil {
@@ -394,9 +400,14 @@ func (s *Scheduler) waitForDeploymentsToStabilize(ctx context.Context, deploymen
 
 // createTemplate takes a scheduler.App, and returns a validated cloudformation
 // template.
-func (s *Scheduler) createTemplate(ctx context.Context, app *scheduler.App) (*cloudformationTemplate, error) {
+func (s *Scheduler) createTemplate(ctx context.Context, app *scheduler.App, stackTags []*cloudformation.Tag) (*cloudformationTemplate, error) {
+	data := &TemplateData{
+		App:       app,
+		StackTags: stackTags,
+	}
+
 	buf := new(bytes.Buffer)
-	if err := s.Template.Execute(buf, app); err != nil {
+	if err := s.Template.Execute(buf, data); err != nil {
 		return nil, err
 	}
 

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -114,6 +114,10 @@ func TestScheduler_Submit_NewStack(t *testing.T) {
 	err := s.Submit(context.Background(), &scheduler.App{
 		ID:   "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name: "acme-inc",
+		Labels: map[string]string{
+			"empire.app.id":   "c9366591-ab68-4d49-a333-95ce5a23df68",
+			"empire.app.name": "acme-inc",
+		},
 		Processes: []*scheduler.Process{
 			{
 				Type:      "web",

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -177,7 +177,7 @@ func (t *EmpireTemplate) Validate() error {
 
 // Execute builds the template, and writes it to w.
 func (t *EmpireTemplate) Execute(w io.Writer, data interface{}) error {
-	v, err := t.Build(data.(*scheduler.App))
+	v, err := t.Build(data.(*TemplateData))
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,9 @@ func (t *EmpireTemplate) Execute(w io.Writer, data interface{}) error {
 }
 
 // Build builds a Go representation of a CloudFormation template for the app.
-func (t *EmpireTemplate) Build(app *scheduler.App) (*troposphere.Template, error) {
+func (t *EmpireTemplate) Build(data *TemplateData) (*troposphere.Template, error) {
+	app := data.App
+
 	tmpl := troposphere.NewTemplate()
 
 	tmpl.Parameters["DNS"] = troposphere.Parameter{
@@ -249,7 +251,7 @@ func (t *EmpireTemplate) Build(app *scheduler.App) (*troposphere.Template, error
 				scheduledProcesses[p.Type] = taskDefinition.Name
 			}
 		default:
-			service, err := t.addService(tmpl, app, p)
+			service, err := t.addService(tmpl, app, p, data.StackTags)
 			if err != nil {
 				return tmpl, err
 			}
@@ -371,7 +373,7 @@ func (t *EmpireTemplate) addScheduledTask(tmpl *troposphere.Template, app *sched
 	return taskDefinition
 }
 
-func (t *EmpireTemplate) addService(tmpl *troposphere.Template, app *scheduler.App, p *scheduler.Process) (serviceName string, err error) {
+func (t *EmpireTemplate) addService(tmpl *troposphere.Template, app *scheduler.App, p *scheduler.Process, stackTags []*cloudformation.Tag) (serviceName string, err error) {
 	key := processResourceName(p.Type)
 
 	// Process specific tags to apply to resources.
@@ -416,7 +418,7 @@ func (t *EmpireTemplate) addService(tmpl *troposphere.Template, app *scheduler.A
 						"Scheme":         scheme,
 						"SecurityGroups": []string{sg},
 						"Subnets":        subnets,
-						"Tags":           tags,
+						"Tags":           append(stackTags, tags...),
 					},
 				},
 			}
@@ -430,7 +432,7 @@ func (t *EmpireTemplate) addService(tmpl *troposphere.Template, app *scheduler.A
 					"Port":     65535, // Not used. ECS sets a port override when registering targets.
 					"Protocol": "HTTP",
 					"VpcId":    t.VpcId,
-					"Tags":     tags,
+					"Tags":     append(stackTags, tags...),
 				},
 			}
 
@@ -849,12 +851,22 @@ func (p fmtPorts) String() string {
 	return strings.Join(mappings, ", ")
 }
 
-// tagsFromLabels generates a list of CloudFormation tags from the labels.
+// cloudformationTags implements the sort.Interface interface to sort the labels
+// variables by key in alphabetical order.
+type cloudformationTags []*cloudformation.Tag
+
+func (e cloudformationTags) Len() int           { return len(e) }
+func (e cloudformationTags) Less(i, j int) bool { return *e[i].Key < *e[j].Key }
+func (e cloudformationTags) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
+
+// tagsFromLabels generates a list of CloudFormation tags from the labels, it
+// also sorts the tags by key.
 func tagsFromLabels(labels map[string]string) []*cloudformation.Tag {
-	tags := []*cloudformation.Tag{}
+	tags := cloudformationTags{}
 	for k, v := range labels {
 		tags = append(tags, &cloudformation.Tag{Key: aws.String(k), Value: aws.String(v)})
 	}
+	sort.Sort(tags)
 	return tags
 }
 

--- a/scheduler/cloudformation/template_test.go
+++ b/scheduler/cloudformation/template_test.go
@@ -197,6 +197,9 @@ func TestEmpireTemplate(t *testing.T) {
 					{
 						Type:    "web",
 						Command: []string{"./bin/web"},
+						Labels: map[string]string{
+							"empire.app.process": "web",
+						},
 						Env: map[string]string{
 							"PORT":               "8080",
 							"LOAD_BALANCER_TYPE": "alb",
@@ -221,6 +224,9 @@ func TestEmpireTemplate(t *testing.T) {
 					{
 						Type:    "api",
 						Command: []string{"./bin/api"},
+						Labels: map[string]string{
+							"empire.app.process": "api",
+						},
 						Env: map[string]string{
 							"PORT": "8080",
 							"EMPIRE_X_LOAD_BALANCER_TYPE": "alb",

--- a/scheduler/cloudformation/templates/basic-alb.json
+++ b/scheduler/cloudformation/templates/basic-alb.json
@@ -190,6 +190,12 @@
       "Properties": {
         "Port": 65535,
         "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "empire.app.process",
+            "Value": "web"
+          }
+        ],
         "VpcId": ""
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup"

--- a/scheduler/cloudformation/templates/basic-alb.json
+++ b/scheduler/cloudformation/templates/basic-alb.json
@@ -134,6 +134,10 @@
         ],
         "Tags": [
           {
+            "Key": "environment",
+            "Value": "test"
+          },
+          {
             "Key": "empire.app.process",
             "Value": "web"
           }
@@ -191,6 +195,10 @@
         "Port": 65535,
         "Protocol": "HTTP",
         "Tags": [
+          {
+            "Key": "environment",
+            "Value": "test"
+          },
           {
             "Key": "empire.app.process",
             "Value": "web"

--- a/scheduler/cloudformation/templates/https-alb.json
+++ b/scheduler/cloudformation/templates/https-alb.json
@@ -134,6 +134,10 @@
         ],
         "Tags": [
           {
+            "Key": "environment",
+            "Value": "test"
+          },
+          {
             "Key": "empire.app.process",
             "Value": "api"
           }
@@ -228,6 +232,10 @@
         "Protocol": "HTTP",
         "Tags": [
           {
+            "Key": "environment",
+            "Value": "test"
+          },
+          {
             "Key": "empire.app.process",
             "Value": "api"
           }
@@ -288,6 +296,10 @@
           "subnet-c85f4091"
         ],
         "Tags": [
+          {
+            "Key": "environment",
+            "Value": "test"
+          },
           {
             "Key": "empire.app.process",
             "Value": "web"
@@ -370,6 +382,10 @@
         "Port": 65535,
         "Protocol": "HTTP",
         "Tags": [
+          {
+            "Key": "environment",
+            "Value": "test"
+          },
           {
             "Key": "empire.app.process",
             "Value": "web"

--- a/scheduler/cloudformation/templates/https-alb.json
+++ b/scheduler/cloudformation/templates/https-alb.json
@@ -226,6 +226,12 @@
       "Properties": {
         "Port": 65535,
         "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "empire.app.process",
+            "Value": "api"
+          }
+        ],
         "VpcId": ""
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup"
@@ -241,7 +247,8 @@
             "DockerLabels": {
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
-              }
+              },
+              "empire.app.process": "api"
             },
             "Environment": [
               {
@@ -362,6 +369,12 @@
       "Properties": {
         "Port": 65535,
         "Protocol": "HTTP",
+        "Tags": [
+          {
+            "Key": "empire.app.process",
+            "Value": "web"
+          }
+        ],
         "VpcId": ""
       },
       "Type": "AWS::ElasticLoadBalancingV2::TargetGroup"
@@ -377,7 +390,8 @@
             "DockerLabels": {
               "cloudformation.restart-key": {
                 "Ref": "RestartKey"
-              }
+              },
+              "empire.app.process": "web"
             },
             "Environment": [
               {

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -181,12 +181,7 @@
           "subnet-bb01c4cd",
           "subnet-c85f4091"
         ],
-        "Tags": [
-          {
-            "Key": "empire.app.process",
-            "Value": "api"
-          }
-        ]
+        "Tags": []
       },
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
     },
@@ -302,12 +297,7 @@
           "subnet-bb01c4cd",
           "subnet-c85f4091"
         ],
-        "Tags": [
-          {
-            "Key": "empire.app.process",
-            "Value": "web"
-          }
-        ]
+        "Tags": []
       },
       "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
     },


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/1002

This does a couple things:

1. All of the apps labels are now set as tags on the stack (this will add the `empire.app.release` tag)
2. All of the process specific labels will be set on process specific resources that support tags (e.g. ALB/ELB/TargetGroup)
3. ALB's will get the stack tags applied directly to them, since CloudFormation currently does not do this for ALB/TargetGroups. With that said, even with this, CloudFormation sometimes doesn't actually apply the tags to the ALB even though it's clearly in the template...if I delete the stack then re-create it, the tags usually get applied.

This a nice side effect, in that if we add `labels` to the extended Procfile, then those labels could get added as tags on the resources automatically.