### PR TITLE
ECS placement constraints/strategy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ Godeps/_workspace/pkg
 tests
 .git
 build
+.env*

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -53,16 +53,17 @@ const (
 	FlagDockerCert = "docker.cert"
 	FlagDockerAuth = "docker.auth"
 
-	FlagAWSDebug             = "aws.debug"
-	FlagS3TemplateBucket     = "s3.templatebucket"
-	FlagCustomResourcesTopic = "customresources.topic"
-	FlagCustomResourcesQueue = "customresources.queue"
-	FlagECSCluster           = "ecs.cluster"
-	FlagECSServiceRole       = "ecs.service.role"
-	FlagECSLogDriver         = "ecs.logdriver"
-	FlagECSLogOpts           = "ecs.logopt"
-	FlagECSAttachedEnabled   = "ecs.attached.enabled"
-	FlagECSDockerCert        = "ecs.docker.cert"
+	FlagAWSDebug                       = "aws.debug"
+	FlagS3TemplateBucket               = "s3.templatebucket"
+	FlagCustomResourcesTopic           = "customresources.topic"
+	FlagCustomResourcesQueue           = "customresources.queue"
+	FlagECSCluster                     = "ecs.cluster"
+	FlagECSServiceRole                 = "ecs.service.role"
+	FlagECSLogDriver                   = "ecs.logdriver"
+	FlagECSLogOpts                     = "ecs.logopt"
+	FlagECSAttachedEnabled             = "ecs.attached.enabled"
+	FlagECSDockerCert                  = "ecs.docker.cert"
+	FlagECSPlacementConstraintsDefault = "ecs.placement-constraints.default"
 
 	FlagELBSGPrivate = "elb.sg.private"
 	FlagELBSGPublic  = "elb.sg.public"
@@ -332,6 +333,12 @@ var EmpireFlags = []cli.Flag{
 		Value:  "",
 		Usage:  "A path to the certificates to use when connecting to Docker daemon's on container instances.",
 		EnvVar: "EMPIRE_ECS_DOCKER_CERT_PATH",
+	},
+	cli.StringFlag{
+		Name:   FlagECSPlacementConstraintsDefault,
+		Value:  "",
+		Usage:  `ECS placement constraints to set when a process does not set any. This should be a JSON formatted array for ECS placement constraints (e.g. '[{"type":"memberOf","expression":"attribute:profile == default"}]'). See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-constraints.html.`,
+		EnvVar: "EMPIRE_ECS_PLACEMENT_CONSTRAINTS_DEFAULT",
 	},
 	cli.StringFlag{
 		Name:   FlagELBSGPrivate,

--- a/docs/deploying_an_application.md
+++ b/docs/deploying_an_application.md
@@ -224,6 +224,24 @@ migrate:
   noservice: true
 ```
 
+## ECS Specific Configuration
+
+The extended Procfile supports specifying some ECS specific options, like placement constraints and placement strategies.
+
+For example, to ensure that a task runs on an instance that has a statsd daemon available, you might do something like this:
+
+```
+worker:
+  ecs:
+    placement_constraints:
+      - type: memberOf
+        expression: "attribute:capability.statsd == true"
+```
+
+Note that, by default, ECS services won't have any placement constraints/strategies applied, which means processes could run on any host within the ECS cluster. If you'd like to specify some default placement constraints for processes that don't define any, you can use the `EMPIRE_ECS_PLACEMENT_CONSTRAINTS_DEFAULT` option when starting the Empire daemon.
+
+See [Procfile specification docs][extended-procfile] for details.
+
 ## Environment variables
 
 Environment variables that start with `EMPIRE_X_` should be considered experimental and subject to

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -13,6 +13,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/ejholmes/flock"
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/dbtest"
@@ -155,6 +157,14 @@ var defaultProcfile = procfile.ExtendedProcfile{
 	"rake": procfile.Process{
 		Command:   "bundle exec rake",
 		NoService: true,
+		ECS: &procfile.ECS{
+			PlacementConstraints: []*ecs.PlacementConstraint{
+				&ecs.PlacementConstraint{
+					Type:       aws.String("memberOf"),
+					Expression: aws.String("attribute:profile = background"),
+				},
+			},
+		},
 	},
 }
 

--- a/extractor.go
+++ b/extractor.go
@@ -107,6 +107,7 @@ func formationFromExtendedProcfile(p procfile.ExtendedProcfile) (Formation, erro
 			NoService:   process.NoService,
 			Ports:       ports,
 			Environment: process.Environment,
+			ECS:         process.ECS,
 		}
 	}
 

--- a/processes.go
+++ b/processes.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/remind101/empire/internal/shellwords"
 	"github.com/remind101/empire/pkg/constraints"
+	"github.com/remind101/empire/procfile"
 )
 
 // DefaultQuantities maps a process type to the default number of instances to
@@ -96,6 +97,9 @@ type Process struct {
 
 	// An process specific environment variables.
 	Environment map[string]string `json:"Environment,omitempty"`
+
+	// ECS specific parameters.
+	ECS *procfile.ECS `json:"ECS,omitempty"`
 }
 
 type Port struct {

--- a/procfile/README.md
+++ b/procfile/README.md
@@ -81,3 +81,19 @@ environment:
 
 See [documentation about deploying an application](../docs/deploying_an_application.md#environment-variables)
 for a list of other supported environment variables.
+
+**ECS**
+
+This allows you to specify any ECS specific properties, like placement strategies and constraints:
+
+```yaml
+ecs:
+  placement_constraints:
+    - type: memberOf
+      expression: "attribute:ecs.instance-type =~ t2.*"
+  placement_strategy:
+    - type: spread
+      field: "attribute:ecs.availability-zone"
+```
+
+See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement.html for details.

--- a/procfile/procfile.go
+++ b/procfile/procfile.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/remind101/empire/procfile/internal/yaml"
 )
 
@@ -30,6 +31,13 @@ type Process struct {
 	NoService   bool              `yaml:"noservice,omitempty"`
 	Ports       []Port            `yaml:"ports,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
+	ECS         *ECS              `yaml:"ecs,omitempty"`
+}
+
+// ECS specific options.
+type ECS struct {
+	PlacementConstraints []*ecs.PlacementConstraint `yaml:"placement_constraints"`
+	PlacementStrategy    []*ecs.PlacementStrategy   `yaml:"placement_strategy"`
 }
 
 // Port represents a port mapping.

--- a/procfile/procfile_test.go
+++ b/procfile/procfile_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -119,6 +121,33 @@ web:
 				},
 				Environment: map[string]string{
 					"ENABLE_FOO": "true",
+				},
+			},
+		},
+	},
+
+	// ECS placement constraints
+	{
+		strings.NewReader(`---
+web:
+  command: nginx
+  ecs:
+    placement_constraints:
+      - type: memberOf
+        expression: "attribute:ecs.instance-type =~ t2.*"
+    placement_strategy:
+      - type: spread
+        field: "attribute:ecs.availability-zone"`),
+		ExtendedProcfile{
+			"web": Process{
+				Command: "nginx",
+				ECS: &ECS{
+					PlacementConstraints: []*ecs.PlacementConstraint{
+						{Type: aws.String("memberOf"), Expression: aws.String("attribute:ecs.instance-type =~ t2.*")},
+					},
+					PlacementStrategy: []*ecs.PlacementStrategy{
+						{Type: aws.String("spread"), Field: aws.String("attribute:ecs.availability-zone")},
+					},
 				},
 			},
 		},

--- a/releases.go
+++ b/releases.go
@@ -378,6 +378,7 @@ func newSchedulerProcess(release *Release, name string, p Process) (*twelvefacto
 		Nproc:     uint(p.Nproc),
 		Exposure:  exposure,
 		Schedule:  processSchedule(name, p),
+		ECS:       p.ECS,
 	}, nil
 }
 

--- a/releases.go
+++ b/releases.go
@@ -188,24 +188,7 @@ func (s *releasesService) ReleaseApp(ctx context.Context, db *gorm.DB, app *App,
 // Restart will find the last release for an app and submit it to the scheduler
 // to restart the app.
 func (s *releasesService) Restart(ctx context.Context, db *gorm.DB, app *App) error {
-	release, err := releasesFind(db, ReleasesQuery{App: app})
-	if err != nil {
-		if err == gorm.RecordNotFound {
-			return ErrNoReleases
-		}
-
-		return err
-	}
-
-	if release == nil {
-		return nil
-	}
-
-	a, err := newSchedulerApp(release)
-	if err != nil {
-		return err
-	}
-	return s.Scheduler.Restart(ctx, a, nil)
+	return s.Scheduler.Restart(ctx, app.ID, nil)
 }
 
 // These associations are always available on a Release.

--- a/runner.go
+++ b/runner.go
@@ -6,6 +6,11 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	// GenericProcessName is the process name for `emp run` processes not defined in the procfile.
+	GenericProcessName = "run"
+)
+
 // RunRecorder is a function that returns an io.Writer that will be written to
 // to record Stdout and Stdin of interactive runs.
 type RunRecorder func() (io.Writer, error)
@@ -21,43 +26,57 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 	}
 
 	procName := opts.Command[0]
-	proc := Process{
-		Quantity: 1,
-	}
+	var proc Process
 
+	// First, let's check if the command we're running matches a defined
+	// process in the Procfile/Formation. If it does, we'll replace the
+	// command, with the one in the procfile and expand it's arguments.
+	//
+	// For example, given a procfile like this:
+	//
+	//	psql:
+	//	  command: ./bin/psql
+	//
+	// Calling `emp run psql DATABASE_URL` will expand the command to
+	// `./bin/psql DATABASE_URL`.
 	if cmd, ok := release.Formation[procName]; ok {
+		proc = cmd
 		proc.Command = append(cmd.Command, opts.Command[1:]...)
+		proc.NoService = false
 	} else {
+		// If we've set the flag to only allow `emp run` on commands
+		// defined in the procfile, return an error since the command is
+		// not defined in the procfile.
 		if r.AllowedCommands == AllowCommandProcfile {
 			return commandNotInFormation(Command{procName}, release.Formation)
 		}
 
 		// This is an unnamed command, fallback to a generic proc name.
-		procName = "run"
+		procName = GenericProcessName
 		proc.Command = opts.Command
+		proc.SetConstraints(DefaultConstraints)
 	}
+
+	proc.Quantity = 1
 
 	// Set the size of the process.
-	constraints := DefaultConstraints
 	if opts.Constraints != nil {
-		constraints = *opts.Constraints
+		proc.SetConstraints(*opts.Constraints)
 	}
-	proc.SetConstraints(constraints)
 
+	release.Formation = Formation{procName: proc}
 	a, err := newSchedulerApp(release)
 	if err != nil {
 		return err
 	}
-	p, err := newSchedulerProcess(release, procName, proc)
-	if err != nil {
-		return err
-	}
-	p.Labels["empire.user"] = opts.User.Name
+	for _, p := range a.Processes {
+		p.Labels["empire.user"] = opts.User.Name
 
-	// Add additional environment variables to the process.
-	for k, v := range opts.Env {
-		p.Env[k] = v
+		// Add additional environment variables to the process.
+		for k, v := range opts.Env {
+			p.Env[k] = v
+		}
 	}
 
-	return r.Scheduler.Run(ctx, a, p, opts.Input, opts.Output)
+	return r.Scheduler.Run(ctx, a, opts.Input, opts.Output)
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -63,9 +63,11 @@ func (m *FakeScheduler) Stop(ctx context.Context, instanceID string) error {
 	return nil
 }
 
-func (m *FakeScheduler) Run(ctx context.Context, app *twelvefactor.Manifest, p *twelvefactor.Process, in io.Reader, out io.Writer) error {
+func (m *FakeScheduler) Run(ctx context.Context, app *twelvefactor.Manifest, in io.Reader, out io.Writer) error {
 	if out != nil {
-		fmt.Fprintf(out, "Fake output for `%s` on %s\n", p.Command, app.Name)
+		for _, p := range app.Processes {
+			fmt.Fprintf(out, "Fake output for `%s` on %s\n", p.Command, app.Name)
+		}
 	}
 	return nil
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -30,8 +30,8 @@ func (m *FakeScheduler) Submit(ctx context.Context, app *twelvefactor.Manifest, 
 	return nil
 }
 
-func (m *FakeScheduler) Restart(ctx context.Context, app *twelvefactor.Manifest, ss twelvefactor.StatusStream) error {
-	return m.Submit(ctx, app, ss)
+func (m *FakeScheduler) Restart(ctx context.Context, appID string, ss twelvefactor.StatusStream) error {
+	return nil
 }
 
 func (m *FakeScheduler) Remove(ctx context.Context, appID string) error {

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -225,8 +225,8 @@ func (s *Scheduler) SubmitWithOptions(ctx context.Context, app *twelvefactor.Man
 	return tx.Commit()
 }
 
-func (s *Scheduler) Restart(ctx context.Context, app *twelvefactor.Manifest, ss twelvefactor.StatusStream) error {
-	stackName, err := s.stackName(app.AppID)
+func (s *Scheduler) Restart(ctx context.Context, appID string, ss twelvefactor.StatusStream) error {
+	stackName, err := s.stackName(appID)
 	if err != nil {
 		return err
 	}

--- a/scheduler/cloudformation/cloudformation.go
+++ b/scheduler/cloudformation/cloudformation.go
@@ -960,12 +960,19 @@ func (m *Scheduler) Run(ctx context.Context, app *twelvefactor.Manifest, in io.R
 			return fmt.Errorf("error registering TaskDefinition: %v", err)
 		}
 
-		runResp, err := m.ecs.RunTask(&ecs.RunTaskInput{
+		input := &ecs.RunTaskInput{
 			TaskDefinition: resp.TaskDefinition.TaskDefinitionArn,
 			Cluster:        aws.String(m.Cluster),
 			Count:          aws.Int64(1),
 			StartedBy:      aws.String(app.AppID),
-		})
+		}
+
+		if v := process.ECS; v != nil {
+			input.PlacementConstraints = v.PlacementConstraints
+			input.PlacementStrategy = v.PlacementStrategy
+		}
+
+		runResp, err := m.ecs.RunTask(input)
 		if err != nil {
 			return fmt.Errorf("error calling RunTask: %v", err)
 		}

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -1543,9 +1543,12 @@ func TestScheduler_Run_Detached(t *testing.T) {
 		Env: map[string]string{
 			"EMPIRE_X_TASK_ROLE_ARN": "arn:aws:iam::897883143566:role/app",
 		},
-	}, &twelvefactor.Process{
-		Type:    "run",
-		Command: []string{"bundle exec rake db:migrate"},
+		Processes: []*twelvefactor.Process{
+			&twelvefactor.Process{
+				Type:    "run",
+				Command: []string{"bundle exec rake db:migrate"},
+			},
+		},
 	}, nil, nil)
 	assert.NoError(t, err)
 
@@ -1679,9 +1682,12 @@ func TestScheduler_Run_Attached(t *testing.T) {
 	err = s.Run(context.Background(), &twelvefactor.Manifest{
 		AppID: "c9366591-ab68-4d49-a333-95ce5a23df68",
 		Name:  "acme-inc",
-	}, &twelvefactor.Process{
-		Type:    "run",
-		Command: []string{"bundle", "exec", "rake", "db:migrate"},
+		Processes: []*twelvefactor.Process{
+			&twelvefactor.Process{
+				Type:    "run",
+				Command: []string{"bundle", "exec", "rake", "db:migrate"},
+			},
+		},
 	}, stdin, stdout)
 	assert.NoError(t, err)
 

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -1480,10 +1480,7 @@ func TestScheduler_Restart(t *testing.T) {
 		StackName: aws.String("acme-inc"),
 	}).Return(nil)
 
-	err = s.Restart(context.Background(), &twelvefactor.Manifest{
-		AppID: "c9366591-ab68-4d49-a333-95ce5a23df68",
-		Name:  "acme-inc",
-	}, twelvefactor.NullStatusStream)
+	err = s.Restart(context.Background(), "c9366591-ab68-4d49-a333-95ce5a23df68", twelvefactor.NullStatusStream)
 	assert.NoError(t, err)
 
 	c.AssertExpectations(t)

--- a/scheduler/cloudformation/resources.go
+++ b/scheduler/cloudformation/resources.go
@@ -5,6 +5,11 @@ type PortMappingProperties struct {
 	HostPort      interface{} `json:",omitempty"`
 }
 
+type PlacementConstraint struct {
+	Type       interface{} `json:",omitempty"`
+	Expression interface{} `json:",omitempty"`
+}
+
 type ContainerDefinitionProperties struct {
 	Command          interface{}              `json:",omitempty"`
 	Cpu              interface{}              `json:",omitempty"`
@@ -20,12 +25,14 @@ type ContainerDefinitionProperties struct {
 }
 
 type TaskDefinitionProperties struct {
+	PlacementConstraints []*PlacementConstraint           `json:",omitempty"`
 	ContainerDefinitions []*ContainerDefinitionProperties `json:",omitempty"`
 	Volumes              []interface{}
 	TaskRoleArn          interface{} `json:",omitempty"`
 }
 
 type CustomTaskDefinitionProperties struct {
+	PlacementConstraints []*PlacementConstraint           `json:",omitempty"`
 	ContainerDefinitions []*ContainerDefinitionProperties `json:",omitempty"`
 	Family               interface{}                      `json:",omitempty"`
 	ServiceToken         interface{}                      `json:",omitempty"`

--- a/scheduler/cloudformation/templates/ecs-extra.json
+++ b/scheduler/cloudformation/templates/ecs-extra.json
@@ -1,0 +1,342 @@
+{
+  "Conditions": {
+    "DNSCondition": {
+      "Fn::Equals": [
+        {
+          "Ref": "DNS"
+        },
+        "true"
+      ]
+    }
+  },
+  "Outputs": {
+    "Deployments": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Fn::GetAtt": [
+                      "webService",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "worker",
+                  {
+                    "Fn::GetAtt": [
+                      "workerService",
+                      "DeploymentId"
+                    ]
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    },
+    "EmpireVersion": {
+      "Value": "x.x.x"
+    },
+    "Release": {
+      "Value": "v1"
+    },
+    "Services": {
+      "Value": {
+        "Fn::Join": [
+          ",",
+          [
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "web",
+                  {
+                    "Ref": "webService"
+                  }
+                ]
+              ]
+            },
+            {
+              "Fn::Join": [
+                "=",
+                [
+                  "worker",
+                  {
+                    "Ref": "workerService"
+                  }
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    }
+  },
+  "Parameters": {
+    "DNS": {
+      "Type": "String",
+      "Description": "When set to `true`, CNAME's will be altered",
+      "Default": "true"
+    },
+    "RestartKey": {
+      "Type": "String",
+      "Description": "Key used to trigger a restart of an app",
+      "Default": "default"
+    },
+    "webScale": {
+      "Type": "String"
+    },
+    "workerScale": {
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "CNAME": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "acme-inc.empire",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
+          }
+        ],
+        "TTL": 60,
+        "Type": "CNAME"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
+    "web8080InstancePort": {
+      "Properties": {
+        "ServiceToken": "sns topic arn"
+      },
+      "Type": "Custom::InstancePort",
+      "Version": "1.0"
+    },
+    "webAlias": {
+      "Condition": "DNSCondition",
+      "Properties": {
+        "AliasTarget": {
+          "DNSName": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "DNSName"
+            ]
+          },
+          "EvaluateTargetHealth": "true",
+          "HostedZoneId": {
+            "Fn::GetAtt": [
+              "webLoadBalancer",
+              "CanonicalHostedZoneNameID"
+            ]
+          }
+        },
+        "HostedZoneId": "Z3DG6IL3SJCGPX",
+        "Name": "web.acme-inc.empire",
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    },
+    "webLoadBalancer": {
+      "Properties": {
+        "ConnectionDrainingPolicy": {
+          "Enabled": true,
+          "Timeout": 30
+        },
+        "CrossZone": true,
+        "Listeners": [
+          {
+            "InstancePort": {
+              "Fn::GetAtt": [
+                "web8080InstancePort",
+                "InstancePort"
+              ]
+            },
+            "InstanceProtocol": "http",
+            "LoadBalancerPort": 80,
+            "Protocol": "http"
+          }
+        ],
+        "Scheme": "internal",
+        "SecurityGroups": [
+          "sg-e7387381"
+        ],
+        "Subnets": [
+          "subnet-bb01c4cd",
+          "subnet-c85f4091"
+        ],
+        "Tags": [
+          {
+            "Key": "empire.app.process",
+            "Value": "web"
+          }
+        ]
+      },
+      "Type": "AWS::ElasticLoadBalancing::LoadBalancer"
+    },
+    "webService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "webScale"
+        },
+        "LoadBalancers": [
+          {
+            "ContainerName": "web",
+            "ContainerPort": 8080,
+            "LoadBalancerName": {
+              "Ref": "webLoadBalancer"
+            }
+          }
+        ],
+        "Role": "ecsServiceRole",
+        "ServiceName": "acme-inc-web",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "webTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService"
+    },
+    "webTaskDefinition": {
+      "Properties": {
+        "PlacementConstraints": [
+          {
+            "Type": "memberOf",
+            "Expression": "attribute:ecs.instance-type =~ t2.*"
+          }
+        ],
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/web"
+            ],
+            "Cpu": 256,
+            "DockerLabels": {
+              "cloudformation.restart-key": {
+                "Ref": "RestartKey"
+              },
+              "empire.app.process": "web"
+            },
+            "Environment": [
+              {
+                "Name": "A",
+                "Value": "foobar"
+              },
+              {
+                "Name": "B",
+                "Value": "bar"
+              },
+              {
+                "Name": "C",
+                "Value": "foo"
+              },
+              {
+                "Name": "PORT",
+                "Value": "8080"
+              }
+            ],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 128,
+            "Name": "web",
+            "PortMappings": [
+              {
+                "ContainerPort": 8080,
+                "HostPort": {
+                  "Fn::GetAtt": [
+                    "web8080InstancePort",
+                    "InstancePort"
+                  ]
+                }
+              }
+            ],
+            "Ulimits": [
+              {
+                "HardLimit": 256,
+                "Name": "nproc",
+                "SoftLimit": 256
+              }
+            ]
+          }
+        ],
+        "Volumes": []
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    },
+    "workerService": {
+      "Properties": {
+        "Cluster": "cluster",
+        "DesiredCount": {
+          "Ref": "workerScale"
+        },
+        "LoadBalancers": [],
+        "ServiceName": "acme-inc-worker",
+        "ServiceToken": "sns topic arn",
+        "TaskDefinition": {
+          "Ref": "workerTaskDefinition"
+        }
+      },
+      "Type": "Custom::ECSService"
+    },
+    "workerTaskDefinition": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/worker"
+            ],
+            "Cpu": 0,
+            "DockerLabels": {
+              "cloudformation.restart-key": {
+                "Ref": "RestartKey"
+              },
+              "empire.app.process": "worker"
+            },
+            "Environment": [
+              {
+                "Name": "A",
+                "Value": "foobar"
+              },
+              {
+                "Name": "B",
+                "Value": "bar"
+              },
+              {
+                "Name": "C",
+                "Value": "foo"
+              },
+              {
+                "Name": "FOO",
+                "Value": "BAR"
+              }
+            ],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 0,
+            "Name": "worker",
+            "Ulimits": []
+          }
+        ],
+        "Volumes": []
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    }
+  }
+}

--- a/server/cloudformation/cloudformation.go
+++ b/server/cloudformation/cloudformation.go
@@ -4,6 +4,7 @@ package cloudformation
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -54,14 +55,14 @@ func NewCustomResourceProvisioner(empire *empire.Empire, config client.ConfigPro
 		sendResponse:  customresources.SendResponse,
 	}
 
-	p.add("Custom::InstancePort", &InstancePortsProvisioner{
+	p.add("Custom::InstancePort", newInstancePortsProvisioner(&InstancePortsResource{
 		ports: newDBPortAllocator(db),
-	})
+	}))
 
 	ecs := newECSClient(config)
-	p.add("Custom::ECSService", &ECSServiceResource{
+	p.add("Custom::ECSService", newECSServiceProvisioner(&ECSServiceResource{
 		ecs: ecs,
-	})
+	}))
 
 	store := &dbEnvironmentStore{db}
 	p.add("Custom::ECSEnvironment", newECSEnvironmentProvisioner(&ECSEnvironmentResource{
@@ -199,6 +200,9 @@ type provisioner struct {
 }
 
 func (p *provisioner) Properties() interface{} {
+	if p.properties == nil {
+		return nil
+	}
 	return p.properties()
 }
 
@@ -223,6 +227,9 @@ func (p *provisioner) Provision(ctx context.Context, req customresources.Request
 		}
 
 		id := req.PhysicalResourceId
+		if p.Update == nil {
+			return id, nil, errors.New("resource does not support updates")
+		}
 		data, err := p.Update(ctx, req)
 		return id, data, err
 	case customresources.Delete:

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -55,10 +54,14 @@ type LoadBalancer struct {
 type ECSServiceProperties struct {
 	ServiceName    *string
 	Cluster        *string
-	DesiredCount   *customresources.IntValue
+	DesiredCount   *customresources.IntValue `hash:"ignore"`
 	LoadBalancers  []LoadBalancer
 	Role           *string
-	TaskDefinition *string
+	TaskDefinition *string `hash:"ignore"`
+}
+
+func (p *ECSServiceProperties) ReplacementHash() (uint64, error) {
+	return hashstructure.Hash(p, nil)
 }
 
 // ECSServiceResource is a Provisioner that creates and updates ECS services.
@@ -66,68 +69,22 @@ type ECSServiceResource struct {
 	ecs ecsClient
 }
 
-func (p *ECSServiceResource) Properties() interface{} {
-	return &ECSServiceProperties{}
-}
-
-func (p *ECSServiceResource) Provision(ctx context.Context, req customresources.Request) (string, interface{}, error) {
-	properties := req.ResourceProperties.(*ECSServiceProperties)
-	oldProperties := req.OldResourceProperties.(*ECSServiceProperties)
-	data := make(map[string]string)
-
-	switch req.RequestType {
-	case customresources.Create:
-		id, deploymentId, err := p.create(ctx, req.Hash(), properties)
-		if err == nil {
-			data["DeploymentId"] = deploymentId
-		}
-		return id, data, err
-	case customresources.Delete:
-		id := req.PhysicalResourceId
-		err := p.delete(ctx, aws.String(id), properties.Cluster)
-		return id, nil, err
-	case customresources.Update:
-		id := req.PhysicalResourceId
-
-		// TODO: Update this to use hashstructure.
-		if serviceRequiresReplacement(properties, oldProperties) {
-			// If we can't update the service, we'll need to create a new
-			// one, and destroy the old one.
-			oldId := id
-			id, deploymentId, err := p.create(ctx, req.Hash(), properties)
-			if err != nil {
-				return oldId, nil, err
-			}
-			data["DeploymentId"] = deploymentId
-
-			// There's no need to delete the old service here, since
-			// CloudFormation will send us a DELETE request for the old
-			// service.
-
-			return id, data, err
-		}
-
-		resp, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
-			Service:        aws.String(id),
-			Cluster:        properties.Cluster,
-			DesiredCount:   properties.DesiredCount.Value(),
-			TaskDefinition: properties.TaskDefinition,
-		})
-		if err == nil {
-			d := primaryDeployment(resp.Service)
-			if d != nil {
-				data["DeploymentId"] = *d.Id
-			} else {
-				err = fmt.Errorf("no primary deployment found")
-			}
-		}
-		return id, data, err
-	default:
-		return "", nil, fmt.Errorf("%s is not supported", req.RequestType)
+func newECSServiceProvisioner(resource *ECSServiceResource) *provisioner {
+	return &provisioner{
+		properties: func() properties {
+			return &ECSServiceProperties{}
+		},
+		Create: resource.Create,
+		Update: resource.Update,
+		Delete: resource.Delete,
 	}
 }
 
-func (p *ECSServiceResource) create(ctx context.Context, clientToken string, properties *ECSServiceProperties) (string, string, error) {
+func (p *ECSServiceResource) Create(ctx context.Context, req customresources.Request) (string, interface{}, error) {
+	properties := req.ResourceProperties.(*ECSServiceProperties)
+	clientToken := req.Hash()
+	data := make(map[string]string)
+
 	var loadBalancers []*ecs.LoadBalancer
 	for _, v := range properties.LoadBalancers {
 		loadBalancers = append(loadBalancers, &ecs.LoadBalancer{
@@ -153,13 +110,14 @@ func (p *ECSServiceResource) create(ctx context.Context, clientToken string, pro
 		LoadBalancers:  loadBalancers,
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("error creating service: %v", err)
+		return "", nil, fmt.Errorf("error creating service: %v", err)
 	}
 
 	d := primaryDeployment(resp.Service)
 	if d == nil {
-		return "", "", fmt.Errorf("no primary deployment found")
+		return "", data, fmt.Errorf("no primary deployment found")
 	}
+	data["DeploymentId"] = *d.Id
 
 	arn := resp.Service.ServiceArn
 
@@ -180,13 +138,40 @@ func (p *ECSServiceResource) create(ctx context.Context, clientToken string, pro
 	select {
 	case <-stabilized:
 	case <-ctx.Done():
-		return *arn, *d.Id, ctx.Err()
+		return *arn, data, ctx.Err()
 	}
 
-	return *arn, *d.Id, nil
+	return *arn, data, nil
 }
 
-func (p *ECSServiceResource) delete(ctx context.Context, service, cluster *string) error {
+func (p *ECSServiceResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
+	properties := req.ResourceProperties.(*ECSServiceProperties)
+	data := make(map[string]string)
+
+	resp, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
+		Service:        aws.String(req.PhysicalResourceId),
+		Cluster:        properties.Cluster,
+		DesiredCount:   properties.DesiredCount.Value(),
+		TaskDefinition: properties.TaskDefinition,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	d := primaryDeployment(resp.Service)
+	if d == nil {
+		return nil, fmt.Errorf("no primary deployment found")
+	}
+
+	data["DeploymentId"] = *d.Id
+	return data, nil
+}
+
+func (p *ECSServiceResource) Delete(ctx context.Context, req customresources.Request) error {
+	properties := req.ResourceProperties.(*ECSServiceProperties)
+	service := aws.String(req.PhysicalResourceId)
+	cluster := properties.Cluster
+
 	// We have to scale the service down to 0, before we're able to
 	// destroy it.
 	if _, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
@@ -267,7 +252,6 @@ func newECSTaskDefinitionProvisioner(resource *ECSTaskDefinitionResource) *provi
 			return &ECSTaskDefinitionProperties{}
 		},
 		Create: resource.Create,
-		Update: resource.Update,
 		Delete: resource.Delete,
 	}
 }
@@ -276,13 +260,6 @@ func (p *ECSTaskDefinitionResource) Create(ctx context.Context, req customresour
 	properties := req.ResourceProperties.(*ECSTaskDefinitionProperties)
 	id, err := p.register(properties, req.Hash())
 	return id, nil, err
-}
-
-func (p *ECSTaskDefinitionResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
-	// Updates of ECSTaskDefinition will generate a replacement resource, so
-	// if we've reached this point, it means that the environment is the
-	// same as it was before.
-	return nil, nil
 }
 
 func (p *ECSTaskDefinitionResource) Delete(ctx context.Context, req customresources.Request) error {
@@ -376,7 +353,7 @@ func (p *ECSTaskDefinitionResource) delete(arn string) error {
 // ECSEnvironmentProperties are the properties provided to the
 // Custom::ECSEnvironment custom resource.
 type ECSEnvironmentProperties struct {
-	Environment []*ecs.KeyValuePair `hash:"set"`
+	Environment []*ecs.KeyValuePair
 }
 
 func (p *ECSEnvironmentProperties) ReplacementHash() (uint64, error) {
@@ -396,7 +373,6 @@ func newECSEnvironmentProvisioner(resource *ECSEnvironmentResource) *provisioner
 			return &ECSEnvironmentProperties{}
 		},
 		Create: resource.Create,
-		Update: resource.Update,
 		Delete: resource.Delete,
 	}
 }
@@ -405,13 +381,6 @@ func (p *ECSEnvironmentResource) Create(ctx context.Context, req customresources
 	properties := req.ResourceProperties.(*ECSEnvironmentProperties)
 	id, err := p.environmentStore.store(properties.Environment)
 	return id, nil, err
-}
-
-func (p *ECSEnvironmentResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
-	// Updates of ECSEnvironment will generate a replacement resource, so if
-	// we've reached this point, it means that the environment is the same
-	// as it was before.
-	return nil, nil
 }
 
 func (p *ECSEnvironmentResource) Delete(ctx context.Context, req customresources.Request) error {
@@ -463,30 +432,6 @@ func (s *dbEnvironmentStore) fetch(id string) ([]*ecs.KeyValuePair, error) {
 	var env ecsKeyValuePair
 	err := s.db.QueryRow(sql, id).Scan(&env)
 	return env, err
-}
-
-// Certain parameters cannot be updated on existing services, so we need to
-// create a new physical resource.
-func serviceRequiresReplacement(new, old *ECSServiceProperties) bool {
-	eq := reflect.DeepEqual
-
-	if !eq(new.Cluster, old.Cluster) {
-		return true
-	}
-
-	if !eq(new.Role, old.Role) {
-		return true
-	}
-
-	if !eq(new.ServiceName, old.ServiceName) {
-		return true
-	}
-
-	if !eq(new.LoadBalancers, old.LoadBalancers) {
-		return true
-	}
-
-	return false
 }
 
 func primaryDeployment(service *ecs.Service) *ecs.Deployment {

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -230,6 +230,61 @@ func TestECSServiceResource_Update_RequiresReplacement(t *testing.T) {
 	e.AssertExpectations(t)
 }
 
+func TestECSServiceResource_Update_Placement(t *testing.T) {
+	e := new(mockECS)
+	p := newECSServiceProvisioner(&ECSServiceResource{
+		ecs: e,
+	})
+
+	e.On("CreateService", &ecs.CreateServiceInput{
+		ClientToken:    aws.String("dxRU5tYsnzt"),
+		ServiceName:    aws.String("acme-inc-web-dxRU5tYsnzt"),
+		Cluster:        aws.String("clusterA"),
+		DesiredCount:   aws.Int64(2),
+		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+		PlacementConstraints: []*ecs.PlacementConstraint{
+			{Type: aws.String("memberOf"), Expression: aws.String("attribute:ecs.instance-type =~ t2.*")},
+		},
+	}).Return(&ecs.CreateServiceOutput{
+		Service: &ecs.Service{
+			ServiceArn:  aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt"),
+			Deployments: []*ecs.Deployment{&ecs.Deployment{Id: aws.String("New"), Status: aws.String("PRIMARY")}},
+		},
+	}, nil)
+
+	e.On("WaitUntilServicesStable", &ecs.DescribeServicesInput{
+		Cluster:  aws.String("clusterA"),
+		Services: []*string{aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt")},
+	}).Return(nil)
+
+	id, data, err := p.Provision(ctx, customresources.Request{
+		StackId:            "arn:aws:cloudformation:us-east-1:012345678901:stack/acme-inc/bc66fd60-32be-11e6-902b-50d501eb4c17",
+		RequestId:          "411f3f38-565f-4216-a711-aeafd5ba635e",
+		RequestType:        customresources.Update,
+		PhysicalResourceId: "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt",
+		ResourceProperties: &ECSServiceProperties{
+			Cluster:        aws.String("clusterA"),
+			ServiceName:    aws.String("acme-inc-web"),
+			DesiredCount:   customresources.Int(2),
+			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+			PlacementConstraints: []ECSPlacementConstraint{
+				{Type: aws.String("memberOf"), Expression: aws.String("attribute:ecs.instance-type =~ t2.*")},
+			},
+		},
+		OldResourceProperties: &ECSServiceProperties{
+			Cluster:        aws.String("clusterA"),
+			ServiceName:    aws.String("acme-inc-web"),
+			DesiredCount:   customresources.Int(1),
+			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web-dxRU5tYsnzt", id)
+	assert.Equal(t, data, map[string]string{"DeploymentId": "New"})
+
+	e.AssertExpectations(t)
+}
+
 func TestECSServiceResource_Delete(t *testing.T) {
 	e := new(mockECS)
 	p := newECSServiceProvisioner(&ECSServiceResource{
@@ -349,6 +404,12 @@ func TestECSTaskDefinition_Create(t *testing.T) {
 				},
 			},
 		},
+		PlacementConstraints: []*ecs.TaskDefinitionPlacementConstraint{
+			{
+				Type:       aws.String("memberOf"),
+				Expression: aws.String("attribute:instance-type =~ t1.micro"),
+			},
+		},
 	}).Return(&ecs.RegisterTaskDefinitionOutput{
 		TaskDefinition: &ecs.TaskDefinition{
 			TaskDefinitionArn: aws.String("arn:aws:ecs:us-east-1:012345678901:task-definition/acme-inc-web"),
@@ -365,6 +426,12 @@ func TestECSTaskDefinition_Create(t *testing.T) {
 						"003483d3-74b8-465d-8c2e-06e005dda776",
 						"ccc8a1ac-32f9-4576-bec6-4ca36520deb3",
 					},
+				},
+			},
+			PlacementConstraints: []ECSPlacementConstraint{
+				{
+					Type:       aws.String("memberOf"),
+					Expression: aws.String("attribute:instance-type =~ t1.micro"),
 				},
 			},
 		},

--- a/server/cloudformation/ports.go
+++ b/server/cloudformation/ports.go
@@ -15,38 +15,36 @@ type portAllocator interface {
 	Put(port int64) error
 }
 
-// InstancePortsProvisioner is a Provisioner that allocates instance ports.
-type InstancePortsProvisioner struct {
+// InstancePortsResource is a Provisioner that allocates instance ports.
+type InstancePortsResource struct {
 	ports portAllocator
 }
 
-func (p *InstancePortsProvisioner) Properties() interface{} {
+func newInstancePortsProvisioner(resource *InstancePortsResource) *provisioner {
+	return &provisioner{
+		Create: resource.Create,
+		Delete: resource.Delete,
+	}
+}
+
+func (p *InstancePortsResource) Properties() interface{} {
 	return nil
 }
 
-func (p *InstancePortsProvisioner) Provision(_ context.Context, req customresources.Request) (id string, data interface{}, err error) {
-	switch req.RequestType {
-	case customresources.Create:
-		var port int64
-		port, err = p.ports.Get()
-		if err != nil {
-			return
-		}
-		id = fmt.Sprintf("%d", port)
-		data = map[string]int64{"InstancePort": port}
-	case customresources.Delete:
-		port, err2 := strconv.Atoi(req.PhysicalResourceId)
-		if err2 != nil {
-			err = fmt.Errorf("physical resource id should have been a port number: %v", err2)
-			return
-		}
-		id = req.PhysicalResourceId
-		err = p.ports.Put(int64(port))
-	default:
-		err = fmt.Errorf("%s is not supported", req.RequestType)
-	}
+func (p *InstancePortsResource) Create(_ context.Context, req customresources.Request) (string, interface{}, error) {
+	var port int64
+	port, err := p.ports.Get()
+	data := map[string]int64{"InstancePort": port}
+	id := fmt.Sprintf("%d", port)
+	return id, data, err
+}
 
-	return
+func (p *InstancePortsResource) Delete(_ context.Context, req customresources.Request) error {
+	port, err := strconv.Atoi(req.PhysicalResourceId)
+	if err != nil {
+		return fmt.Errorf("physical resource id should have been a port number: %v", err)
+	}
+	return p.ports.Put(int64(port))
 }
 
 // dbPortAllocator implements the portAllocator interface backed by database/sql.

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -10,6 +10,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/empiretest"
 	"github.com/remind101/empire/pkg/image"
@@ -501,6 +503,15 @@ func TestEmpire_Run_WithAllowCommandProcfile(t *testing.T) {
 				Labels: map[string]string{
 					"empire.app.process": "rake",
 					"empire.user":        "ejholmes",
+				},
+				ECS: &procfile.ECS{
+					PlacementConstraints: []*ecs.PlacementConstraint{
+						&ecs.PlacementConstraint{
+							Type:       aws.String("memberOf"),
+							Expression: aws.String("attribute:profile = background"),
+						},
+					},
+					PlacementStrategy: []*ecs.PlacementStrategy{},
 				},
 			},
 		},

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -308,26 +308,28 @@ func TestEmpire_Run(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v1",
 		},
-	},
-		&twelvefactor.Process{
-			Type:      "run",
-			Image:     img,
-			Command:   []string{"bundle", "exec", "rake", "db:migrate"},
-			Quantity:  1,
-			Memory:    536870912,
-			CPUShares: 256,
-			Nproc:     256,
-			Env: map[string]string{
-				"EMPIRE_PROCESS":       "run",
-				"EMPIRE_PROCESS_SCALE": "1",
-				"SOURCE":               "acme-inc.run.v1",
-				"TERM":                 "xterm",
+		Processes: []*twelvefactor.Process{
+			&twelvefactor.Process{
+				Type:      "run",
+				Image:     img,
+				Command:   []string{"bundle", "exec", "rake", "db:migrate"},
+				Quantity:  1,
+				Memory:    536870912,
+				CPUShares: 256,
+				Nproc:     256,
+				Env: map[string]string{
+					"EMPIRE_PROCESS":       "run",
+					"EMPIRE_PROCESS_SCALE": "1",
+					"SOURCE":               "acme-inc.run.v1",
+					"TERM":                 "xterm",
+				},
+				Labels: map[string]string{
+					"empire.app.process": "run",
+					"empire.user":        "ejholmes",
+				},
 			},
-			Labels: map[string]string{
-				"empire.app.process": "run",
-				"empire.user":        "ejholmes",
-			},
-		}, nil, nil).Return(nil)
+		},
+	}, nil, nil).Return(nil)
 
 	err = e.Run(context.Background(), empire.RunOpts{
 		User:    user,
@@ -384,26 +386,28 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 			"empire.app.id":      app.ID,
 			"empire.app.release": "v1",
 		},
-	},
-		&twelvefactor.Process{
-			Type:      "run",
-			Image:     img,
-			Command:   []string{"bundle", "exec", "rake", "db:migrate"},
-			Quantity:  1,
-			Memory:    1073741824,
-			CPUShares: 512,
-			Nproc:     512,
-			Env: map[string]string{
-				"EMPIRE_PROCESS":       "run",
-				"EMPIRE_PROCESS_SCALE": "1",
-				"SOURCE":               "acme-inc.run.v1",
-				"TERM":                 "xterm",
+		Processes: []*twelvefactor.Process{
+			&twelvefactor.Process{
+				Type:      "run",
+				Image:     img,
+				Command:   []string{"bundle", "exec", "rake", "db:migrate"},
+				Quantity:  1,
+				Memory:    1073741824,
+				CPUShares: 512,
+				Nproc:     512,
+				Env: map[string]string{
+					"EMPIRE_PROCESS":       "run",
+					"EMPIRE_PROCESS_SCALE": "1",
+					"SOURCE":               "acme-inc.run.v1",
+					"TERM":                 "xterm",
+				},
+				Labels: map[string]string{
+					"empire.app.process": "run",
+					"empire.user":        "ejholmes",
+				},
 			},
-			Labels: map[string]string{
-				"empire.app.process": "run",
-				"empire.user":        "ejholmes",
-			},
-		}, nil, nil).Return(nil)
+		},
+	}, nil, nil).Return(nil)
 
 	constraints := empire.NamedConstraints["2X"]
 	err = e.Run(context.Background(), empire.RunOpts{
@@ -479,26 +483,28 @@ func TestEmpire_Run_WithAllowCommandProcfile(t *testing.T) {
 			"empire.app.name":    "acme-inc",
 			"empire.app.release": "v1",
 		},
-	},
-		&twelvefactor.Process{
-			Type:      "rake",
-			Image:     img,
-			Command:   []string{"bundle", "exec", "rake", "db:migrate"},
-			Quantity:  1,
-			Memory:    536870912,
-			CPUShares: 256,
-			Nproc:     256,
-			Env: map[string]string{
-				"EMPIRE_PROCESS":       "rake",
-				"EMPIRE_PROCESS_SCALE": "1",
-				"SOURCE":               "acme-inc.rake.v1",
-				"TERM":                 "xterm",
+		Processes: []*twelvefactor.Process{
+			&twelvefactor.Process{
+				Type:      "rake",
+				Image:     img,
+				Command:   []string{"bundle", "exec", "rake", "db:migrate"},
+				Quantity:  1,
+				Memory:    536870912,
+				CPUShares: 256,
+				Nproc:     256,
+				Env: map[string]string{
+					"EMPIRE_PROCESS":       "rake",
+					"EMPIRE_PROCESS_SCALE": "1",
+					"SOURCE":               "acme-inc.rake.v1",
+					"TERM":                 "xterm",
+				},
+				Labels: map[string]string{
+					"empire.app.process": "rake",
+					"empire.user":        "ejholmes",
+				},
 			},
-			Labels: map[string]string{
-				"empire.app.process": "rake",
-				"empire.user":        "ejholmes",
-			},
-		}, nil, nil).Return(nil)
+		},
+	}, nil, nil).Return(nil)
 
 	err = e.Run(context.Background(), empire.RunOpts{
 		User:    user,
@@ -683,8 +689,7 @@ func (m *mockScheduler) Submit(_ context.Context, app *twelvefactor.Manifest, ss
 	return args.Error(0)
 }
 
-func (m *mockScheduler) Run(_ context.Context, app *twelvefactor.Manifest, process *twelvefactor.Process, in io.Reader, out io.Writer) error {
-	app.Processes = nil // This is bogus and doesn't actually matter for Runs.
-	args := m.Called(app, process, in, out)
+func (m *mockScheduler) Run(_ context.Context, app *twelvefactor.Manifest, in io.Reader, out io.Writer) error {
+	args := m.Called(app, in, out)
 	return args.Error(0)
 }

--- a/twelvefactor/twelvefactor.go
+++ b/twelvefactor/twelvefactor.go
@@ -154,14 +154,10 @@ type Task struct {
 	UpdatedAt time.Time
 }
 
-type Runner interface {
-	// Run runs a process.
-	Run(ctx context.Context, app *Manifest, process *Process, in io.Reader, out io.Writer) error
-}
-
 // Scheduler is an interface for interfacing with Services.
 type Scheduler interface {
-	Runner
+	// Run runs a process.
+	Run(ctx context.Context, app *Manifest, in io.Reader, out io.Writer) error
 
 	// Submit submits an app, creating it or updating it as necessary.
 	// When StatusStream is nil, Submit should return as quickly as possible,

--- a/twelvefactor/twelvefactor.go
+++ b/twelvefactor/twelvefactor.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/remind101/empire/pkg/image"
+	"github.com/remind101/empire/procfile"
 )
 
 type Manifest struct {
@@ -65,6 +66,9 @@ type Process struct {
 
 	// Can be used to setup a CRON schedule to run this task periodically.
 	Schedule Schedule
+
+	// Any ECS specific configuration.
+	ECS *procfile.ECS
 }
 
 // Schedule represents a Schedule for scheduled tasks that run periodically.

--- a/twelvefactor/twelvefactor.go
+++ b/twelvefactor/twelvefactor.go
@@ -177,7 +177,7 @@ type Scheduler interface {
 	Stop(ctx context.Context, instanceID string) error
 
 	// Restart restarts the processes within the App.
-	Restart(context.Context, *Manifest, StatusStream) error
+	Restart(context.Context, string, StatusStream) error
 }
 
 // Env merges the App environment with any environment variables provided


### PR DESCRIPTION
This adds support to the procfile for specifying ECS [placement constraints](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html) and [placement strategies](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html).

I cherry-picked https://github.com/remind101/empire/pull/941 into this, since it makes it easier, so may be better to only look at the second commit.