### PR TITLE
Allow scaling process to negative values to remove resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Fixed a regression in env-load, which caused it to set keys to random values. [#1062](https://github.com/remind101/empire/pull/1062)
 * Fixed an issue where the ECS task role was not set on tasks started from `emp run`. [#1063](https://github.com/remind101/empire/pull/1063)
 
+**Improvements**
+
+* Processes can now be scaled down to a negative value to prevent AWS resources from being created. [#1064](https://github.com/remind101/empire/pull/1064)
+* AWS resources for scheduled processes are now always created, unless scaled down to a negative value. [#1064](https://github.com/remind101/empire/pull/1064)
+
 ## 0.12.0 (2017-03-10)
 
 **Features**

--- a/cmd/emp/scale.go
+++ b/cmd/emp/scale.go
@@ -97,8 +97,8 @@ func runScale(cmd *Command, args []string) {
 		types[pstype] = true
 
 		opt := heroku.FormationBatchUpdateOpts{Process: pstype}
-		if qty != -1 {
-			opt.Quantity = &qty
+		if qty != nil {
+			opt.Quantity = qty
 		}
 		if size != "" {
 			opt.Size = &size
@@ -137,8 +137,7 @@ func formatResults(formations []heroku.Formation) []string {
 
 var errInvalidScaleArg = errors.New("invalid argument")
 
-func parseScaleArg(arg string) (pstype string, qty int, size string, err error) {
-	qty = -1
+func parseScaleArg(arg string) (pstype string, qty *int, size string, err error) {
 	iEquals := strings.IndexRune(arg, '=')
 	if fields := strings.Fields(arg); len(fields) > 1 || iEquals == -1 {
 		err = errInvalidScaleArg
@@ -154,25 +153,27 @@ func parseScaleArg(arg string) (pstype string, qty int, size string, err error) 
 
 	if iColon := strings.IndexRune(rem, ':'); iColon == -1 {
 		if iX := strings.IndexRune(rem, 'X'); iX == -1 {
-			qty, err = strconv.Atoi(rem)
+			v, err := strconv.Atoi(rem)
 			if err != nil {
-				return pstype, -1, "", errInvalidScaleArg
+				return pstype, nil, "", errInvalidScaleArg
 			}
+			qty = &v
 		} else {
 			size = rem
 		}
 	} else {
 		if iColon > 0 {
-			qty, err = strconv.Atoi(rem[:iColon])
+			v, err := strconv.Atoi(rem[:iColon])
 			if err != nil {
-				return pstype, -1, "", errInvalidScaleArg
+				return pstype, nil, "", errInvalidScaleArg
 			}
+			qty = &v
 		}
 		if len(rem) > iColon+1 {
 			size = rem[iColon+1:]
 		}
 	}
-	if err != nil || qty == -1 && size == "" {
+	if err != nil || qty == nil && size == "" {
 		err = errInvalidScaleArg
 	}
 	return

--- a/cmd/emp/scale_test.go
+++ b/cmd/emp/scale_test.go
@@ -1,31 +1,37 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 )
+
+func qty(v int) *int {
+	return &v
+}
 
 var parseScaleTests = []struct {
 	in     string
 	pstype string
-	qty    int
+	qty    *int
 	size   string
 	err    error
 }{
-	{"web=5", "web", 5, "", nil},
-	{"bg_worker=50:1X", "bg_worker", 50, "1X", nil},
-	{"bg_worker=50:PX", "bg_worker", 50, "PX", nil},
-	{"web=:2X", "web", -1, "2X", nil},
-	{"web=:PX", "web", -1, "PX", nil},
-	{"web=1X", "web", -1, "1X", nil},
-	{"web=1x", "web", -1, "1X", nil},
-	{"web=PX", "web", -1, "PX", nil},
-	{"web=px", "web", -1, "PX", nil},
-	{"web=1X:5", "web", -1, "", errInvalidScaleArg},
-	{"web=PX:5", "web", -1, "", errInvalidScaleArg},
-	{"web", "", -1, "", errInvalidScaleArg},
-	{"web=", "web", -1, "", errInvalidScaleArg},
-	{"web =", "", -1, "", errInvalidScaleArg},
-	{"web=1X: 5", "", -1, "", errInvalidScaleArg},
+	{"web=5", "web", qty(5), "", nil},
+	{"bg_worker=50:1X", "bg_worker", qty(50), "1X", nil},
+	{"bg_worker=50:PX", "bg_worker", qty(50), "PX", nil},
+	{"web=:2X", "web", nil, "2X", nil},
+	{"web=:PX", "web", nil, "PX", nil},
+	{"web=1X", "web", nil, "1X", nil},
+	{"web=1x", "web", nil, "1X", nil},
+	{"web=PX", "web", nil, "PX", nil},
+	{"web=px", "web", nil, "PX", nil},
+	{"worker=-1", "worker", qty(-1), "", nil},
+	{"web=1X:5", "web", nil, "", errInvalidScaleArg},
+	{"web=PX:5", "web", nil, "", errInvalidScaleArg},
+	{"web", "", nil, "", errInvalidScaleArg},
+	{"web=", "web", nil, "", errInvalidScaleArg},
+	{"web =", "", nil, "", errInvalidScaleArg},
+	{"web=1X: 5", "", nil, "", errInvalidScaleArg},
 }
 
 func TestParseScaleArg(t *testing.T) {
@@ -34,7 +40,7 @@ func TestParseScaleArg(t *testing.T) {
 		if pstype != pt.pstype {
 			t.Errorf("%d. parseScaleArg(%q).pstype => %q, want %q", i, pt.in, pstype, pt.pstype)
 		}
-		if qty != pt.qty {
+		if !reflect.DeepEqual(qty, pt.qty) {
 			t.Errorf("%d. parseScaleArg(%q).qty => %d, want %d", i, pt.in, qty, pt.qty)
 		}
 		if size != pt.size {

--- a/scheduler/cloudformation/templates/cron.json
+++ b/scheduler/cloudformation/templates/cron.json
@@ -175,6 +175,106 @@
         }
       },
       "Type": "AWS::Lambda::Permission"
+    },
+    "vacuumTaskDefinition": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "./bin/vacuum"
+            ],
+            "Cpu": 256,
+            "DockerLabels": {
+              "empire.app.process": "vacuum"
+            },
+            "Environment": [],
+            "Essential": true,
+            "Image": "remind101/acme-inc:latest",
+            "Memory": 128,
+            "Name": "vacuum",
+            "Ulimits": [
+              {
+                "HardLimit": 256,
+                "Name": "nproc",
+                "SoftLimit": 256
+              }
+            ]
+          }
+        ],
+        "Volumes": []
+      },
+      "Type": "AWS::ECS::TaskDefinition"
+    },
+    "vacuumTrigger": {
+      "Properties": {
+        "Description": "Rule to periodically trigger the `vacuum` scheduled task",
+        "RoleArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:iam::",
+              {
+                "Ref": "AWS::AccountId"
+              },
+              ":role/",
+              "ecsServiceRole"
+            ]
+          ]
+        },
+        "ScheduleExpression": "cron(* * * * *)",
+        "State": "DISABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RunTaskFunction",
+                "Arn"
+              ]
+            },
+            "Id": "f",
+            "Input": {
+              "Fn::Join": [
+                "",
+                [
+                  "{\"taskDefinition\":\"",
+                  {
+                    "Ref": "vacuumTaskDefinition"
+                  },
+                  "\",\"count\":",
+                  {
+                    "Ref": "vacuumScale"
+                  },
+                  ",\"cluster\":\"",
+                  "cluster",
+                  "\",\"startedBy\": \"",
+                  "1234",
+                  "\"}"
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "Type": "AWS::Events::Rule"
+    },
+    "vacuumTriggerPermission": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RunTaskFunction",
+            "Arn"
+          ]
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "vacuumTrigger",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Permission"
     }
   }
 }

--- a/scheduler/fake.go
+++ b/scheduler/fake.go
@@ -31,22 +31,6 @@ func (m *FakeScheduler) Restart(ctx context.Context, app *App, ss StatusStream) 
 	return m.Submit(ctx, app, ss)
 }
 
-func (m *FakeScheduler) Scale(ctx context.Context, app string, ptype string, instances uint) error {
-	if a, ok := m.apps[app]; ok {
-		var process *Process
-		for _, p := range a.Processes {
-			if p.Type == ptype {
-				process = p
-			}
-		}
-
-		if process != nil {
-			process.Instances = instances
-		}
-	}
-	return nil
-}
-
 func (m *FakeScheduler) Remove(ctx context.Context, appID string) error {
 	delete(m.apps, appID)
 	return nil
@@ -58,7 +42,7 @@ func (m *FakeScheduler) Instances(ctx context.Context, appID string) ([]*Instanc
 		for _, p := range a.Processes {
 			pp := *p
 			pp.Env = Env(a, p)
-			for i := uint(1); i <= p.Instances; i++ {
+			for i := 1; i <= p.Instances; i++ {
 				instances = append(instances, &Instance{
 					ID:        fmt.Sprintf("%d", i),
 					Host:      Host{ID: "i-aa111aa1"},

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -60,7 +60,7 @@ type Process struct {
 	Nproc uint
 
 	// Instances is the desired instances of this service to run.
-	Instances uint
+	Instances int
 
 	// Exposure is the level of exposure for this process.
 	Exposure *Exposure

--- a/tests/cli/scale_test.go
+++ b/tests/cli/scale_test.go
@@ -33,6 +33,10 @@ v1.web.2  i-aa111aa1  1X  running   5d  "./bin/web"`,
 			"dynos -a acme-inc",
 			"v1.web.1  i-aa111aa1  1X  running   5d  \"./bin/web\"",
 		},
+		{
+			"scale web=-1 -a acme-inc",
+			"Scaled acme-inc to web=-1:1X.",
+		},
 	})
 }
 


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/1042

There's two changes here:

1. Allow processes to be scaled to a negative value, to remove the AWS resources.
2. Removes the condition where resources for scheduled jobs wouldn't be added to the template if the scale was 0. Now they're added, but the CloudWatch Events trigger is disabled if the process is scaled down.