### PR TITLE
Differentiate between added/changed/removed env vars

### DIFF
--- a/events.go
+++ b/events.go
@@ -202,9 +202,9 @@ func (e RollbackEvent) GetApp() *App {
 // SetEvent is triggered when environment variables are changed on an
 // application.
 type SetEvent struct {
+	*VarsDiff
 	User    string
 	App     string
-	Changed []string
 	Message string
 
 	app *App
@@ -215,7 +215,16 @@ func (e SetEvent) Event() string {
 }
 
 func (e SetEvent) String() string {
-	msg := fmt.Sprintf("%s changed environment variables on %s (%s)", e.User, e.App, strings.Join(e.Changed, ", "))
+	msg := fmt.Sprintf("%s changed environment variables on %s", e.User, e.App)
+	if len(e.Added) > 0 {
+		msg += fmt.Sprintf(" (added %s)", strings.Join(e.Added, ", "))
+	}
+	if len(e.Changed) > 0 {
+		msg += fmt.Sprintf(" (changed %s)", strings.Join(e.Changed, ", "))
+	}
+	if len(e.Removed) > 0 {
+		msg += fmt.Sprintf(" (removed %s)", strings.Join(e.Removed, ", "))
+	}
 	return appendCommitMessage(msg, e.Message)
 }
 

--- a/events_test.go
+++ b/events_test.go
@@ -99,8 +99,9 @@ func TestEvents_String(t *testing.T) {
 		{RollbackEvent{User: "ejholmes", App: "acme-inc", Version: 1, Message: "commit message"}, "ejholmes rolled back acme-inc to v1: 'commit message'"},
 
 		// SetEvent
-		{SetEvent{User: "ejholmes", App: "acme-inc", Changed: []string{"RAILS_ENV"}}, "ejholmes changed environment variables on acme-inc (RAILS_ENV)"},
-		{SetEvent{User: "ejholmes", App: "acme-inc", Changed: []string{"RAILS_ENV"}, Message: "commit message"}, "ejholmes changed environment variables on acme-inc (RAILS_ENV): 'commit message'"},
+		{SetEvent{User: "ejholmes", App: "acme-inc", VarsDiff: &VarsDiff{Added: []string{"RAILS_ENV"}}}, "ejholmes changed environment variables on acme-inc (added RAILS_ENV)"},
+		{SetEvent{User: "ejholmes", App: "acme-inc", VarsDiff: &VarsDiff{Changed: []string{"RAILS_ENV"}}, Message: "commit message"}, "ejholmes changed environment variables on acme-inc (changed RAILS_ENV): 'commit message'"},
+		{SetEvent{User: "ejholmes", App: "acme-inc", VarsDiff: &VarsDiff{Changed: []string{"RAILS_ENV"}, Removed: []string{"COOKIE_SECRET"}}, Message: "commit message"}, "ejholmes changed environment variables on acme-inc (changed RAILS_ENV) (removed COOKIE_SECRET): 'commit message'"},
 
 		// CreateEvent
 		{CreateEvent{User: "ejholmes", Name: "acme-inc"}, "ejholmes created acme-inc"},

--- a/tests/cli/env_test.go
+++ b/tests/cli/env_test.go
@@ -117,6 +117,31 @@ func TestConfigConsistency(t *testing.T) {
 	})
 }
 
+func TestConfigNoop(t *testing.T) {
+	run(t, []Command{
+		DeployCommand("latest", "v1"),
+		{
+			"set FOO=bar -a acme-inc",
+			"Set env vars and restarted acme-inc.",
+		},
+		{
+			"releases -a acme-inc",
+			`v1    Dec 31  2014  Deploy remind101/acme-inc:latest (fake)
+v2    Dec 31  2014  Added (FOO) config var (fake)`,
+		},
+		{
+			"set FOO=bar -a acme-inc",
+			"Set env vars and restarted acme-inc.",
+		},
+		{
+			"releases -a acme-inc",
+			`v1    Dec 31  2014  Deploy remind101/acme-inc:latest (fake)
+v2    Dec 31  2014  Added (FOO) config var (fake)
+v3    Dec 31  2014  Made no changes to config vars (fake)`,
+		},
+	})
+}
+
 func TestEnvConfig(t *testing.T) {
 	f, err := ioutil.TempFile(os.TempDir(), "acme-inc.env")
 	if err != nil {

--- a/tests/cli/rollback_test.go
+++ b/tests/cli/rollback_test.go
@@ -18,7 +18,7 @@ func TestRollback(t *testing.T) {
 			"releases -a acme-inc",
 			`v1    Dec 31  2014  Deploy remind101/acme-inc:latest (fake)
 v2    Dec 31  2014  Deploy remind101/acme-inc:latest (fake)
-v3    Dec 31  2014  Set FOO config var (fake)
+v3    Dec 31  2014  Added (FOO) config var (fake)
 v4    Dec 31  2014  Rollback to v1 (fake)`,
 		},
 		{


### PR DESCRIPTION
This makes it so that the SetEvent, and the release description have more information about what environment variables were added/changed/unset during `emp set/unset`. Previously, the SetEvent only said things were "changed", and the release description was buggy in that sometimes it would say "Set" and sometimes it would say "Unset". This made it hard to see what actually happened from `emp set`.