### PR TITLE
Retry requests to api.github.com/user with backoff

### DIFF
--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -39,13 +39,13 @@ func (a *Authenticator) Authenticate(username, password, otp string) (*auth.Sess
 		case errUnauthorized:
 			return nil, auth.ErrForbidden
 		default:
-			return nil, err
+			return nil, fmt.Errorf("unable to create github authorization: %v", err)
 		}
 	}
 
 	u, err := a.client.GetUser(authorization.Token)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to fetch GitHub user information: %v", err)
 	}
 
 	user := &empire.User{
@@ -79,7 +79,7 @@ func (a *OrganizationAuthorizer) Authorize(user *empire.User) error {
 
 	ok, err := a.client.IsOrganizationMember(a.Organization, user.GitHubToken)
 	if err != nil {
-		return err
+		return fmt.Errorf("error checking organization membership: %v", err)
 	}
 
 	if !ok {
@@ -112,7 +112,7 @@ func (a *TeamAuthorizer) Authorize(user *empire.User) error {
 
 	ok, err := a.client.IsTeamMember(a.TeamID, user.GitHubToken)
 	if err != nil {
-		return err
+		return fmt.Errorf("error checking team membership: %v", err)
 	}
 
 	if !ok {


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/1026 (I think)

I was originally thinking that using `fingerprint` in the authorizations API would be the way to go, but that would require a bigger change, since the GitHub token is only returned if the authorization is new. We'd have to store GitHub tokens somewhere.

This should help/fix the given issue, and retry calls to /user if they return an error.