### PR TITLE
Refactor out argument count check

### DIFF
--- a/cmd/emp/api.go
+++ b/cmd/emp/api.go
@@ -11,6 +11,7 @@ var cmdAPI = &Command{
 	Usage:    "api <method> <path>",
 	Category: "emp",
 	Short:    "make a single API request" + extra,
+	NumArgs:  2,
 	Long: `
 The api command is a convenient but low-level way to send requests
 to the Heroku API. It sends an HTTP request to the Heroku API
@@ -45,10 +46,7 @@ Examples:
 }
 
 func runAPI(cmd *Command, args []string) {
-	if len(args) != 2 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 	method := strings.ToUpper(args[0])
 	var body io.Reader
 	if method == "PATCH" || method == "PUT" || method == "POST" {

--- a/cmd/emp/api.go
+++ b/cmd/emp/api.go
@@ -46,7 +46,7 @@ Examples:
 }
 
 func runAPI(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 	method := strings.ToUpper(args[0])
 	var body io.Reader
 	if method == "PATCH" || method == "PUT" || method == "POST" {

--- a/cmd/emp/auth.go
+++ b/cmd/emp/auth.go
@@ -32,7 +32,7 @@ Example:
 }
 
 func runAuthorize(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	if os.Getenv("HEROKU_AGENT_SOCK") == "" {
 		printFatal("Authorize must be used with heroku-agent; please set " +
@@ -106,7 +106,7 @@ Example:
 }
 
 func runLogin(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	oldEmail := client.Username
 	var email string
@@ -218,7 +218,7 @@ Example:
 }
 
 func runLogout(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	u, err := url.Parse(client.URL)
 	if err != nil {

--- a/cmd/emp/auth.go
+++ b/cmd/emp/auth.go
@@ -16,6 +16,7 @@ var cmdAuthorize = &Command{
 	Run:      runAuthorize,
 	Usage:    "authorize",
 	Category: "emp",
+	NumArgs:  0,
 	Short:    "procure a temporary privileged token" + extra,
 	Long: `
 Have heroku-agent procure and store a temporary privileged token
@@ -31,10 +32,7 @@ Example:
 }
 
 func runAuthorize(cmd *Command, args []string) {
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 
 	if os.Getenv("HEROKU_AGENT_SOCK") == "" {
 		printFatal("Authorize must be used with heroku-agent; please set " +
@@ -91,6 +89,7 @@ var cmdLogin = &Command{
 	Run:      runLogin,
 	Usage:    "login",
 	Category: "emp",
+	NumArgs:  0,
 	Short:    "log in to your Heroku account" + extra,
 	Long: `
 Log in with your Heroku credentials. Input is accepted by typing
@@ -107,10 +106,7 @@ Example:
 }
 
 func runLogin(cmd *Command, args []string) {
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 
 	oldEmail := client.Username
 	var email string
@@ -208,6 +204,7 @@ var cmdLogout = &Command{
 	Run:      runLogout,
 	Usage:    "logout",
 	Category: "emp",
+	NumArgs:  0,
 	Short:    "log out of your Heroku account" + extra,
 	Long: `
 Log out of your Heroku account and remove credentials from
@@ -221,10 +218,8 @@ Example:
 }
 
 func runLogout(cmd *Command, args []string) {
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
+
 	u, err := url.Parse(client.URL)
 	if err != nil {
 		printFatal("couldn't parse client URL: " + err.Error())

--- a/cmd/emp/certs.go
+++ b/cmd/emp/certs.go
@@ -34,7 +34,7 @@ func init() {
 }
 
 func runCertAttach(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	cert := args[0]
 

--- a/cmd/emp/certs.go
+++ b/cmd/emp/certs.go
@@ -11,7 +11,7 @@ var cmdCertAttach = &Command{
 	Usage:    "cert-attach <aws_cert_arn>",
 	NeedsApp: true,
 	Category: "certs",
-	NumArgs:  0,
+	NumArgs:  1,
 	Short:    "attach a certificate to an app",
 	Long: `
 Attaches an SSL certificate to an applications web process. When using the ECS backend, this will attach an IAM server certificate to the applications ELB.

--- a/cmd/emp/certs.go
+++ b/cmd/emp/certs.go
@@ -1,10 +1,6 @@
 package main
 
-import (
-	"os"
-
-	"github.com/remind101/empire/pkg/heroku"
-)
+import "github.com/remind101/empire/pkg/heroku"
 
 var (
 	process string
@@ -15,6 +11,7 @@ var cmdCertAttach = &Command{
 	Usage:    "cert-attach <aws_cert_arn>",
 	NeedsApp: true,
 	Category: "certs",
+	NumArgs:  0,
 	Short:    "attach a certificate to an app",
 	Long: `
 Attaches an SSL certificate to an applications web process. When using the ECS backend, this will attach an IAM server certificate to the applications ELB.
@@ -37,10 +34,7 @@ func init() {
 }
 
 func runCertAttach(cmd *Command, args []string) {
-	if len(args) == 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 
 	cert := args[0]
 

--- a/cmd/emp/destroy.go
+++ b/cmd/emp/destroy.go
@@ -30,7 +30,7 @@ Example:
 }
 
 func runDestroy(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 	appname := args[0]
 	message := getMessage()
 

--- a/cmd/emp/destroy.go
+++ b/cmd/emp/destroy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 	"os/exec"
 )
 
@@ -13,6 +12,7 @@ var cmdDestroy = &Command{
 	OptionalMessage: true,
 	Category:        "app",
 	Short:           "destroy an app",
+	NumArgs:         1,
 	Long: `
 Destroy destroys a heroku app. There is no going back, so be
 sure you mean it. The command will prompt for confirmation, or
@@ -30,10 +30,7 @@ Example:
 }
 
 func runDestroy(cmd *Command, args []string) {
-	if len(args) != 1 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 	appname := args[0]
 	message := getMessage()
 

--- a/cmd/emp/domains.go
+++ b/cmd/emp/domains.go
@@ -32,7 +32,7 @@ func runDomains(cmd *Command, args []string) {
 	defer w.Flush()
 
 	appname := mustApp()
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 	domains, err := client.DomainList(appname, &heroku.ListRange{
 		Field: "hostname",
 		Max:   1000,
@@ -55,7 +55,7 @@ var cmdDomainAdd = &Command{
 
 func runDomainAdd(cmd *Command, args []string) {
 	appname := mustApp()
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 	domain := args[0]
 	_, err := client.DomainCreate(appname, domain)
 	must(err)
@@ -73,7 +73,7 @@ var cmdDomainRemove = &Command{
 
 func runDomainRemove(cmd *Command, args []string) {
 	appname := mustApp()
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 	domain := args[0]
 	must(client.DomainDelete(appname, domain))
 	log.Printf("Removed %s from %s.", domain, appname)

--- a/cmd/emp/domains.go
+++ b/cmd/emp/domains.go
@@ -14,6 +14,7 @@ var cmdDomains = &Command{
 	Usage:    "domains",
 	NeedsApp: true,
 	Category: "domain",
+	NumArgs:  0,
 	Short:    "list domains",
 	Long: `
 Lists domains.
@@ -31,10 +32,7 @@ func runDomains(cmd *Command, args []string) {
 	defer w.Flush()
 
 	appname := mustApp()
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 	domains, err := client.DomainList(appname, &heroku.ListRange{
 		Field: "hostname",
 		Max:   1000,
@@ -51,15 +49,13 @@ var cmdDomainAdd = &Command{
 	Usage:    "domain-add <domain>",
 	NeedsApp: true,
 	Category: "domain",
+	NumArgs:  1,
 	Short:    "add a domain",
 }
 
 func runDomainAdd(cmd *Command, args []string) {
 	appname := mustApp()
-	if len(args) != 1 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 	domain := args[0]
 	_, err := client.DomainCreate(appname, domain)
 	must(err)
@@ -71,15 +67,13 @@ var cmdDomainRemove = &Command{
 	Usage:    "domain-remove <domain>",
 	NeedsApp: true,
 	Category: "domain",
+	NumArgs:  1,
 	Short:    "remove a domain",
 }
 
 func runDomainRemove(cmd *Command, args []string) {
 	appname := mustApp()
-	if len(args) != 1 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 	domain := args[0]
 	must(client.DomainDelete(appname, domain))
 	log.Printf("Removed %s from %s.", domain, appname)

--- a/cmd/emp/dynos.go
+++ b/cmd/emp/dynos.go
@@ -19,7 +19,7 @@ var cmdDynos = &Command{
 	Alias:    "dynos",
 	NeedsApp: true,
 	Category: "dyno",
-	NumArgs:  1,
+	NumArgs:  0,
 	Short:    "list processes",
 	Long: `
 Lists processes. Shows the name, size, host, state, age, and command.

--- a/cmd/emp/dynos.go
+++ b/cmd/emp/dynos.go
@@ -19,6 +19,7 @@ var cmdDynos = &Command{
 	Alias:    "dynos",
 	NeedsApp: true,
 	Category: "dyno",
+	NumArgs:  1,
 	Short:    "list processes",
 	Long: `
 Lists processes. Shows the name, size, host, state, age, and command.
@@ -35,10 +36,7 @@ Examples:
 func runDynos(cmd *Command, args []string) {
 	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
 	defer w.Flush()
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 
 	listDynos(w)
 }

--- a/cmd/emp/dynos.go
+++ b/cmd/emp/dynos.go
@@ -36,7 +36,7 @@ Examples:
 func runDynos(cmd *Command, args []string) {
 	w := tabwriter.NewWriter(os.Stdout, 1, 2, 2, ' ', 0)
 	defer w.Flush()
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	listDynos(w)
 }

--- a/cmd/emp/env.go
+++ b/cmd/emp/env.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+
 	"github.com/joho/godotenv"
 )
 
@@ -14,15 +15,13 @@ var cmdEnv = &Command{
 	Usage:    "env",
 	NeedsApp: true,
 	Category: "config",
+	NumArgs:  0,
 	Short:    "list env vars",
 	Long:     `Show all env vars.`,
 }
 
 func runEnv(cmd *Command, args []string) {
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 	config, err := client.ConfigVarInfo(mustApp())
 	must(err)
 	var configKeys []string
@@ -40,6 +39,7 @@ var cmdGet = &Command{
 	Usage:    "get <name>",
 	NeedsApp: true,
 	Category: "config",
+	NumArgs:  1,
 	Short:    "get env var" + extra,
 	Long: `
 Get the value of an env var.
@@ -52,10 +52,7 @@ Example:
 }
 
 func runGet(cmd *Command, args []string) {
-	if len(args) != 1 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 	config, err := client.ConfigVarInfo(mustApp())
 	must(err)
 	value, found := config[args[0]]
@@ -142,6 +139,7 @@ var cmdEnvLoad = &Command{
 	NeedsApp:        true,
 	OptionalMessage: true,
 	Category:        "config",
+	NumArgs:         1,
 	Short:           "load env file",
 	Long: `
 Loads environment variables from a file.
@@ -156,10 +154,7 @@ Example:
 func runEnvLoad(cmd *Command, args []string) {
 	appname := mustApp()
 	message := getMessage()
-	if len(args) != 1 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 
 	parsedVars, err := godotenv.Read(args[0])
 	must(err)

--- a/cmd/emp/env.go
+++ b/cmd/emp/env.go
@@ -21,7 +21,7 @@ var cmdEnv = &Command{
 }
 
 func runEnv(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 	config, err := client.ConfigVarInfo(mustApp())
 	must(err)
 	var configKeys []string
@@ -52,7 +52,7 @@ Example:
 }
 
 func runGet(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 	config, err := client.ConfigVarInfo(mustApp())
 	must(err)
 	value, found := config[args[0]]
@@ -154,7 +154,7 @@ Example:
 func runEnvLoad(cmd *Command, args []string) {
 	appname := mustApp()
 	message := getMessage()
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	parsedVars, err := godotenv.Read(args[0])
 	must(err)

--- a/cmd/emp/info.go
+++ b/cmd/emp/info.go
@@ -1,24 +1,20 @@
 package main
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 var cmdInfo = &Command{
 	Run:      runInfo,
 	Usage:    "info",
 	NeedsApp: true,
 	Category: "app",
+	NumArgs:  0,
 	Short:    "show app info",
 	Long:     `Info shows general information about the current app.`,
 }
 
 func runInfo(cmd *Command, args []string) {
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
+
 	app, err := client.AppInfo(mustApp())
 	must(err)
 	fmt.Printf("Name: %s\n", app.Name)

--- a/cmd/emp/info.go
+++ b/cmd/emp/info.go
@@ -13,7 +13,7 @@ var cmdInfo = &Command{
 }
 
 func runInfo(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	app, err := client.AppInfo(mustApp())
 	must(err)

--- a/cmd/emp/log.go
+++ b/cmd/emp/log.go
@@ -40,7 +40,7 @@ type PostLogForm struct {
 }
 
 func runLog(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	var d int64
 	if duration != "" {

--- a/cmd/emp/log.go
+++ b/cmd/emp/log.go
@@ -13,6 +13,7 @@ var cmdLog = &Command{
 	Usage:    "log [-d]",
 	NeedsApp: true,
 	Category: "app",
+	NumArgs:  0,
 	Short:    "stream app log lines",
 	Long: `
 Log prints the streaming application log.
@@ -39,10 +40,7 @@ type PostLogForm struct {
 }
 
 func runLog(cmd *Command, args []string) {
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
 
 	var d int64
 	if duration != "" {

--- a/cmd/emp/main.go
+++ b/cmd/emp/main.go
@@ -38,6 +38,7 @@ type Command struct {
 	Long     string // `emp help cmd` output
 	Alias    string // Optional alias for the command.
 	Hidden   bool   // Set to true to hide a command from usage information.
+	NumArgs  int    // Expected number of arguments, optional
 }
 
 func (c *Command) PrintUsage() {
@@ -101,6 +102,13 @@ func (c *Command) ListAsExtra() bool {
 
 func (c *Command) ShortExtra() string {
 	return c.Short[:len(c.Short)-len(extra)]
+}
+
+func (c *Command) CheckNumArgs(args []string) {
+	if len(args) != c.NumArgs {
+		c.PrintUsage()
+		os.Exit(2)
+	}
 }
 
 // Running `emp help` will list commands in this order.

--- a/cmd/emp/main.go
+++ b/cmd/emp/main.go
@@ -104,7 +104,7 @@ func (c *Command) ShortExtra() string {
 	return c.Short[:len(c.Short)-len(extra)]
 }
 
-func (c *Command) CheckNumArgs(args []string) {
+func (c *Command) AssertNumArgsCorrect(args []string) {
 	if len(args) != c.NumArgs {
 		c.PrintUsage()
 		os.Exit(2)

--- a/cmd/emp/releases.go
+++ b/cmd/emp/releases.go
@@ -164,6 +164,7 @@ var cmdReleaseInfo = &Command{
 	Usage:    "release-info <version>",
 	NeedsApp: true,
 	Category: "release",
+	NumArgs:  1,
 	Short:    "show release info",
 	Long: `
 release-info shows detailed information about a release.
@@ -182,10 +183,8 @@ Examples:
 
 func runReleaseInfo(cmd *Command, args []string) {
 	appname := mustApp()
-	if len(args) != 1 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
+
 	ver := strings.TrimPrefix(args[0], "v")
 	rel, err := client.ReleaseInfo(appname, ver)
 	must(err)
@@ -206,6 +205,7 @@ var cmdRollback = &Command{
 	NeedsApp:        true,
 	OptionalMessage: true,
 	Category:        "release",
+	NumArgs:         1,
 	Short:           "roll back to a previous release",
 	Long: `
 Rollback re-releases an app at an older version. This action
@@ -222,10 +222,8 @@ Examples:
 func runRollback(cmd *Command, args []string) {
 	appname := mustApp()
 	message := getMessage()
-	if len(args) != 1 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
+
 	ver := strings.TrimPrefix(args[0], "v")
 	rollbackSafetyCheck(ver, appname)
 

--- a/cmd/emp/releases.go
+++ b/cmd/emp/releases.go
@@ -183,7 +183,7 @@ Examples:
 
 func runReleaseInfo(cmd *Command, args []string) {
 	appname := mustApp()
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	ver := strings.TrimPrefix(args[0], "v")
 	rel, err := client.ReleaseInfo(appname, ver)
@@ -222,7 +222,7 @@ Examples:
 func runRollback(cmd *Command, args []string) {
 	appname := mustApp()
 	message := getMessage()
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	ver := strings.TrimPrefix(args[0], "v")
 	rollbackSafetyCheck(ver, appname)

--- a/cmd/emp/rename.go
+++ b/cmd/emp/rename.go
@@ -22,7 +22,7 @@ Example:
 }
 
 func runRename(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	oldname, newname := args[0], args[1]
 	app, err := client.AppUpdate(oldname, &heroku.AppUpdateOpts{Name: &newname})

--- a/cmd/emp/rename.go
+++ b/cmd/emp/rename.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/remind101/empire/pkg/heroku"
 )
@@ -11,6 +10,7 @@ var cmdRename = &Command{
 	Run:      runRename,
 	Usage:    "rename <oldname> <newname>",
 	Category: "app",
+	NumArgs:  2,
 	Short:    "rename an app",
 	Long: `
 Rename renames a heroku app.
@@ -22,10 +22,8 @@ Example:
 }
 
 func runRename(cmd *Command, args []string) {
-	if len(args) != 2 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
+
 	oldname, newname := args[0], args[1]
 	app, err := client.AppUpdate(oldname, &heroku.AppUpdateOpts{Name: &newname})
 	must(err)

--- a/cmd/emp/url.go
+++ b/cmd/emp/url.go
@@ -13,7 +13,7 @@ var cmdURL = &Command{
 }
 
 func runURL(cmd *Command, args []string) {
-	cmd.CheckNumArgs(args)
+	cmd.AssertNumArgsCorrect(args)
 
 	app, err := client.AppInfo(mustApp())
 	must(err)

--- a/cmd/emp/url.go
+++ b/cmd/emp/url.go
@@ -1,24 +1,20 @@
 package main
 
-import (
-	"fmt"
-	"os"
-)
+import "fmt"
 
 var cmdURL = &Command{
 	Run:      runURL,
 	Usage:    "url",
 	NeedsApp: true,
 	Category: "app",
+	NumArgs:  0,
 	Short:    "show app url" + extra,
 	Long:     `Prints the web URL for the app.`,
 }
 
 func runURL(cmd *Command, args []string) {
-	if len(args) != 0 {
-		cmd.PrintUsage()
-		os.Exit(2)
-	}
+	cmd.CheckNumArgs(args)
+
 	app, err := client.AppInfo(mustApp())
 	must(err)
 	fmt.Println(app.WebURL)


### PR DESCRIPTION
I was reading through the codebase when I saw:
```
if len(args) != 2 {
	cmd.PrintUsage()
	os.Exit(2)
}
```
repeated a lot.

Therefore, I decided to refactor that out into an optional parameter on the `Command` struct with its own validation function.

I did not touch commands with a variable argument count.