### PR TITLE
Stop double confirmation messages

### DIFF
--- a/cmd/emp/destroy.go
+++ b/cmd/emp/destroy.go
@@ -7,7 +7,7 @@ import (
 )
 
 var cmdDestroy = &Command{
-	Run:             maybeMessage(runDestroy),
+	Run:             mustConfirmAndMessageRequired(runDestroy, warningMessage),
 	Usage:           "destroy <name>",
 	OptionalMessage: true,
 	Category:        "app",
@@ -34,9 +34,7 @@ func runDestroy(cmd *Command, args []string) {
 	appname := args[0]
 	message := getMessage()
 
-	warning := fmt.Sprintf("This will destroy %s and its add-ons. Please type %q to continue:", appname, appname)
-	mustConfirm(warning, appname)
-
+	appname := args[0]
 	must(client.AppDelete(appname, message))
 	log.Printf("Destroyed %s.", appname)
 	remotes, _ := gitRemotes()
@@ -45,4 +43,11 @@ func runDestroy(cmd *Command, args []string) {
 			exec.Command("git", "remote", "rm", remote).Run()
 		}
 	}
+}
+
+func warningMessage(args []string) (warning, desired string) {
+	appname := args[0]
+	warning = fmt.Sprintf("This will destroy %s and its add-ons. Please type %q to continue:", appname, appname)
+	desired = appname
+	return
 }

--- a/cmd/emp/destroy.go
+++ b/cmd/emp/destroy.go
@@ -31,10 +31,7 @@ Example:
 
 func confirmDestroy(action func(cmd *Command, args []string)) func(cmd *Command, args []string) {
 	return func(cmd *Command, args []string) {
-		if len(args) != 1 {
-			cmd.PrintUsage()
-			os.Exit(2)
-		}
+		cmd.AssertNumArgsCorrect(args)
 
 		appname := args[0]
 		warning := fmt.Sprintf("This will destroy %s and its add-ons. Please type %q to continue:", appname, appname)

--- a/cmd/emp/util.go
+++ b/cmd/emp/util.go
@@ -305,3 +305,14 @@ func maybeMessage(action func(cmd *Command, args []string)) func(cmd *Command, a
 		action(cmd, args)
 	}
 }
+
+func mustConfirmAndMessageRequired(action func(cmd *Command, args []string), warning func(args []string) (warning, desired string)) func(cmd *Command, args []string) {
+	return func(cmd *Command, args []string) {
+		retry := func() {
+			action(cmd, args)
+		}
+		defer retryMessageRequired(retry, nil)
+		mustConfirm(warning(args))
+		action(cmd, args)
+	}
+}

--- a/cmd/emp/util.go
+++ b/cmd/emp/util.go
@@ -305,14 +305,3 @@ func maybeMessage(action func(cmd *Command, args []string)) func(cmd *Command, a
 		action(cmd, args)
 	}
 }
-
-func mustConfirmAndMessageRequired(action func(cmd *Command, args []string), warning func(args []string) (warning, desired string)) func(cmd *Command, args []string) {
-	return func(cmd *Command, args []string) {
-		retry := func() {
-			action(cmd, args)
-		}
-		defer retryMessageRequired(retry, nil)
-		mustConfirm(warning(args))
-		action(cmd, args)
-	}
-}


### PR DESCRIPTION
Fixes #1047 

Changes:
- Added a function similar to `maybeMessage` that only checks for confirmation once
- Removed confirmation checking from the destroy command