### PR TITLE
GitHub auth: Fail fast if username/password aren't provided.

### DIFF
--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -27,6 +27,12 @@ func NewAuthenticator(c *Client) *Authenticator {
 }
 
 func (a *Authenticator) Authenticate(username, password, otp string) (*auth.Session, error) {
+	// GitHub authentication is guaranteed to fail if one of these are not
+	// present, so fail fast and avoid making an HTTP request.
+	if username == "" || password == "" {
+		return nil, auth.ErrForbidden
+	}
+
 	authorization, err := a.client.CreateAuthorization(CreateAuthorizationOptions{
 		Username: username,
 		Password: password,

--- a/server/auth/github/github_test.go
+++ b/server/auth/github/github_test.go
@@ -31,6 +31,16 @@ func TestAuthenticator(t *testing.T) {
 	assert.Equal(t, "access_token", session.User.GitHubToken)
 }
 
+func TestAuthenticator_FailFast(t *testing.T) {
+	a := &Authenticator{}
+
+	_, err := a.Authenticate("username", "", "")
+	assert.Equal(t, err, auth.ErrForbidden)
+
+	_, err = a.Authenticate("", "password", "")
+	assert.Equal(t, err, auth.ErrForbidden)
+}
+
 func TestAuthenticator_ErrTwoFactor(t *testing.T) {
 	c := new(mockClient)
 	a := &Authenticator{client: c}


### PR DESCRIPTION
This is just a small optimization to the GitHub authentication backend, that allows it to fail fast if a username or password aren't provided, since we know it will fail to create an authorization.