### PR TITLE
Check response of GetUser

### DIFF
--- a/server/auth/github/client.go
+++ b/server/auth/github/client.go
@@ -148,7 +148,12 @@ func (c *Client) GetUser(token string) (*User, error) {
 
 	var u User
 
-	if _, err := c.Do(req, &u); err != nil {
+	resp, err := c.Do(req, &u)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := checkResponse(resp); err != nil {
 		return nil, err
 	}
 

--- a/server/auth/github/client_test.go
+++ b/server/auth/github/client_test.go
@@ -172,6 +172,27 @@ func TestClient_GetUser(t *testing.T) {
 	assert.Equal(t, "ejholmes", user.Login)
 }
 
+func TestClient_GetUser_Error(t *testing.T) {
+	h := new(mockHTTPClient)
+	c := &Client{
+		Config: oauthConfig,
+		client: h,
+	}
+
+	req, _ := http.NewRequest("GET", "https://api.github.com/user", nil)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.SetBasicAuth("access_token", "x-oauth-basic")
+
+	h.On("Do", req).Return(&http.Response{
+		Request:    req,
+		StatusCode: http.StatusNotFound,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(`{"message":"not found"}`)),
+	}, nil)
+
+	_, err := c.GetUser("access_token")
+	assert.Error(t, err)
+}
+
 func TestClient_IsOrganizationMember(t *testing.T) {
 	tests := []struct {
 		status int


### PR DESCRIPTION
This previously wasn't bubbling up the response error, which would result in a cryptic error message when authenticating (https://github.com/remind101/empire/issues/1026).

I'm not sure why this endpoint occasionally errors, but this should expose that.