### PR TITLE
Create ALIAS records for each exposed process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Features**
 
 * The extended Procfile format now allows you to attach a load balancer to any process in the Procfile. [#800](https://github.com/remind101/empire/pull/800)
+* An ALIAS record is now created for `<process>.<app>.<zone>` [#1005](https://github.com/remind101/empire/pull/1005)
 
 **Improvements**
 

--- a/scheduler/cloudformation/templates/basic-alb.json
+++ b/scheduler/cloudformation/templates/basic-alb.json
@@ -122,6 +122,30 @@
       },
       "Type": "AWS::Route53::RecordSet"
     },
+    "webAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "webApplicationLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "webApplicationLoadBalancer",
+              "CanonicalHostedZoneID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "web.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
     "webApplicationLoadBalancer": {
       "Properties": {
         "Scheme": "internal",

--- a/scheduler/cloudformation/templates/basic.json
+++ b/scheduler/cloudformation/templates/basic.json
@@ -129,6 +129,30 @@
       "Type": "Custom::InstancePort",
       "Version": "1.0"
     },
+    "webAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "CanonicalHostedZoneNameID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "web.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
     "webLoadBalancer": {
       "Properties": {
         "ConnectionDrainingPolicy": {

--- a/scheduler/cloudformation/templates/custom.json
+++ b/scheduler/cloudformation/templates/custom.json
@@ -256,6 +256,30 @@
       "Type": "Custom::InstancePort",
       "Version": "1.0"
     },
+    "webAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "CanonicalHostedZoneNameID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "web.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
     "webEnvironment": {
       "Properties": {
         "Environment": [

--- a/scheduler/cloudformation/templates/https-alb.json
+++ b/scheduler/cloudformation/templates/https-alb.json
@@ -122,6 +122,30 @@
       },
       "Type": "AWS::Route53::RecordSet"
     },
+    "apiAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "apiApplicationLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "apiApplicationLoadBalancer",
+              "CanonicalHostedZoneID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "api.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
     "apiApplicationLoadBalancer": {
       "Properties": {
         "Scheme": "internal",
@@ -269,6 +293,30 @@
         "Volumes": []
       },
       "Type": "AWS::ECS::TaskDefinition"
+    },
+    "webAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "webApplicationLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "webApplicationLoadBalancer",
+              "CanonicalHostedZoneID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "web.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
     },
     "webApplicationLoadBalancer": {
       "Properties": {

--- a/scheduler/cloudformation/templates/https.json
+++ b/scheduler/cloudformation/templates/https.json
@@ -129,6 +129,30 @@
       "Type": "Custom::InstancePort",
       "Version": "1.0"
     },
+    "apiAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "apiLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "apiLoadBalancer",
+              "CanonicalHostedZoneNameID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "api.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
     "apiLoadBalancer": {
       "Properties": {
         "ConnectionDrainingPolicy": {
@@ -261,6 +285,30 @@
       },
       "Type": "Custom::InstancePort",
       "Version": "1.0"
+    },
+    "webAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "CanonicalHostedZoneNameID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "web.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
     },
     "webLoadBalancer": {
       "Properties": {


### PR DESCRIPTION
Also closes https://github.com/remind101/empire/issues/796

For every process that is exposed, an ALIAS record will be created as `<process>.<app>.<zone>`  that points to the load balancer.

For backwards compatibility, I'm keeping the special case CNAME that is created for `<app>.<zone>` for "web" procs, but I think moving forward, the more specific `<process>.<app>.<zone>` record should be used. If a less specific `<app>.<zone>` is desired, it can be created outside of Empire to point to `<process>.<app>.<zone>`, which can make transitioning between different processes (without downtime) very easy (e.g. if you want to switch to an ALB, you can create a new `web2` process that uses an ALB, then update `<app>.<zone>` to point to `web2.<app>.<zone>`)