### PR TITLE
Set Load Balancer internal/external per process instead of per application

### DIFF
--- a/procfile/README.md
+++ b/procfile/README.md
@@ -85,5 +85,6 @@ inside the `Procfile` for a specific process.
 Name | Default value | Available options | Description
 -----|---------------|-------------------|------------
 `EMPIRE_X_LOAD_BALANCER_TYPE` | `elb` | `alb`, `elb`| Determines whether you will use an ALB or ELB
+`EMPIRE_X_EXPOSURE` | `private` | `private`, `public` | Sets whether your ALB or ELB will be public (internet-facing) or private (internal), the default is private, however if you have used the deprecated `domain-add` command then the load balancer will become public. **If you change this setting, the load balancer will be recreated as soon as you deploy**
 `EMPIRE_X_TASK_DEFINITION_TYPE` | not set | `custom` | Determines whether we use the Custom::ECSTaskDefinition (better explanation needed)
 `EMPIRE_X_TASK_ROLE_ARN` | not set | any IAM role ARN | Sets the IAM role for that app/process. **Your ECS cluster MUST have Task Role support enabled before this can work!**

--- a/runner.go
+++ b/runner.go
@@ -48,7 +48,7 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 	if err != nil {
 		return err
 	}
-	p, err := newSchedulerProcess(release, procName, proc)
+	p, err := newSchedulerProcess(release, procName, proc, a.Env)
 	if err != nil {
 		return err
 	}

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"reflect"
 	"regexp"
 	"sort"
@@ -403,11 +404,13 @@ func (t *EmpireTemplate) addService(tmpl *troposphere.Template, app *twelvefacto
 		scheme := schemeInternal
 		sg := t.InternalSecurityGroupID
 		subnets := t.InternalSubnetIDs
+		targetGroupPrefix := "Internal"
 
 		if p.Exposure.External {
 			scheme = schemeExternal
 			sg = t.ExternalSecurityGroupID
 			subnets = t.ExternalSubnetIDs
+			targetGroupPrefix = "External"
 		}
 
 		loadBalancerType := loadBalancerType(app, p)
@@ -435,7 +438,8 @@ func (t *EmpireTemplate) addService(tmpl *troposphere.Template, app *twelvefacto
 
 			tmpl.AddResource(loadBalancer)
 
-			targetGroup := fmt.Sprintf("%sTargetGroup", key)
+			targetGroup := fmt.Sprintf("%s%sTargetGroup", key, targetGroupPrefix)
+			log.Printf("using TargetGroup name %s\n", targetGroup)
 			tmpl.Resources[targetGroup] = troposphere.Resource{
 				Type: "AWS::ElasticLoadBalancingV2::TargetGroup",
 				Properties: map[string]interface{}{

--- a/twelvefactor/twelvefactor.go
+++ b/twelvefactor/twelvefactor.go
@@ -187,16 +187,16 @@ type Scheduler interface {
 // Env merges the App environment with any environment variables provided
 // in the process.
 func Env(app *Manifest, process *Process) map[string]string {
-	return merge(app.Env, process.Env)
+	return Merge(app.Env, process.Env)
 }
 
 // Labels merges the App labels with any labels provided in the process.
 func Labels(app *Manifest, process *Process) map[string]string {
-	return merge(app.Labels, process.Labels)
+	return Merge(app.Labels, process.Labels)
 }
 
 // merges the maps together, favoring keys from the right to the left.
-func merge(envs ...map[string]string) map[string]string {
+func Merge(envs ...map[string]string) map[string]string {
 	merged := make(map[string]string)
 	for _, env := range envs {
 		for k, v := range env {


### PR DESCRIPTION
Introduces EMPIRE_X_EXPOSURE which needs to be `public`.

If that environment variable is not set, we fallback to the default selection via application (where you use `domain-add`).

Added this explanation in the Procfile doc.

Fixes #1076

Things working and tested:
- [x] Creating a new application using Procfile work as specified (one internal and one external ALB) https://github.com/iserko/flask_test/blob/f369c115fd41a0086d364f38b693a353963c041d/Procfile :white_check_mark:
- [x] Modifying a running application by setting this environment variable and deploying ✅ (new ALB/ELB gets created and the old one is **deleted**)
- [x] When using old Procfile format doing `env set EMPIRE_X_EXPOSURE=public` creates a public ALB/ELB
- [x] Migrating from old Procfile with an internal ALB/ELB to new Procfile format (LB is not recreated)
- [x] Migrating from old Procfile with an external ALB/ELB to new Procfile format (LB is not recreated)

The biggest thing is that this setting shouldn't be considered as harmless. If you change it ... your load balancer WILL get recreated.

@ejholmes Thoughts?