### PR TITLE
Update ECS AMI link in CONTRIBUTING text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ If you want to contribute to Empire, you may end up wanting to run a local insta
 1. Ensure that you have the AWS CLI installed and configured.
 2. Ensure that you accepted the terms and conditions for the official ECS AMI:
 
-   https://aws.amazon.com/marketplace/ordering?productId=4ce33fd9-63ff-4f35-8d3a-939b641f1931&ref_=dtl_psb_continue&region=us-east-1
+   https://aws.amazon.com/marketplace/fulfillment?productId=52d5fd7f-92c7-4d60-a830-41a596f4d8f3&region=us-east-1
 
    Also check that the offical ECS AMI ID for US East matches with the one in [cloudformation.json](./docs/cloudformation.json): https://github.com/remind101/empire/blob/master/docs/cloudformation.json#L20
 

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -66,7 +66,7 @@
     "AmiId" : {
       "Type": "AWS::EC2::Image::Id",
       "Description": "The AMI id of the AMI to run the instances with. This defaults to the official ECS ami.",
-      "Default": "ami-55870742"
+      "Default": "ami-275ffe31"
     },
     "KeyName": {
       "Type": "String",


### PR DESCRIPTION
Looks like Amazon changed the URLs for their Marketplace apps.

Also the CloudFormation JSON had an old AMI ID there, so it's probably
a good idea to update it

AMI ID was taken from the corrected link.