### PR TITLE
Add message to emp help run to prompt user to press enter

### DIFF
--- a/cmd/emp/run.go
+++ b/cmd/emp/run.go
@@ -33,7 +33,9 @@ Run a process on Heroku. Flags such as` + " `-a` " + `may be parsed out of
 the command unless the command is quoted or provided after a
 double-dash (--).
 
-You may need to press enter after this command to continue.
+When running an attached process that reads from stdin (like bash) you may experience a "hang".
+Usually, pressing a key like "enter" will flush the output to your terminal.
+See https://github.com/remind101/empire/issues/609
 
 Options:
 

--- a/cmd/emp/run.go
+++ b/cmd/emp/run.go
@@ -188,6 +188,7 @@ func runRun(cmd *Command, args []string) {
 	case err = <-errChanOut:
 		must(err)
 	}
+	fmt.Println("Press enter to continue")
 }
 
 func dialParams(u *url.URL) (proto, address string) {

--- a/cmd/emp/run.go
+++ b/cmd/emp/run.go
@@ -33,6 +33,8 @@ Run a process on Heroku. Flags such as` + " `-a` " + `may be parsed out of
 the command unless the command is quoted or provided after a
 double-dash (--).
 
+You may need to press enter after this command to continue.
+
 Options:
 
     -s <size>  set the size for this dyno (e.g. 2X)
@@ -188,7 +190,6 @@ func runRun(cmd *Command, args []string) {
 	case err = <-errChanOut:
 		must(err)
 	}
-	fmt.Println("Press enter to continue")
 }
 
 func dialParams(u *url.URL) (proto, address string) {


### PR DESCRIPTION
This isn't immediately obvious and can confuse people (me). A simple message would help.