### PR TITLE
Onelogin authentication backend

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -25,9 +25,15 @@ const (
 
 	FlagServerAuth = "server.auth"
 
-	FlagSAMLMetadata       = "saml.metadata"
-	FlagSAMLKey            = "saml.key"
-	FlagSAMLCert           = "saml.cert"
+	FlagSAMLMetadata = "saml.metadata"
+	FlagSAMLKey      = "saml.key"
+	FlagSAMLCert     = "saml.cert"
+
+	FlagOneloginClientID     = "onelogin.client.id"
+	FlagOneloginClientSecret = "onelogin.client.secret"
+	FlagOneloginAppID        = "onelogin.app.id"
+	FlagOneloginSubdomain    = "onelogin.subdomain"
+
 	FlagGithubClient       = "github.client.id"
 	FlagGithubClientSecret = "github.client.secret"
 	FlagGithubOrg          = "github.organization"
@@ -132,6 +138,30 @@ var Commands = []cli.Command{
 				Value:  "",
 				Usage:  "The location of the public key for this service provider. (e.g. file:///etc/empire/saml.cert)",
 				EnvVar: "EMPIRE_SAML_CERT",
+			},
+			cli.StringFlag{
+				Name:   FlagOneloginClientID,
+				Value:  "",
+				Usage:  "The client id for Onelogin to generate API access tokens",
+				EnvVar: "EMPIRE_ONELOGIN_CLIENT_ID",
+			},
+			cli.StringFlag{
+				Name:   FlagOneloginClientSecret,
+				Value:  "",
+				Usage:  "The client secret for Onelogin to generate API access tokens",
+				EnvVar: "EMPIRE_ONELOGIN_CLIENT_SECRET",
+			},
+			cli.StringFlag{
+				Name:   FlagOneloginAppID,
+				Value:  "",
+				Usage:  "The Onelogin SAML app id",
+				EnvVar: "EMPIRE_ONELOGIN_APP_ID",
+			},
+			cli.StringFlag{
+				Name:   FlagOneloginSubdomain,
+				Value:  "",
+				Usage:  "The subdomain of the onelogin app",
+				EnvVar: "EMPIRE_ONELOGIN_SUBDOMAIN",
 			},
 			cli.StringFlag{
 				Name:   FlagGithubClient,

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/remind101/empire/server"
 	"github.com/remind101/empire/server/auth"
 	githubauth "github.com/remind101/empire/server/auth/github"
+	oneloginauth "github.com/remind101/empire/server/auth/onelogin"
 	"github.com/remind101/empire/server/cloudformation"
 	"github.com/remind101/empire/server/github"
 	"github.com/remind101/empire/server/heroku"
@@ -89,6 +90,11 @@ func newServer(c *Context, e *empire.Empire) http.Handler {
 
 	if sp != nil {
 		s.ServiceProvider = sp
+	}
+
+	// When the SAML auth backend us used, we want to disable the `You can
+	// login with emp login` message.
+	if c.String(FlagServerAuth) == "saml" {
 		s.Heroku.Unauthorized = heroku.SAMLUnauthorized(c.String(FlagURL) + "/saml/login")
 	}
 
@@ -206,7 +212,7 @@ func newAuth(c *Context, e *empire.Empire) *auth.Auth {
 		// When using the SAML authentication backend, access tokens are
 		// created through the browser, so username/password
 		// authentication should be disabled.
-		usernamePasswordDisabled := auth.AuthenticatorFunc(func(username, password, otp string) (*empire.User, error) {
+		usernamePasswordDisabled := auth.AuthenticatorFunc(func(username, password, otp string) (*auth.Session, error) {
 			return nil, fmt.Errorf("Authentication via username/password is disabled. Login at %s", loginURL)
 		})
 
@@ -218,6 +224,24 @@ func newAuth(c *Context, e *empire.Empire) *auth.Auth {
 					// Ensure that this strategy isn't used
 					// by default.
 					Disabled: true,
+				},
+			},
+		}
+	case "onelogin":
+		sp, err := c.SAMLServiceProvider()
+		if err != nil {
+			panic(err)
+		}
+
+		authenticator := oneloginauth.NewAuthenticator(sp, c.String(FlagOneloginClientID), c.String(FlagOneloginClientSecret))
+		authenticator.AppID = c.String(FlagOneloginAppID)
+		authenticator.Subdomain = c.String(FlagOneloginSubdomain)
+
+		return &auth.Auth{
+			Strategies: auth.Strategies{
+				{
+					Name:          auth.StrategyUsernamePassword,
+					Authenticator: authenticator,
 				},
 			},
 		}

--- a/pkg/onelogin/onelogin.go
+++ b/pkg/onelogin/onelogin.go
@@ -1,0 +1,293 @@
+// Pacakge onelogin implements a client for the onelogin API.
+//
+// https://developers.onelogin.com/api-docs/1/getting-started/dev-overview
+package onelogin
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Default OneLogin region.
+const DefaultRegion = "us"
+
+// accessToken represents an API Access Token that will be used to authenticate
+// requests.
+type accessToken struct {
+	token     string
+	expiresAt time.Time
+}
+
+// Returns true if the token is expired.
+func (t *accessToken) isExpired() bool {
+	return time.Now().After(t.expiresAt)
+}
+
+// Client implements an http client around the OneLogin API
+//
+// https://developers.onelogin.com/api-docs/1/getting-started/dev-overview
+type Client struct {
+	Region string
+
+	ClientID, ClientSecret string
+
+	mu          sync.Mutex // Protects the access token.
+	accessToken *accessToken
+
+	client *http.Client
+}
+
+func New(c *http.Client) *Client {
+	if c == nil {
+		c = http.DefaultClient
+	}
+
+	return &Client{
+		client: c,
+	}
+}
+
+// ResponseMeta represents a OneLogin API response.
+type ResponseMeta struct {
+	Status struct {
+		Error   bool   `json:"error"`
+		Code    int    `json:"code"`
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"status"`
+}
+
+// Error is returned when the Onelogin API returns an error.
+type Error struct {
+	ResponseMeta
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	return fmt.Sprintf("onelogin: unexpected response %d (%s): %s", e.Status.Code, e.Status.Type, e.Status.Message)
+}
+
+type GenerateTokenOptions struct {
+	GrantType string `json:"grant_type"`
+}
+
+type GenerateTokenResponse struct {
+	ResponseMeta
+	Data []*GenerateTokenData `json:"data"`
+}
+
+type GenerateTokenData struct {
+	AccessToken  string    `json:"access_token"`
+	CreatedAt    time.Time `json:"created_at"`
+	ExpiresIn    int       `json:"expires_in"`
+	RefreshToken string    `json:"refresh_token"`
+	TokenType    string    `json:"token_type"`
+	AccountID    int       `json:"account_id"`
+}
+
+func (c *Client) GenerateToken(options GenerateTokenOptions) (*GenerateTokenResponse, error) {
+	req, err := c.NewRequest("POST", "/auth/oauth2/token", options)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("client_id:%s, client_secret:%s", c.ClientID, c.ClientSecret))
+
+	var resp GenerateTokenResponse
+	_, err = c.do(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+type GenerateSAMLAssertionOptions struct {
+	UsernameOrEmail string  `json:"username_or_email"`
+	Password        string  `json:"password"`
+	AppID           string  `json:"app_id"`
+	Subdomain       string  `json:"subdomain"`
+	IPAddress       *string `json:"ip_address,omitempty"`
+}
+
+type GenerateSAMLAssertionResponse struct {
+	ResponseMeta
+	Data interface{} `json:"data"`
+}
+
+func (r *GenerateSAMLAssertionResponse) UnmarshalJSON(b []byte) error {
+	type alias GenerateSAMLAssertionResponse
+	var a alias
+
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+
+	if a.Status.Message == "MFA is required for this user" {
+		var data struct {
+			Data []*GenerateSAMLAssertionMFAData `json:"data"`
+		}
+		if err := json.Unmarshal(b, &data); err != nil {
+			return err
+		}
+		a.Data = data.Data
+	}
+
+	*r = GenerateSAMLAssertionResponse(a)
+
+	return nil
+}
+
+type Device struct {
+	DeviceID       int     `json:"device_id"`
+	DeviceType     string  `json:"device_type"`
+	DuoSigRequest  *string `json:"duo_sig_request"`
+	DuoApiHostname *string `json:"duo_api_hostname"`
+}
+
+type User struct {
+	ID        int    `json:"id"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	FirstName string `json:"firstname"`
+	LastName  string `json:"lastname"`
+}
+
+type GenerateSAMLAssertionMFAData struct {
+	StateToken  string    `json:"state_token"`
+	Devices     []*Device `json:"devices"`
+	CallbackURL string    `json:"callback_url"`
+	User        *User     `json:"user"`
+}
+
+// GenerateSAMLAssertion generates a SAML assertion and returns the response
+func (c *Client) GenerateSAMLAssertion(options GenerateSAMLAssertionOptions) (*GenerateSAMLAssertionResponse, error) {
+	req, err := c.NewRequest("POST", "/api/1/saml_assertion", options)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp GenerateSAMLAssertionResponse
+	_, err = c.Do(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+type VerifyFactorSAMLOptions struct {
+	AppID      string  `json:"app_id"`
+	DeviceID   string  `json:"device_id"`
+	StateToken string  `json:"state_token"`
+	OTPToken   *string `json:"otp_token,omitempty"`
+}
+
+type VerifyFactorSAMLResponse struct {
+	ResponseMeta
+	Data string `json:"data"`
+}
+
+func (c *Client) VerifyFactorSAML(options VerifyFactorSAMLOptions) (*VerifyFactorSAMLResponse, error) {
+	req, err := c.NewRequest("POST", "/api/1/saml_assertion/verify_factor", options)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp VerifyFactorSAMLResponse
+	_, err = c.Do(req, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (c *Client) NewRequest(method, path string, v interface{}) (*http.Request, error) {
+	region := c.Region
+	if region == "" {
+		region = DefaultRegion
+	}
+
+	var r io.Reader
+	switch v := v.(type) {
+	case io.Reader:
+		r = v
+	default:
+		if v != nil {
+			raw, err := json.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			r = bytes.NewReader(raw)
+		}
+	}
+
+	req, err := http.NewRequest(method, fmt.Sprintf("https://api.%s.onelogin.com/%s", region, path), r)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
+	if err := c.authorize(req); err != nil {
+		return nil, err
+	}
+
+	return c.do(req, v)
+}
+
+func (c *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode/100 != 2 {
+		defer resp.Body.Close()
+		var e Error
+		if err := json.NewDecoder(resp.Body).Decode(&e); err != nil {
+			return resp, fmt.Errorf("onelogin: decode error: %v", err)
+		}
+		return resp, &e
+	}
+
+	if v != nil {
+		defer resp.Body.Close()
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return resp, fmt.Errorf("onelogin: decode response: %v", err)
+		}
+	}
+
+	return resp, nil
+}
+
+func (c *Client) authorize(req *http.Request) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.accessToken == nil || c.accessToken.isExpired() {
+		resp, err := c.GenerateToken(GenerateTokenOptions{
+			GrantType: "client_credentials",
+		})
+		if err != nil {
+			return fmt.Errorf("generate client credentials (client_id %q): %v", c.ClientID, err)
+		}
+
+		d := resp.Data[0]
+		c.accessToken = &accessToken{
+			token:     d.AccessToken,
+			expiresAt: d.CreatedAt.Add(time.Duration(d.ExpiresIn) * time.Second),
+		}
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("bearer:%s", c.accessToken.token))
+	return nil
+}

--- a/pkg/onelogin/onelogin_test.go
+++ b/pkg/onelogin/onelogin_test.go
@@ -1,0 +1,61 @@
+package onelogin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateSAMLAssertionResponse_Success(t *testing.T) {
+	b := `{
+    "status": {
+        "type": "success",
+        "message": "Success",
+        "error": false,
+        "code": 200 
+    },
+   "data": "PHNhb+P..."
+    }`
+
+	var resp GenerateSAMLAssertionResponse
+	err := json.Unmarshal([]byte(b), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, "PHNhb+P...", resp.Data)
+}
+
+func TestGenerateSAMLAssertionResponse_MFA(t *testing.T) {
+	b := `{
+    "status": {
+        "type": "success",
+        "message": "MFA is required for this user",
+        "code": 200,
+        "error": false
+    },
+    "data": [
+        {
+            "state_token": "5xxx604x8xx9x694xx860173xxx3x78x3x870x56",
+            "devices": [
+                {
+                    "device_id": 666666,
+                    "device_type": "Google Authenticator"
+                }
+            ],
+            "callback_url": "https://api.us.onelogin.com/api/1/saml_assertion/verify_factor",
+            "user": {
+                "lastname": "Zhang",
+                "username": "hzhang123",
+                "email": "hazel.zhang@onelogin.com",
+                "firstname": "Hazel",
+                "id": 88888888
+            }
+        }
+    ]
+}`
+
+	var resp GenerateSAMLAssertionResponse
+	err := json.Unmarshal([]byte(b), &resp)
+	assert.NoError(t, err)
+	data := resp.Data.([]*GenerateSAMLAssertionMFAData)
+	assert.Equal(t, "5xxx604x8xx9x694xx860173xxx3x78x3x870x56", data[0].StateToken)
+}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/remind101/empire"
 )
@@ -122,15 +123,15 @@ func (a *Auth) Authenticate(ctx context.Context, username, password, otp string,
 }
 
 func (a *Auth) authenticate(ctx context.Context, authenticator Authenticator, username, password, otp string) (context.Context, error) {
-	user, err := authenticator.Authenticate(username, password, otp)
+	session, err := authenticator.Authenticate(username, password, otp)
 	if err != nil {
 		return ctx, err
 	}
 
-	ctx = WithUser(ctx, user)
+	ctx = WithSession(ctx, session)
 
 	if a.Authorizer != nil {
-		if err := a.Authorizer.Authorize(user); err != nil {
+		if err := a.Authorizer.Authorize(session.User); err != nil {
 			return ctx, err
 		}
 	}
@@ -138,19 +139,33 @@ func (a *Auth) authenticate(ctx context.Context, authenticator Authenticator, us
 	return ctx, nil
 }
 
+// Session represents an authenticated Session.
+type Session struct {
+	// The authenticated User.
+	User *empire.User
+
+	// When this Session will expire. The zero value means no expiration.
+	ExpiresAt *time.Time
+}
+
+// NewSession returns a new Session for the user.
+func NewSession(user *empire.User) *Session {
+	return &Session{User: user}
+}
+
 // Authenticator represents something that, given a username, password and OTP
 // can authenticate an Empire user.
 type Authenticator interface {
-	// Authenticate should check the credentials and return the Empire user.
-	Authenticate(username, password, twofactor string) (*empire.User, error)
+	// Authenticate should check the credentials and return a login Session.
+	Authenticate(username, password, twofactor string) (*Session, error)
 }
 
 // AuthenticatorFunc is a function signature that implements the Authenticator
 // interface.
-type AuthenticatorFunc func(string, string, string) (*empire.User, error)
+type AuthenticatorFunc func(string, string, string) (*Session, error)
 
 // Authenticate calls the AuthenticatorFunc.
-func (fn AuthenticatorFunc) Authenticate(username, password, otp string) (*empire.User, error) {
+func (fn AuthenticatorFunc) Authenticate(username, password, otp string) (*Session, error) {
 	return fn(username, password, otp)
 }
 
@@ -170,7 +185,7 @@ func (fn AuthorizerFunc) Authorize(user *empire.User) error {
 // StaticAuthenticator returns an Authenticator that returns the provided user
 // when the given credentials are provided.
 func StaticAuthenticator(username, password, otp string, user *empire.User) Authenticator {
-	return AuthenticatorFunc(func(givenUsername, givenPassword, givenOtp string) (*empire.User, error) {
+	return AuthenticatorFunc(func(givenUsername, givenPassword, givenOtp string) (*Session, error) {
 		if givenUsername != username {
 			return nil, ErrForbidden
 		}
@@ -183,15 +198,15 @@ func StaticAuthenticator(username, password, otp string, user *empire.User) Auth
 			return nil, ErrTwoFactor
 		}
 
-		return user, nil
+		return NewSession(user), nil
 	})
 }
 
 // Anyone returns an Authenticator that let's anyone in and sets them as the
 // given user.
 func Anyone(user *empire.User) Authenticator {
-	return AuthenticatorFunc(func(username, password, otp string) (*empire.User, error) {
-		return user, nil
+	return AuthenticatorFunc(func(username, password, otp string) (*Session, error) {
+		return NewSession(user), nil
 	})
 }
 
@@ -201,13 +216,13 @@ func Anyone(user *empire.User) Authenticator {
 // It will proceed to the next authenticator when the error returned is
 // ErrForbidden. Any other errors are bubbled up (e.g. ErrTwoFactor).
 func MultiAuthenticator(authenticators ...Authenticator) Authenticator {
-	return AuthenticatorFunc(func(username, password, otp string) (*empire.User, error) {
+	return AuthenticatorFunc(func(username, password, otp string) (*Session, error) {
 		for _, authenticator := range authenticators {
-			user, err := authenticator.Authenticate(username, password, otp)
+			session, err := authenticator.Authenticate(username, password, otp)
 
 			// No error so we're authenticated.
 			if err == nil {
-				return user, nil
+				return session, nil
 			}
 
 			// Try the next authenticator.
@@ -228,19 +243,25 @@ func MultiAuthenticator(authenticators ...Authenticator) Authenticator {
 type key int
 
 const (
-	userKey key = iota
+	sessionKey key = iota
 )
 
-// WithUser adds a user to the context.Context.
-func WithUser(ctx context.Context, u *empire.User) context.Context {
-	return context.WithValue(ctx, userKey, u)
+// WithSession embeds the authentication Session in the context.Context.
+func WithSession(ctx context.Context, session *Session) context.Context {
+	return context.WithValue(ctx, sessionKey, session)
 }
 
 // UserFromContext returns a user from a context.Context if one is present.
 func UserFromContext(ctx context.Context) *empire.User {
-	u, ok := ctx.Value(userKey).(*empire.User)
+	session := SessionFromContext(ctx)
+	return session.User
+}
+
+// SessionFromContext returns the embedded Session in the context.Context.
+func SessionFromContext(ctx context.Context) *Session {
+	session, ok := ctx.Value(sessionKey).(*Session)
 	if !ok {
 		panic("expected user to be authenticated")
 	}
-	return u
+	return session
 }

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -12,34 +12,35 @@ func TestStaticAuthenticator(t *testing.T) {
 	u := &empire.User{}
 	a := StaticAuthenticator("username", "password", "otp", u)
 
-	user, err := a.Authenticate("badusername", "password", "otp")
+	session, err := a.Authenticate("badusername", "password", "otp")
 	assert.Equal(t, ErrForbidden, err)
-	assert.Nil(t, user)
+	assert.Nil(t, session)
 
-	user, err = a.Authenticate("username", "badpassword", "otp")
+	session, err = a.Authenticate("username", "badpassword", "otp")
 	assert.Equal(t, ErrForbidden, err)
-	assert.Nil(t, user)
+	assert.Nil(t, session)
 
-	user, err = a.Authenticate("username", "password", "badotp")
+	session, err = a.Authenticate("username", "password", "badotp")
 	assert.Equal(t, ErrTwoFactor, err)
-	assert.Nil(t, user)
+	assert.Nil(t, session)
 
-	user, err = a.Authenticate("username", "password", "otp")
+	session, err = a.Authenticate("username", "password", "otp")
 	assert.NoError(t, err)
-	assert.Equal(t, u, user)
+	assert.Equal(t, NewSession(u), session)
 }
 
 func TestMultiAuthenticator_First(t *testing.T) {
 	u := &empire.User{}
+	s := NewSession(u)
 	a1 := new(mockAuthenticator)
 	a2 := new(mockAuthenticator)
 	a := MultiAuthenticator(a1, a2)
 
-	a1.On("Authenticate", "username", "password", "").Return(&empire.User{}, nil)
+	a1.On("Authenticate", "username", "password", "").Return(s, nil)
 
-	user, err := a.Authenticate("username", "password", "")
+	session, err := a.Authenticate("username", "password", "")
 	assert.NoError(t, err)
-	assert.Equal(t, u, user)
+	assert.Equal(t, s, session)
 
 	a1.AssertExpectations(t)
 	a2.AssertExpectations(t)
@@ -47,16 +48,17 @@ func TestMultiAuthenticator_First(t *testing.T) {
 
 func TestMultiAuthenticator_Second(t *testing.T) {
 	u := &empire.User{}
+	s := NewSession(u)
 	a1 := new(mockAuthenticator)
 	a2 := new(mockAuthenticator)
 	a := MultiAuthenticator(a1, a2)
 
 	a1.On("Authenticate", "username", "password", "").Return(nil, ErrForbidden)
-	a2.On("Authenticate", "username", "password", "").Return(&empire.User{}, nil)
+	a2.On("Authenticate", "username", "password", "").Return(s, nil)
 
-	user, err := a.Authenticate("username", "password", "")
+	session, err := a.Authenticate("username", "password", "")
 	assert.NoError(t, err)
-	assert.Equal(t, u, user)
+	assert.Equal(t, s, session)
 
 	a1.AssertExpectations(t)
 	a2.AssertExpectations(t)
@@ -97,11 +99,11 @@ type mockAuthenticator struct {
 	mock.Mock
 }
 
-func (m *mockAuthenticator) Authenticate(username, password, otp string) (*empire.User, error) {
+func (m *mockAuthenticator) Authenticate(username, password, otp string) (*Session, error) {
 	args := m.Called(username, password, otp)
-	user := args.Get(0)
-	if user != nil {
-		return user.(*empire.User), args.Error(1)
+	session := args.Get(0)
+	if session != nil {
+		return session.(*Session), args.Error(1)
 	}
 	return nil, args.Error(1)
 }

--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -26,7 +26,7 @@ func NewAuthenticator(c *Client) *Authenticator {
 	return &Authenticator{client: c}
 }
 
-func (a *Authenticator) Authenticate(username, password, otp string) (*empire.User, error) {
+func (a *Authenticator) Authenticate(username, password, otp string) (*auth.Session, error) {
 	authorization, err := a.client.CreateAuthorization(CreateAuthorizationOptions{
 		Username: username,
 		Password: password,
@@ -48,10 +48,12 @@ func (a *Authenticator) Authenticate(username, password, otp string) (*empire.Us
 		return nil, err
 	}
 
-	return &empire.User{
+	user := &empire.User{
 		Name:        u.Login,
 		GitHubToken: authorization.Token,
-	}, nil
+	}
+
+	return auth.NewSession(user), nil
 }
 
 // OrganizationAuthorizer is an implementation of the auth.Authorizer interface

--- a/server/auth/github/github_test.go
+++ b/server/auth/github/github_test.go
@@ -25,10 +25,10 @@ func TestAuthenticator(t *testing.T) {
 		Login: "ejholmes",
 	}, nil)
 
-	user, err := a.Authenticate("username", "password", "otp")
+	session, err := a.Authenticate("username", "password", "otp")
 	assert.NoError(t, err)
-	assert.Equal(t, "ejholmes", user.Name)
-	assert.Equal(t, "access_token", user.GitHubToken)
+	assert.Equal(t, "ejholmes", session.User.Name)
+	assert.Equal(t, "access_token", session.User.GitHubToken)
 }
 
 func TestAuthenticator_ErrTwoFactor(t *testing.T) {
@@ -40,9 +40,9 @@ func TestAuthenticator_ErrTwoFactor(t *testing.T) {
 		Password: "password",
 	}).Return(nil, errTwoFactor)
 
-	user, err := a.Authenticate("username", "password", "")
+	session, err := a.Authenticate("username", "password", "")
 	assert.Equal(t, auth.ErrTwoFactor, err)
-	assert.Nil(t, user)
+	assert.Nil(t, session)
 }
 
 func TestAuthenticator_ErrForbidden(t *testing.T) {
@@ -54,9 +54,9 @@ func TestAuthenticator_ErrForbidden(t *testing.T) {
 		Password: "badpassword",
 	}).Return(nil, errUnauthorized)
 
-	user, err := a.Authenticate("username", "badpassword", "")
+	session, err := a.Authenticate("username", "badpassword", "")
 	assert.Equal(t, auth.ErrForbidden, err)
-	assert.Nil(t, user)
+	assert.Nil(t, session)
 }
 
 func TestOrganizationAuthorizer(t *testing.T) {

--- a/server/auth/onelogin/onelogin.go
+++ b/server/auth/onelogin/onelogin.go
@@ -1,0 +1,118 @@
+// Package onelogin implements an auth.Authenticator for OneLogin delegated
+// authentication using SAML.
+package onelogin
+
+import (
+	"fmt"
+
+	"github.com/remind101/empire/pkg/onelogin"
+	"github.com/remind101/empire/pkg/saml"
+	"github.com/remind101/empire/server/auth"
+	samlauth "github.com/remind101/empire/server/auth/saml"
+)
+
+// oneloginClient duck types the interface that we need from onelogin.Client.
+type oneloginClient interface {
+	GenerateSAMLAssertion(options onelogin.GenerateSAMLAssertionOptions) (*onelogin.GenerateSAMLAssertionResponse, error)
+	VerifyFactorSAML(options onelogin.VerifyFactorSAMLOptions) (*onelogin.VerifyFactorSAMLResponse, error)
+}
+
+type serviceProvider interface {
+	ParseSAMLResponse(string, []string) (*saml.Assertion, error)
+}
+
+// Authenticator implements the auth.Authenticator interface.
+type Authenticator struct {
+	// Onelogin SAML app id.
+	AppID string
+
+	// Onelogin subdomain.
+	Subdomain string
+
+	onelogin oneloginClient
+
+	// ServiceProvider that will be used to verify the SAML response.
+	sp serviceProvider
+}
+
+// NewAuthenticator returns a new Authenticator instance backed by the given
+// client.
+func NewAuthenticator(sp *saml.ServiceProvider, clientID, clientSecret string) *Authenticator {
+	c := onelogin.New(nil)
+	c.ClientID = clientID
+	c.ClientSecret = clientSecret
+
+	return &Authenticator{
+		onelogin: c,
+		sp:       sp,
+	}
+}
+
+func (a *Authenticator) Authenticate(username, password, otp string) (*auth.Session, error) {
+	resp, err := a.onelogin.GenerateSAMLAssertion(onelogin.GenerateSAMLAssertionOptions{
+		UsernameOrEmail: username,
+		Password:        password,
+		AppID:           a.AppID,
+		Subdomain:       a.Subdomain,
+	})
+	if err != nil {
+		return nil, handleAuthError(err)
+	}
+
+	var samlResponse string
+	switch v := resp.Data.(type) {
+	case []*onelogin.GenerateSAMLAssertionMFAData:
+		// MFA is required, so if we don't have an otp, we can't
+		// continue.
+		if otp == "" {
+			return nil, auth.ErrTwoFactor
+		}
+
+		if len(v) != 1 {
+			return nil, fmt.Errorf("onelogin: unexpected number of GenerateSAMLAssertionMFAData: %d", len(v))
+		}
+
+		data := v[0]
+
+		if len(data.Devices) <= 0 {
+			return nil, fmt.Errorf("onelogin: MFA is required, but user has no devices")
+		}
+
+		// TODO: There could be multiple devices here. What do we do in
+		// that case?
+		device := data.Devices[0]
+
+		resp, err := a.onelogin.VerifyFactorSAML(onelogin.VerifyFactorSAMLOptions{
+			AppID:      a.AppID,
+			DeviceID:   fmt.Sprintf("%d", device.DeviceID),
+			StateToken: data.StateToken,
+			OTPToken:   &otp,
+		})
+		if err != nil {
+			return nil, handleAuthError(err)
+		}
+
+		samlResponse = resp.Data
+	case string:
+		samlResponse = v
+	}
+
+	assertion, err := a.sp.ParseSAMLResponse(samlResponse, []string{""})
+	if err != nil {
+		return nil, err
+	}
+
+	return samlauth.SessionFromAssertion(assertion), nil
+}
+
+// handleAuthError handles a onelogin API error. If the error is a 401, then we
+// return auth.Forbidden.
+func handleAuthError(err error) error {
+	if err, ok := err.(*onelogin.Error); ok {
+		switch err.Status.Code {
+		case 401:
+			return auth.ErrForbidden
+		}
+	}
+	return err
+}

--- a/server/auth/onelogin/onelogin_test.go
+++ b/server/auth/onelogin/onelogin_test.go
@@ -1,0 +1,224 @@
+package onelogin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/remind101/empire/pkg/onelogin"
+	"github.com/remind101/empire/pkg/saml"
+	"github.com/remind101/empire/server/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAuthenticator(t *testing.T) {
+	sp := new(mockServiceProvider)
+	c := new(mockOnelogin)
+	a := &Authenticator{
+		AppID:     "1234",
+		Subdomain: "acme",
+		sp:        sp,
+		onelogin:  c,
+	}
+
+	c.On("GenerateSAMLAssertion", onelogin.GenerateSAMLAssertionOptions{
+		UsernameOrEmail: "username",
+		Password:        "password",
+		AppID:           "1234",
+		Subdomain:       "acme",
+	}).Return(&onelogin.GenerateSAMLAssertionResponse{
+		Data: `SAMLResponse`,
+	}, nil)
+
+	session, err := a.Authenticate("username", "password", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "ejholmes", session.User.Name)
+	assert.NotNil(t, session.ExpiresAt)
+}
+
+func TestAuthenticator_BadUsernamePassword(t *testing.T) {
+	sp := new(mockServiceProvider)
+	c := new(mockOnelogin)
+	a := &Authenticator{
+		AppID:     "1234",
+		Subdomain: "acme",
+		sp:        sp,
+		onelogin:  c,
+	}
+
+	var meta onelogin.ResponseMeta
+	meta.Status.Code = 401
+	c.On("GenerateSAMLAssertion", onelogin.GenerateSAMLAssertionOptions{
+		UsernameOrEmail: "username",
+		Password:        "password",
+		AppID:           "1234",
+		Subdomain:       "acme",
+	}).Return(nil, &onelogin.Error{
+		ResponseMeta: meta,
+	})
+
+	_, err := a.Authenticate("username", "password", "")
+	assert.Equal(t, auth.ErrForbidden, err)
+}
+
+func TestAuthenticator_WithOTP(t *testing.T) {
+	sp := new(mockServiceProvider)
+	c := new(mockOnelogin)
+	a := &Authenticator{
+		AppID:     "1234",
+		Subdomain: "acme",
+		sp:        sp,
+		onelogin:  c,
+	}
+
+	c.On("GenerateSAMLAssertion", onelogin.GenerateSAMLAssertionOptions{
+		UsernameOrEmail: "username",
+		Password:        "password",
+		AppID:           "1234",
+		Subdomain:       "acme",
+	}).Return(&onelogin.GenerateSAMLAssertionResponse{
+		Data: []*onelogin.GenerateSAMLAssertionMFAData{
+			{
+				StateToken: "5xxx604x8xx9x694xx860173xxx3x78x3x870x56",
+				Devices: []*onelogin.Device{
+					{
+						DeviceID:   666666,
+						DeviceType: "Duo",
+					},
+				},
+			},
+		},
+	}, nil)
+
+	otp := "otp"
+	c.On("VerifyFactorSAML", onelogin.VerifyFactorSAMLOptions{
+		AppID:      "1234",
+		StateToken: "5xxx604x8xx9x694xx860173xxx3x78x3x870x56",
+		DeviceID:   "666666",
+		OTPToken:   &otp,
+	}).Return(&onelogin.VerifyFactorSAMLResponse{
+		Data: `<SAMLResponse>`,
+	}, nil)
+
+	session, err := a.Authenticate("username", "password", "otp")
+	assert.NoError(t, err)
+	assert.Equal(t, "ejholmes", session.User.Name)
+	assert.NotNil(t, session.ExpiresAt)
+}
+
+func TestAuthenticator_BadOTP(t *testing.T) {
+	sp := new(mockServiceProvider)
+	c := new(mockOnelogin)
+	a := &Authenticator{
+		AppID:     "1234",
+		Subdomain: "acme",
+		sp:        sp,
+		onelogin:  c,
+	}
+
+	c.On("GenerateSAMLAssertion", onelogin.GenerateSAMLAssertionOptions{
+		UsernameOrEmail: "username",
+		Password:        "password",
+		AppID:           "1234",
+		Subdomain:       "acme",
+	}).Return(&onelogin.GenerateSAMLAssertionResponse{
+		Data: []*onelogin.GenerateSAMLAssertionMFAData{
+			{
+				StateToken: "5xxx604x8xx9x694xx860173xxx3x78x3x870x56",
+				Devices: []*onelogin.Device{
+					{
+						DeviceID:   666666,
+						DeviceType: "Duo",
+					},
+				},
+			},
+		},
+	}, nil)
+
+	otp := "otp"
+	var meta onelogin.ResponseMeta
+	meta.Status.Code = 401
+	meta.Status.Type = "Unauthorized"
+	meta.Status.Message = "Failed authentication with this factor"
+	c.On("VerifyFactorSAML", onelogin.VerifyFactorSAMLOptions{
+		AppID:      "1234",
+		StateToken: "5xxx604x8xx9x694xx860173xxx3x78x3x870x56",
+		DeviceID:   "666666",
+		OTPToken:   &otp,
+	}).Return(nil, &onelogin.Error{
+		ResponseMeta: meta,
+	})
+
+	_, err := a.Authenticate("username", "password", "otp")
+	assert.Equal(t, auth.ErrForbidden, err)
+}
+
+func TestAuthenticator_MissingOTP(t *testing.T) {
+	sp := new(mockServiceProvider)
+	c := new(mockOnelogin)
+	a := &Authenticator{
+		AppID:     "1234",
+		Subdomain: "acme",
+		sp:        sp,
+		onelogin:  c,
+	}
+
+	c.On("GenerateSAMLAssertion", onelogin.GenerateSAMLAssertionOptions{
+		UsernameOrEmail: "username",
+		Password:        "password",
+		AppID:           "1234",
+		Subdomain:       "acme",
+	}).Return(&onelogin.GenerateSAMLAssertionResponse{
+		Data: []*onelogin.GenerateSAMLAssertionMFAData{
+			{
+				StateToken: "5xxx604x8xx9x694xx860173xxx3x78x3x870x56",
+				Devices: []*onelogin.Device{
+					{
+						DeviceID:   666666,
+						DeviceType: "Duo",
+					},
+				},
+			},
+		},
+	}, nil)
+
+	_, err := a.Authenticate("username", "password", "")
+	assert.Equal(t, auth.ErrTwoFactor, err)
+}
+
+type mockOnelogin struct {
+	mock.Mock
+}
+
+func (m *mockOnelogin) GenerateSAMLAssertion(options onelogin.GenerateSAMLAssertionOptions) (*onelogin.GenerateSAMLAssertionResponse, error) {
+	args := m.Called(options)
+	var resp *onelogin.GenerateSAMLAssertionResponse
+	if v := args.Get(0); v != nil {
+		resp = v.(*onelogin.GenerateSAMLAssertionResponse)
+	}
+	return resp, args.Error(1)
+}
+
+func (m *mockOnelogin) VerifyFactorSAML(options onelogin.VerifyFactorSAMLOptions) (*onelogin.VerifyFactorSAMLResponse, error) {
+	args := m.Called(options)
+	var resp *onelogin.VerifyFactorSAMLResponse
+	if v := args.Get(0); v != nil {
+		resp = v.(*onelogin.VerifyFactorSAMLResponse)
+	}
+	return resp, args.Error(1)
+}
+
+type mockServiceProvider struct{}
+
+func (m *mockServiceProvider) ParseSAMLResponse(samlResponse string, possibleRequestIds []string) (*saml.Assertion, error) {
+	return &saml.Assertion{
+		Subject: &saml.Subject{
+			NameID: &saml.NameID{
+				Value: "ejholmes",
+			},
+		},
+		AuthnStatement: &saml.AuthnStatement{
+			SessionNotOnOrAfter: time.Now().Add(24 * time.Hour),
+		},
+	}, nil
+}

--- a/server/auth/saml/saml.go
+++ b/server/auth/saml/saml.go
@@ -1,0 +1,20 @@
+package saml
+
+import (
+	"github.com/remind101/empire"
+	"github.com/remind101/empire/pkg/saml"
+	"github.com/remind101/empire/server/auth"
+)
+
+// SessionFromAssertion returns a new auth.Session generated from the SAML
+// assertion.
+func SessionFromAssertion(assertion *saml.Assertion) *auth.Session {
+	login := assertion.Subject.NameID.Value
+	user := &empire.User{
+		Name: login,
+	}
+
+	session := auth.NewSession(user)
+	session.ExpiresAt = &assertion.AuthnStatement.SessionNotOnOrAfter
+	return session
+}

--- a/server/heroku/authentication.go
+++ b/server/heroku/authentication.go
@@ -102,7 +102,7 @@ type accessTokenAuthenticator struct {
 
 // Authenticate authenticates the access token, which should be provided as the
 // password parameter. Username and otp are ignored.
-func (a *accessTokenAuthenticator) Authenticate(_ string, token string, _ string) (*empire.User, error) {
+func (a *accessTokenAuthenticator) Authenticate(_ string, token string, _ string) (*auth.Session, error) {
 	at, err := a.findAccessToken(token)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,12 @@ func (a *accessTokenAuthenticator) Authenticate(_ string, token string, _ string
 		return nil, auth.ErrForbidden
 	}
 
-	return at.User, nil
+	session := &auth.Session{
+		User:      at.User,
+		ExpiresAt: at.ExpiresAt,
+	}
+
+	return session, nil
 }
 
 // AccessTokensCreate "creates" the token by jwt signing it and setting the

--- a/server/heroku/authentication_test.go
+++ b/server/heroku/authentication_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/server/auth"
@@ -48,7 +49,7 @@ func TestServer_Authenticate_UsernamePassword(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.SetBasicAuth("username", "password")
 
-	a.On("Authenticate", "username", "password", "").Return(&empire.User{}, nil)
+	a.On("Authenticate", "username", "password", "").Return(auth.NewSession(&empire.User{}), nil)
 
 	_, err := m.Authenticate(ctx, req)
 	assert.NoError(t, err)
@@ -75,7 +76,7 @@ func TestServer_Authenticate_WithStrategy(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.SetBasicAuth("username", "password")
 
-	a.On("Authenticate", "username", "password", "").Return(&empire.User{}, nil)
+	a.On("Authenticate", "username", "password", "").Return(auth.NewSession(&empire.User{}), nil)
 
 	_, err := m.Authenticate(ctx, req)
 	assert.NoError(t, err)
@@ -94,7 +95,7 @@ func TestServer_Authenticate_UsernamePasswordWithOTP(t *testing.T) {
 	req.SetBasicAuth("username", "password")
 	req.Header.Set("Heroku-Two-Factor-Code", "otp")
 
-	a.On("Authenticate", "username", "password", "otp").Return(&empire.User{}, nil)
+	a.On("Authenticate", "username", "password", "otp").Return(auth.NewSession(&empire.User{}), nil)
 
 	_, err := m.Authenticate(ctx, req)
 	assert.NoError(t, err)
@@ -156,9 +157,10 @@ func TestAccessTokenAuthenticator(t *testing.T) {
 		},
 	}
 
-	user, err := a.Authenticate("", "token", "")
+	s := auth.NewSession(u)
+	session, err := a.Authenticate("", "token", "")
 	assert.NoError(t, err)
-	assert.Equal(t, u, user)
+	assert.Equal(t, s, session)
 }
 
 func TestAccessTokenAuthenticator_TokenNotFound(t *testing.T) {
@@ -169,9 +171,30 @@ func TestAccessTokenAuthenticator_TokenNotFound(t *testing.T) {
 		},
 	}
 
-	user, err := a.Authenticate("", "token", "")
+	session, err := a.Authenticate("", "token", "")
 	assert.Equal(t, auth.ErrForbidden, err)
-	assert.Nil(t, user)
+	assert.Nil(t, session)
+}
+
+func TestAccessTokenAuthenticator_WithExpiresAt(t *testing.T) {
+	exp := time.Now().Add(24 * time.Hour)
+
+	u := &empire.User{}
+	a := &accessTokenAuthenticator{
+		findAccessToken: func(token string) (*AccessToken, error) {
+			assert.Equal(t, "token", token)
+			return &AccessToken{
+				User:      u,
+				ExpiresAt: &exp,
+			}, nil
+		},
+	}
+
+	s := auth.NewSession(u)
+	s.ExpiresAt = &exp
+	session, err := a.Authenticate("", "token", "")
+	assert.NoError(t, err)
+	assert.Equal(t, s, session)
 }
 
 func TestAccessTokensFind(t *testing.T) {
@@ -192,11 +215,11 @@ type mockAuthenticator struct {
 	mock.Mock
 }
 
-func (m *mockAuthenticator) Authenticate(username, password, otp string) (*empire.User, error) {
+func (m *mockAuthenticator) Authenticate(username, password, otp string) (*auth.Session, error) {
 	args := m.Called(username, password, otp)
-	user := args.Get(0)
-	if user != nil {
-		return user.(*empire.User), args.Error(1)
+	session := args.Get(0)
+	if session != nil {
+		return session.(*auth.Session), args.Error(1)
 	}
 	return nil, args.Error(1)
 

--- a/server/heroku/oauth.go
+++ b/server/heroku/oauth.go
@@ -33,8 +33,11 @@ func newAuthorization(token *AccessToken) *Authorization {
 }
 
 func (h *Server) PostAuthorizations(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	session := auth.SessionFromContext(ctx)
+
 	at, err := h.AccessTokensCreate(&AccessToken{
-		User: auth.UserFromContext(ctx),
+		User:      session.User,
+		ExpiresAt: session.ExpiresAt,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This compliments the SAML authentication backend added in https://github.com/remind101/empire/pull/1017, with a Onelogin extension using the [Generate SAML assertion](https://developers.onelogin.com/api-docs/1/saml-assertions/generate-saml-assertion) API of Onelogin. This allows users to use `emp login` to perform SAML authentication, instead of using the browser flow.

With that said, this currently doesn't work for me because Duo devices are apparently broken in the Onelogin API. Onelogin has verified that it is broken, but I've yet to hear back from them one what they're doing to fix it.