### PR TITLE
Use the ECS RunTask API to run attached processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## HEAD
 
+**Features**
+
+* Empire now supports a new (experimental) feature to enable attached processes to be ran with ECS. [#1043](https://github.com/remind101/empire/pull/1043)
+
 ## 0.12.0 (2017-03-10)
 
 **Features**

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -45,9 +45,9 @@ const (
 
 	FlagDB = "db"
 
-	FlagDockerSocket = "docker.socket"
-	FlagDockerCert   = "docker.cert"
-	FlagDockerAuth   = "docker.auth"
+	FlagDockerHost = "docker.socket"
+	FlagDockerCert = "docker.cert"
+	FlagDockerAuth = "docker.auth"
 
 	FlagAWSDebug             = "aws.debug"
 	FlagS3TemplateBucket     = "s3.templatebucket"
@@ -57,6 +57,8 @@ const (
 	FlagECSServiceRole       = "ecs.service.role"
 	FlagECSLogDriver         = "ecs.logdriver"
 	FlagECSLogOpts           = "ecs.logopt"
+	FlagECSAttachedEnabled   = "ecs.attached.enabled"
+	FlagECSDockerCert        = "ecs.docker.cert"
 
 	FlagELBSGPrivate = "elb.sg.private"
 	FlagELBSGPublic  = "elb.sg.public"
@@ -249,7 +251,7 @@ var DBFlags = []cli.Flag{
 
 var EmpireFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:   FlagDockerSocket,
+		Name:   FlagDockerHost,
 		Value:  "unix:///var/run/docker.sock",
 		Usage:  "The location of the docker api",
 		EnvVar: "DOCKER_HOST",
@@ -309,6 +311,17 @@ var EmpireFlags = []cli.Flag{
 		Value:  &cli.StringSlice{},
 		Usage:  "Log driver to options. Maps to the --log-opt docker cli arg",
 		EnvVar: "EMPIRE_ECS_LOG_OPT",
+	},
+	cli.BoolFlag{
+		Name:   FlagECSAttachedEnabled,
+		Usage:  "When enabled, indicates that ECS tasks can be attached to, using `docker attach`. When provided, this will also use ECS to run attached processes. At the moment, this flag should only be set if you're running a patched ECS agent. See http://empire.readthedocs.io/en/latest/configuration/ for more information.",
+		EnvVar: "EMPIRE_ECS_ATTACHED_ENABLED",
+	},
+	cli.StringFlag{
+		Name:   FlagECSDockerCert,
+		Value:  "",
+		Usage:  "A path to the certificates to use when connecting to Docker daemon's on container instances.",
+		EnvVar: "EMPIRE_ECS_DOCKER_CERT_PATH",
 	},
 	cli.StringFlag{
 		Name:   FlagELBSGPrivate,

--- a/contrib/amazon-ecs-agent/tty
+++ b/contrib/amazon-ecs-agent/tty
@@ -1,0 +1,74 @@
+diff --git a/agent/engine/docker_task_engine.go b/agent/engine/docker_task_engine.go
+index 9a9f3a3..cd5171d 100644
+--- a/agent/engine/docker_task_engine.go
++++ b/agent/engine/docker_task_engine.go
+@@ -17,6 +17,7 @@ package engine
+ import (
+ 	"errors"
+ 	"fmt"
++	"strconv"
+ 	"sync"
+ 	"time"
+ 
+@@ -548,6 +549,16 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
+ 		return DockerContainerMetadata{Error: api.NamedError(err)}
+ 	}
+ 
++	if v, ok := config.Labels["docker.config.Tty"]; ok {
++		config.Tty, _ = strconv.ParseBool(v)
++		delete(config.Labels, "docker.config.Tty")
++	}
++
++	if v, ok := config.Labels["docker.config.OpenStdin"]; ok {
++		config.OpenStdin, _ = strconv.ParseBool(v)
++		delete(config.Labels, "docker.config.OpenStdin")
++	}
++
+ 	// Augment labels with some metadata from the agent. Explicitly do this last
+ 	// such that it will always override duplicates in the provided raw config
+ 	// data.
+diff --git a/agent/engine/docker_task_engine_test.go b/agent/engine/docker_task_engine_test.go
+index cc6523c..3818f25 100644
+--- a/agent/engine/docker_task_engine_test.go
++++ b/agent/engine/docker_task_engine_test.go
+@@ -675,6 +675,40 @@ func TestCreateContainerMergesLabels(t *testing.T) {
+ 	taskEngine.(*DockerTaskEngine).createContainer(testTask, testTask.Containers[0])
+ }
+ 
++func TestCreateContainerAllowsExtraDockerConfigInLabels(t *testing.T) {
++	ctrl, client, _, taskEngine, _, _ := mocks(t, &defaultConfig)
++	defer ctrl.Finish()
++
++	testTask := &api.Task{
++		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
++		Family:  "myFamily",
++		Version: "1",
++		Containers: []*api.Container{
++			&api.Container{
++				Name: "c1",
++				DockerConfig: api.DockerConfig{
++					Config: aws.String(`{"Labels":{"docker.config.Tty":"true","docker.config.OpenStdin":"true"}}`),
++				},
++			},
++		},
++	}
++	expectedConfig, err := testTask.DockerConfig(testTask.Containers[0])
++	if err != nil {
++		t.Fatal(err)
++	}
++	expectedConfig.Tty = true
++	expectedConfig.OpenStdin = true
++	expectedConfig.Labels = map[string]string{
++		"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
++		"com.amazonaws.ecs.container-name":          "c1",
++		"com.amazonaws.ecs.task-definition-family":  "myFamily",
++		"com.amazonaws.ecs.task-definition-version": "1",
++		"com.amazonaws.ecs.cluster":                 "",
++	}
++	client.EXPECT().CreateContainer(expectedConfig, gomock.Any(), gomock.Any(), gomock.Any())
++	taskEngine.(*DockerTaskEngine).createContainer(testTask, testTask.Containers[0])
++}
++
+ // TestTaskTransitionWhenStopContainerTimesout tests that task transitions to stopped
+ // only when terminal events are recieved from docker event stream when
+ // StopContainer times out

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -587,6 +587,13 @@
             {
               "Effect": "Allow",
               "Action": [
+                "ec2:DescribeInstances"
+              ],
+              "Resource": "*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
                 "route53:GetChange*"
               ],
               "Resource": "arn:aws:route53:::change/*"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,3 +145,12 @@ In this configuration, you would create a dedicated Docker host, exposing the Do
 #### Use Docker Swarm
 
 Theoretically, you could point Empire at multiple Docker daemons that are connected via Docker swarm.
+
+#### Use ECS
+
+By default, Empire will run attached processes entirely through the Docker daemon that you point Empire at. You can specify the `--ecs.attached.enabled` (`EMPIRE_ECS_ATTACHED_ENABLED`) to run attached processes via ECS. This method is not yet suitable for production, and there's some important caveats and tradeoff's to be aware of:
+
+1. It currently requires a [patch](https://github.com/remind101/empire/tree/master/contrib/amazon-ecs-agent/tty) to the Amazon ECS agent, to allow Empire to pass additional flags down to Docker when creating the container.
+2. Empire needs to be able to connect to the Docker daemon of container instances in the ECS cluster. If you do this, it's _highly_ encouraged that you only expose the Docker socket over TLS (https://docs.docker.com/engine/security/https/) and restrict your security groups to only allow Empire access to port 2376 on container instances.
+
+The primary benefit of this approach is that, by using ECS, attached runs can be easily scaled out to a group of hosts, and it also allows attached processes to benefit from AWS Roles for ECS tasks.

--- a/pkg/dockerutil/client.go
+++ b/pkg/dockerutil/client.go
@@ -2,7 +2,6 @@ package dockerutil
 
 import (
 	"fmt"
-	"os"
 
 	"golang.org/x/net/context"
 
@@ -14,22 +13,16 @@ import (
 // Docker API.
 var dockerAPI124, _ = docker.NewAPIVersion("1.24")
 
-// NewDockerClient returns a new docker.Client using the given socket and certificate path.
-func NewDockerClient(socket, certPath string) (*docker.Client, error) {
+// NewDockerClient returns a new docker.Client using the given host and certificate path.
+func NewDockerClient(host, certPath string) (*docker.Client, error) {
 	if certPath != "" {
 		cert := certPath + "/cert.pem"
 		key := certPath + "/key.pem"
 		ca := certPath + "/ca.pem"
-		return docker.NewTLSClient(socket, cert, key, ca)
+		return docker.NewTLSClient(host, cert, key, ca)
 	}
 
-	return docker.NewClient(socket)
-}
-
-// NewDockerClientFromEnv returns a new docker client configured by the DOCKER_*
-// environment variables.
-func NewDockerClientFromEnv() (*docker.Client, error) {
-	return NewDockerClient(os.Getenv("DOCKER_HOST"), os.Getenv("DOCKER_CERT_PATH"))
+	return docker.NewClient(host)
 }
 
 // Client wraps a docker.Client to authenticate pulls.
@@ -44,18 +37,8 @@ type Client struct {
 }
 
 // NewClient returns a new Client instance.
-func NewClient(authProvider dockerauth.AuthProvider, socket, certPath string) (*Client, error) {
-	c, err := NewDockerClient(socket, certPath)
-	if err != nil {
-		return nil, err
-	}
-	return newClient(authProvider, c)
-}
-
-// NewClientFromEnv returns a new Client instance configured by the DOCKER_*
-// environment variables.
-func NewClientFromEnv(authProvider dockerauth.AuthProvider) (*Client, error) {
-	c, err := NewDockerClientFromEnv()
+func NewClient(authProvider dockerauth.AuthProvider, host, certPath string) (*Client, error) {
+	c, err := NewDockerClient(host, certPath)
 	if err != nil {
 		return nil, err
 	}

--- a/scheduler/cloudformation/clients.go
+++ b/scheduler/cloudformation/clients.go
@@ -3,6 +3,7 @@ package cloudformation
 import (
 	"time"
 
+	awswaiter "github.com/aws/aws-sdk-go/private/waiter"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/pmylund/go-cache"
 	"github.com/remind101/empire/pkg/arn"
@@ -30,7 +31,7 @@ type cachingECSClient struct {
 }
 
 // ecsWithCaching wraps an ecs.ECS client with caching.
-func ecsWithCaching(ecs *ecs.ECS) *cachingECSClient {
+func ecsWithCaching(ecs *ECS) *cachingECSClient {
 	return &cachingECSClient{
 		ecsClient:       ecs,
 		taskDefinitions: cache.New(defaultExpiration, defaultPurge),
@@ -58,4 +59,46 @@ func (c *cachingECSClient) DescribeTaskDefinition(input *ecs.DescribeTaskDefinit
 	c.taskDefinitions.Set(*resp.TaskDefinition.TaskDefinitionArn, resp.TaskDefinition, 0)
 
 	return resp, err
+}
+
+// ECS augments the ecs.ECS client with extra waiters.
+type ECS struct {
+	*ecs.ECS
+}
+
+// WaitUntilTasksNotPending waits until all the given tasks are either RUNNING
+// or STOPPED.
+func (c *ECS) WaitUntilTasksNotPending(input *ecs.DescribeTasksInput) error {
+	waiterCfg := awswaiter.Config{
+		Operation:   "DescribeTasks",
+		Delay:       6,
+		MaxAttempts: 100,
+		Acceptors: []awswaiter.WaitAcceptor{
+			{
+				State:    "failure",
+				Matcher:  "pathAny",
+				Argument: "failures[].reason",
+				Expected: "MISSING",
+			},
+			{
+				State:    "success",
+				Matcher:  "pathAll",
+				Argument: "tasks[].lastStatus",
+				Expected: "RUNNING",
+			},
+			{
+				State:    "success",
+				Matcher:  "pathAll",
+				Argument: "tasks[].lastStatus",
+				Expected: "STOPPED",
+			},
+		},
+	}
+
+	w := awswaiter.Waiter{
+		Client: c.ECS,
+		Input:  input,
+		Config: waiterCfg,
+	}
+	return w.Wait()
 }


### PR DESCRIPTION
Not ready to merge.

This is a prototype for switching `emp run` to use the ECS RunTask API, instead of calling out to Docker directly. The primary motivation behind this is to allow containers started with `emp run` to use AWS Roles for ECS tasks. This is described in https://github.com/remind101/empire/wiki/RFC:-Use-RunTask-API-for-attached-runs.

There's some serious caveats with this implementation at the moment:

1. Because we use `AttachToContainer`, the container needs to be started with the `Tty` and `OpenStdin` flags set to true. Unfortunately, the ECS API and the ECS agent don't currently provide a method to pass these down. We would currently need to fork the agent.
2. I haven't yet addressed backwards compatibility. It may be a good idea to provide a flag to use the old method for running attached runs entirely through Docker.

On the plus side, this sets up some infrastructure for adding an `emp exec/attach` command for starting up a process in an existing container, or attaching to a running process.

**TODO**

* [x] Figure out how to pass down `Tty`/`OpenStdin` flags.
* [x] Add the ability to limit attached runs to a group of hosts.
* [x] Enable this feature with a flag.
* [ ] <strike>Add ability to limit normal containers to a group of hosts.</strike>
* [x] Docs
  * Expiremental
  * Document Docker TLS requirements
  * Document need for ECS agent patch.