### PR TITLE
Increase stack operation timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `emp env-load` now handles multi-line environment variables. [#990](https://github.com/remind101/empire/pull/990)
 * In preparation for the 0.12 release, the legacy ECS scheduler has been removed. [#1001](https://github.com/remind101/empire/pull/1001)
 * All application labels are set on the CloudFormation stack, rather than just `empire.app.id` and `empire.app.name`. In addition, ALB's will get stack tags applied to them. [#1004](https://github.com/remind101/empire/pull/1004)
+* The lock timeout for CloudFormation stack operations has been increased [#1030](https://github.com/remind101/empire/pull/1030)
 
 **Bugs**
 

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -56,7 +56,7 @@ var (
 
 	// Controls the maximum amount of time we'll wait for a stack operation to
 	// complete before releasing the lock.
-	stackOperationTimeout = 10 * time.Minute
+	stackOperationTimeout = 1 * time.Hour
 
 	// Controls how long we'll wait between requests to describe services when
 	// waiting for a deployment to stabilize


### PR DESCRIPTION
10 minutes is a little too aggressive, since CloudFormation gets slow sometimes. 1 hour is a little more reasonable, this just prevents Empire from getting in a stuck state and holding onto the stack operation lock indefinitely.