### PR TITLE
Fix regression in env-load subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Empire now supports a new (experimental) feature to enable attached processes to be ran with ECS. [#1043](https://github.com/remind101/empire/pull/1043)
 
+**Bugs**
+
+* Fixed a regression in env-load, which caused it to set keys to random values. [#1062](https://github.com/remind101/empire/pull/1062)
+
 ## 0.12.0 (2017-03-10)
 
 **Features**

--- a/cmd/emp/env.go
+++ b/cmd/emp/env.go
@@ -161,6 +161,7 @@ func runEnvLoad(cmd *Command, args []string) {
 
 	config := make(map[string]*string)
 	for key, value := range parsedVars {
+		value := value
 		config[key] = &value
 	}
 

--- a/tests/cli/env_test.go
+++ b/tests/cli/env_test.go
@@ -124,7 +124,7 @@ func TestEnvConfig(t *testing.T) {
 	}
 	defer os.Remove(f.Name())
 
-	content := []byte("FOO=bar\\nmoarbar\n")
+	content := []byte("FOO=bar\\nmoarbar\nBAR=foo")
 	f.Write(content)
 
 	run(t, []Command{
@@ -132,6 +132,10 @@ func TestEnvConfig(t *testing.T) {
 		{
 			fmt.Sprintf("env-load %s -a acme-inc", f.Name()),
 			fmt.Sprintf("Updated env vars from %s and restarted acme-inc.", f.Name()),
+		},
+		{
+			"env -a acme-inc",
+			"BAR=foo\nFOO=bar\\nmoarbar",
 		},
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/remind101/empire/issues/1061

This fixes an issue where env-load behaved inconsistently, where keys
would be set to random values. The behavior is best described by
https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables,
which states that it's a mistake to use a pointer in a `range` loop
without first copying it.

I feel like this is something that should be caught by `go vet`, but isn't.