### PR TITLE
Allow certs to be attached to specific processes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build
 .env*
 *.swp
-release
+*.dump

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * The extended Procfile format now allows you to attach a load balancer to any process in the Procfile. [#800](https://github.com/remind101/empire/pull/800)
 * An ALIAS record is now created for `<process>.<app>.<zone>` [#1005](https://github.com/remind101/empire/pull/1005)
+* You can now provide a `-p` flag to the `emp cert-attach` command to attach a certificate to a specific process (instead of just `web`). [#1014](https://github.com/remind101/empire/pull/1014)
 
 **Improvements**
 

--- a/certs.go
+++ b/certs.go
@@ -9,8 +9,18 @@ type certsService struct {
 	*Empire
 }
 
-func (s *certsService) CertsAttach(ctx context.Context, db *gorm.DB, app *App, cert string) error {
-	app.Cert = cert
+func (s *certsService) CertsAttach(ctx context.Context, db *gorm.DB, opts CertsAttachOpts) error {
+	app := opts.App
+	if app.Certs == nil {
+		app.Certs = make(Certs)
+	}
+
+	process := opts.Process
+	if process == "" {
+		process = webProcessType
+	}
+
+	app.Certs[process] = opts.Cert
 
 	if err := appsUpdate(db, app); err != nil {
 		return err

--- a/cmd/emp/apps.go
+++ b/cmd/emp/apps.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -137,9 +138,19 @@ func listApp(w io.Writer, a hkapp) {
 	}
 	listRec(w,
 		a.Name,
-		a.Cert,
+		fmtCerts(a.Certs),
 		prettyTime{t},
 	)
+}
+
+type fmtCerts map[string]string
+
+func (certs fmtCerts) String() string {
+	var p []string
+	for process, cert := range certs {
+		p = append(p, fmt.Sprintf("%s=%s", process, cert))
+	}
+	return strings.Join(p, ",")
 }
 
 type appsByName []hkapp
@@ -165,7 +176,7 @@ type hkapp struct {
 	Stack                        string
 	UpdatedAt                    time.Time
 	WebURL                       string
-	Cert                         string
+	Certs                        map[string]string
 }
 
 func fromApp(app heroku.App) (happ hkapp) {
@@ -190,7 +201,7 @@ func fromApp(app heroku.App) (happ hkapp) {
 		Stack:                        app.Stack.Name,
 		UpdatedAt:                    app.UpdatedAt,
 		WebURL:                       app.WebURL,
-		Cert:                         app.Cert,
+		Certs:                        app.Certs,
 	}
 }
 

--- a/cmd/emp/certs.go
+++ b/cmd/emp/certs.go
@@ -6,6 +6,10 @@ import (
 	"github.com/remind101/empire/pkg/heroku"
 )
 
+var (
+	process string
+)
+
 var cmdCertAttach = &Command{
 	Run:      runCertAttach,
 	Usage:    "cert-attach <aws_cert_arn>",
@@ -20,10 +24,16 @@ Before running this command, you should upload your SSL certificate and key to I
 Examples:
 
     $ aws iam upload-server-certificate --server-certificate-name myServerCertificate --certificate-body file://public_key_cert_file.pem --private-key file://my_private_key.pem --certificate-chain file://my_certificate_chain_file.pem
-	# ^^ The above command will return the ARN of the certificate, you'll need that for the command below
-	# Say it returns the arn arn:aws:iam::123456789012:server-certificate/myServerCertificate, you'd use that like this:
-	$ emp cert-attach arn:aws:iam::123456789012:server-certificate/myServerCertificate -a myapp
+    # ^^ The above command will return the ARN of the certificate, you'll need that for the command below
+    # Say it returns the arn arn:aws:iam::123456789012:server-certificate/myServerCertificate, you'd use that like this:
+    $ emp cert-attach arn:aws:iam::123456789012:server-certificate/myServerCertificate -a myapp
+    # By default, this will attach the certifcate to a process named "web". You can override that with the -p flag:
+    $ emp cert-attach myServerCertificate -p http -a myapp
 `,
+}
+
+func init() {
+	cmdCertAttach.Flag.StringVarP(&process, "process", "p", "", "process name")
 }
 
 func runCertAttach(cmd *Command, args []string) {
@@ -34,8 +44,12 @@ func runCertAttach(cmd *Command, args []string) {
 
 	cert := args[0]
 
-	_, err := client.AppUpdate(mustApp(), &heroku.AppUpdateOpts{
+	opts := &heroku.CertsAttachOpts{
 		Cert: &cert,
-	})
+	}
+	if process != "" {
+		opts.Process = &process
+	}
+	err := client.CertsAttach(mustApp(), opts)
 	must(err)
 }

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -29,7 +29,7 @@ func TestMigrations(t *testing.T) {
 }
 
 func TestLatestSchema(t *testing.T) {
-	assert.Equal(t, 18, latestSchema())
+	assert.Equal(t, 19, latestSchema())
 }
 
 func TestNoDuplicateMigrations(t *testing.T) {

--- a/pkg/heroku/app.go
+++ b/pkg/heroku/app.go
@@ -67,6 +67,9 @@ type App struct {
 
 	// certificate for the app
 	Cert string `json:"cert,omitempty"`
+
+	// maps a process name to a certificate to use for it.
+	Certs map[string]string `json:"certs,omitempty"`
 }
 
 // Create a new app.
@@ -136,6 +139,6 @@ type AppUpdateOpts struct {
 	Maintenance *bool `json:"maintenance,omitempty"`
 	// unique name of app
 	Name *string `json:"name,omitempty"`
-	// certificate for the app
+	// DEPRECATED:
 	Cert *string `json:"cert,omitempty"`
 }

--- a/pkg/heroku/app_test.go
+++ b/pkg/heroku/app_test.go
@@ -2,6 +2,7 @@ package heroku
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -79,7 +80,7 @@ func TestAppInfoSuccess(t *testing.T) {
 		t.Fatal("no app object returned")
 	}
 	var emptyapp App
-	if *app == emptyapp {
+	if reflect.DeepEqual(*app, emptyapp) {
 		t.Errorf("returned app is empty")
 	}
 }
@@ -112,7 +113,7 @@ func TestAppListSuccess(t *testing.T) {
 		t.Fatalf("expected 1 app, got %d", len(apps))
 	}
 	var emptyapp App
-	if apps[0] == emptyapp {
+	if reflect.DeepEqual(apps[0], emptyapp) {
 		t.Errorf("returned app is empty")
 	}
 }
@@ -171,7 +172,7 @@ func TestAppCreateSuccess(t *testing.T) {
 		t.Fatal("no app object returned")
 	}
 	var emptyapp App
-	if *app == emptyapp {
+	if reflect.DeepEqual(*app, emptyapp) {
 		t.Errorf("returned app is empty")
 	}
 
@@ -204,7 +205,7 @@ func TestAppCreateSuccessWithOpts(t *testing.T) {
 		t.Fatal("no app object returned")
 	}
 	var emptyapp App
-	if *app == emptyapp {
+	if reflect.DeepEqual(*app, emptyapp) {
 		t.Errorf("returned app is empty")
 	}
 
@@ -287,7 +288,7 @@ func TestAppUpdateSuccess(t *testing.T) {
 		t.Fatal("no app object returned")
 	}
 	var emptyapp App
-	if *app == emptyapp {
+	if reflect.DeepEqual(*app, emptyapp) {
 		t.Errorf("returned app is empty")
 	}
 

--- a/pkg/heroku/certs.go
+++ b/pkg/heroku/certs.go
@@ -1,0 +1,10 @@
+package heroku
+
+func (c *Client) CertsAttach(appIdentity string, options *CertsAttachOpts) error {
+	return c.Post(nil, "/apps/"+appIdentity+"/certs", options)
+}
+
+type CertsAttachOpts struct {
+	Cert    *string `json:"cert,omitempty"`
+	Process *string `json:"process,omitempty"`
+}

--- a/runner.go
+++ b/runner.go
@@ -86,8 +86,14 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 	}
 	proc.SetConstraints(constraints)
 
-	a := newSchedulerApp(release)
-	p := newSchedulerProcess(release, procName, proc)
+	a, err := newSchedulerApp(release)
+	if err != nil {
+		return err
+	}
+	p, err := newSchedulerProcess(release, procName, proc)
+	if err != nil {
+		return err
+	}
 	p.Labels["empire.user"] = opts.User.Name
 
 	// Add additional environment variables to the process.

--- a/server/heroku/apps.go
+++ b/server/heroku/apps.go
@@ -18,7 +18,8 @@ func newApp(a *empire.App) *App {
 		Id:        a.ID,
 		Name:      a.Name,
 		CreatedAt: *a.CreatedAt,
-		Cert:      a.Cert,
+		Cert:      a.Certs["web"], // For backwards compatibility.
+		Certs:     a.Certs,
 	}
 }
 
@@ -130,8 +131,12 @@ func (h *Server) PatchApp(ctx context.Context, w http.ResponseWriter, r *http.Re
 		return err
 	}
 
+	// DEPRECATED: For backwards compatibility with older emp clients.
 	if form.Cert != nil {
-		if err := h.CertsAttach(ctx, a, *form.Cert); err != nil {
+		if err := h.CertsAttach(ctx, empire.CertsAttachOpts{
+			App:  a,
+			Cert: *form.Cert,
+		}); err != nil {
 			return err
 		}
 	}

--- a/server/heroku/certs.go
+++ b/server/heroku/certs.go
@@ -1,0 +1,36 @@
+package heroku
+
+import (
+	"net/http"
+
+	"github.com/remind101/empire"
+	"github.com/remind101/empire/pkg/heroku"
+	"golang.org/x/net/context"
+)
+
+func (h *Server) PostCerts(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	a, err := findApp(ctx, h)
+	if err != nil {
+		return err
+	}
+
+	var form heroku.CertsAttachOpts
+
+	if err := Decode(r, &form); err != nil {
+		return err
+	}
+
+	opts := empire.CertsAttachOpts{
+		App:  a,
+		Cert: *form.Cert,
+	}
+	if form.Process != nil {
+		opts.Process = *form.Process
+	}
+
+	if err := h.CertsAttach(ctx, opts); err != nil {
+		return err
+	}
+
+	return Encode(w, nil)
+}

--- a/server/heroku/heroku.go
+++ b/server/heroku/heroku.go
@@ -88,6 +88,9 @@ func New(e *empire.Empire) *Server {
 	// OAuth
 	r.handle("POST", "/oauth/authorizations", r.PostAuthorizations)
 
+	// Certs
+	r.handle("POST", "/apps/{app}/certs", r.PostCerts)
+
 	// SSL
 	sslRemoved := errHandler(ErrSSLRemoved)
 	r.mux.Handle("/apps/{app}/ssl-endpoints", sslRemoved).Methods("GET")           // hk ssl

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -49,12 +49,27 @@ func TestEmpire_CertsAttach(t *testing.T) {
 	assert.NoError(t, err)
 
 	cert := "serverCertificate"
-	err = e.CertsAttach(context.Background(), app, cert)
+	err = e.CertsAttach(context.Background(), empire.CertsAttachOpts{
+		App:  app,
+		Cert: cert,
+	})
 	assert.NoError(t, err)
 
 	app, err = e.AppsFind(empire.AppsQuery{ID: &app.ID})
 	assert.NoError(t, err)
-	assert.Equal(t, cert, app.Cert)
+	assert.Equal(t, empire.Certs{"web": "serverCertificate"}, app.Certs)
+
+	cert = "otherCertificate"
+	err = e.CertsAttach(context.Background(), empire.CertsAttachOpts{
+		App:     app,
+		Cert:    cert,
+		Process: "http",
+	})
+	assert.NoError(t, err)
+
+	app, err = e.AppsFind(empire.AppsQuery{ID: &app.ID})
+	assert.NoError(t, err)
+	assert.Equal(t, empire.Certs{"web": "serverCertificate", "http": "otherCertificate"}, app.Certs)
 
 	s.AssertExpectations(t)
 }


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/1013

With the addition of the `ports` key in the extended Procfile, it makes more sense to be able to attach a certificate to a process within the app, rather than the app itself. This is supported in the backend (CloudFormation scheduler), so this is just UI to expose it in the frontend.

This will allow you to attach different certificates to different processes (only 1 cert per process is allowed, since that's the case with ELB/ALB).

This should be fully backwards compatible with older emp clients. If the `-p` flag isn't provided, it just defaults to attaching the cert to the `web` proc:

```console
$ emp cert-attach webCert -a acme-inc
$ emp cert-attach apiCert -p api -a acme-inc
$ emp apps 
acme-inc  web=webCert,api=apiCert  Aug 25 19:02
```