### PR TITLE
Canonical user id's (company email)

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -27,6 +27,7 @@ const (
 	FlagGithubOrg          = "github.organization"
 	FlagGithubApiURL       = "github.api.url"
 	FlagGithubTeam         = "github.team.id"
+	FlagGithubIDDomain     = "github.id.domain"
 
 	FlagGithubWebhooksSecret           = "github.webhooks.secret"
 	FlagGithubDeploymentsEnvironments  = "github.deployments.environment"
@@ -120,6 +121,12 @@ var Commands = []cli.Command{
 				Value:  "",
 				Usage:  "The ID of the github team to allow access to",
 				EnvVar: "EMPIRE_GITHUB_TEAM_ID",
+			},
+			cli.StringFlag{
+				Name:   FlagGithubIDDomain,
+				Value:  "",
+				Usage:  "If provided, the GitHub authentication backend will look for an email on GitHub user that matches this domain, then use that email as the id.",
+				EnvVar: "EMPIRE_GITHUB_ID_DOMAIN",
 			},
 			cli.StringFlag{
 				Name:   FlagGithubApiURL,

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -127,7 +127,7 @@ func newAuth(c *Context, e *empire.Empire) *auth.Auth {
 		config := &oauth2.Config{
 			ClientID:     c.String(FlagGithubClient),
 			ClientSecret: c.String(FlagGithubClientSecret),
-			Scopes:       []string{"repo_deployment", "read:org"},
+			Scopes:       []string{"repo_deployment", "read:org", "user:email"},
 		}
 
 		client = githubauth.NewClient(config)
@@ -141,7 +141,11 @@ func newAuth(c *Context, e *empire.Empire) *auth.Auth {
 
 		// an authenticator for authenticating requests with a users github
 		// credentials.
-		authenticators = append(authenticators, githubauth.NewAuthenticator(client))
+		authenticator := githubauth.NewAuthenticator(client)
+		if domain := c.String(FlagGithubIDDomain); domain != "" {
+			authenticator.IDFunc = githubauth.EmailDomainID(domain)
+		}
+		authenticators = append(authenticators, authenticator)
 	}
 
 	// build the authentication chain.

--- a/server/auth/github/client_test.go
+++ b/server/auth/github/client_test.go
@@ -167,6 +167,16 @@ func TestClient_GetUser(t *testing.T) {
 		Body:       ioutil.NopCloser(bytes.NewBufferString(`{"login":"ejholmes"}`)),
 	}, nil)
 
+	req, _ = http.NewRequest("GET", "https://api.github.com/user/emails", nil)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.SetBasicAuth("access_token", "x-oauth-basic")
+
+	h.On("Do", req).Return(&http.Response{
+		Request:    req,
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(`[{"email":"octocat@github.com","verified":true,"primary":true}]`)),
+	}, nil)
+
 	user, err := c.GetUser("access_token")
 	assert.NoError(t, err)
 	assert.Equal(t, "ejholmes", user.Login)

--- a/server/auth/github/github_test.go
+++ b/server/auth/github/github_test.go
@@ -28,6 +28,7 @@ func TestAuthenticator(t *testing.T) {
 	user, err := a.Authenticate("username", "password", "otp")
 	assert.NoError(t, err)
 	assert.Equal(t, "ejholmes", user.Name)
+	assert.Equal(t, "ejholmes", user.ID)
 	assert.Equal(t, "access_token", user.GitHubToken)
 }
 
@@ -120,6 +121,23 @@ func TestTeamAuthorizer_Unauthorized(t *testing.T) {
 	})
 	assert.IsType(t, &auth.UnauthorizedError{}, err)
 	assert.EqualError(t, err, `ejholmes is not a member of team 123.`)
+}
+
+func TestEmailDomainID(t *testing.T) {
+	id, err := EmailDomainID("remind101.com")(&User{
+		Emails: []string{
+			"eric@remind101.com",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "eric@remind101.com", id)
+
+	id, err = EmailDomainID("remind101.com")(&User{
+		Emails: []string{
+			"eric@example.org",
+		},
+	})
+	assert.Error(t, err)
 }
 
 type mockClient struct {

--- a/users.go
+++ b/users.go
@@ -2,6 +2,9 @@ package empire
 
 // User represents a user of Empire.
 type User struct {
+	// Unique identifier for this User.
+	ID string `json:"id"`
+
 	// Name is the users username.
 	Name string `json:"name"`
 


### PR DESCRIPTION
https://github.com/remind101/empire/pull/989 is difficult to implement right now, because there's not an easy way to map an Empire user to a Duo account.

With this change, you can make the GitHub authentication backend use emails as canonical user id's, by setting an email domain. For example, if we set the email domain to `acme-inc.com`, then it will set the internal Empire user ID as `<employee>@acme-inc.com` assuming that GitHub account has a verified `@acme-inc.com` email, which we can then use with the Duo integration to map that directly to a Duo user account. Since an employee's email is their canonical user identity across most systems, this might work well, and easier than a full blown user management system. Thoughts?
