### PR TITLE
Ignore invalid TD when rolling back

### DIFF
--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/mitchellh/hashstructure"
 	"github.com/remind101/empire/pkg/cloudformation/customresources"
+	"github.com/remind101/pkg/logger"
 	"github.com/remind101/pkg/reporter"
 )
 
@@ -121,7 +122,10 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.
 				err = fmt.Errorf("no primary deployment found")
 			}
 		} else {
-			if err, ok := err.(awserr.Error); ok && strings.Contains(err.Message(), "TaskDefinition is inactive") {
+			logger.Info(ctx, "cloudformation.service.update.error",
+				"error", err.Message(),
+			)
+			if strings.Contains(err.Message(), "TaskDefinition is inactive") {
 				err = nil
 			}
 		}

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -123,7 +123,8 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.
 			}
 		} else {
 			logger.Info(ctx, "cloudformation.service.update.error",
-				"error", err.Message(),
+				"error_type", reflect.TypeOf(err),
+				"error_msg", err.Error(),
 			)
 			if strings.Contains(err.Message(), "TaskDefinition is inactive") {
 				err = nil

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -122,8 +122,6 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.
 			}
 		} else {
 			if err, ok := err.(awserr.Error); ok && strings.Contains(err.Message(), "TaskDefinition is inactive") {
-				d := primaryDeployment(resp.Service)
-				data["DeploymentId"] = *d.Id
 				err = nil
 			}
 		}

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -120,6 +120,12 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.
 			} else {
 				err = fmt.Errorf("no primary deployment found")
 			}
+		} else {
+			if err, ok := err.(awserr.Error); ok && strings.Contains(err.Message(), "TaskDefinition is inactive") {
+				d := primaryDeployment(resp.Service)
+				data["DeploymentId"] = *d.Id
+				err = nil
+			}
 		}
 		return id, data, err
 	default:

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -126,7 +126,7 @@ func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.
 				"error_type", reflect.TypeOf(err),
 				"error_msg", err.Error(),
 			)
-			if strings.Contains(err.Message(), "TaskDefinition is inactive") {
+			if strings.Contains(err.Error(), "TaskDefinition is inactive") {
 				err = nil
 			}
 		}


### PR DESCRIPTION
This is to deal with an issue we ran into in empire staging that got the
stack in a bad (unable to rollback state).

Should not be merged with master.