### PR TITLE
Allow tests to be run with docker-compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,25 @@ Unit tests live alongside each go file as `_test.go`.
 
 There is also a `tests` directory that contains integration and functional tests that tests the system using the [heroku-go][heroku-go] client and the [emp][emp] command.
 
+The easiest way to run the tests is by using [docker-compose](https://docs.docker.com/compose/).
+
+### Docker Compose
+
+To get started, run:
+
+```console
+$ docker-compose -f docker-compose.test.yml build
+$ docker-compose -f docker-compose.test.yml up -d db
+```
+
+Then run the tests with:
+
+```console
+$ docker-compose -f docker-compose.test.yml run tests
+```
+
+### Mac
+
 To get started, run:
 
 ```console

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,10 @@
+FROM golang:1.7.0
+MAINTAINER Eric Holmes <eric@remind101.com>
+
+RUN apt-get update -yy && \
+  apt-get install -yy git make curl libxml2-dev libxmlsec1-dev liblzma-dev pkg-config xmlsec1
+
+WORKDIR /go/src/github.com/remind101/empire
+
+ENTRYPOINT ["make"]
+CMD ["test"]

--- a/db.go
+++ b/db.go
@@ -10,6 +10,9 @@ import (
 	"github.com/remind101/migrate"
 )
 
+// Empire only supports postgres at the moment.
+const DBDriver = "postgres"
+
 // IncompatibleSchemaError is an error that gets returned from
 // CheckSchemaVersion.
 type IncompatibleSchemaError struct {
@@ -33,17 +36,22 @@ type DB struct {
 
 // OpenDB returns a new gorm.DB instance.
 func OpenDB(uri string) (*DB, error) {
-	u, err := url.Parse(uri)
+	_, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
 	}
 
-	conn, err := sql.Open(u.Scheme, uri)
+	conn, err := sql.Open(DBDriver, uri)
 	if err != nil {
 		return nil, err
 	}
 
-	db, err := gorm.Open(u.Scheme, conn)
+	return NewDB(conn)
+}
+
+// NewDB wraps a sql.DB instance as a DB.
+func NewDB(conn *sql.DB) (*DB, error) {
+	db, err := gorm.Open(DBDriver, conn)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +66,6 @@ func OpenDB(uri string) (*DB, error) {
 
 	return &DB{
 		DB:       &db,
-		uri:      uri,
 		migrator: m,
 	}, nil
 }

--- a/dbtest/dbtest.go
+++ b/dbtest/dbtest.go
@@ -1,0 +1,26 @@
+package dbtest
+
+import (
+	"database/sql"
+	"flag"
+	"os"
+	"testing"
+)
+
+var DatabaseURL = flag.String("db.url", getenv("TEST_DATABASE_URL", "postgres://localhost/empire?sslmode=disable"), "A connection string where a postgres instance is running.")
+
+func Open(t testing.TB) *sql.DB {
+	db, err := sql.Open("postgres", *DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func getenv(key, fallback string) string {
+	v, ok := os.LookupEnv(key)
+	if ok {
+		return v
+	}
+	return fallback
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    entrypoint: make
+    command: test
+    links:
+      - db:db
+    volumes:
+      - ".:/go/src/github.com/remind101/empire"
+    environment:
+      TEST_DATABASE_URL: "postgres://postgres:postgres@db/postgres?sslmode=disable"
+  db:
+    image: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,21 @@
-server:
-  build: .
-  command: server -automigrate=true
-  links:
-    - db:db
-  ports:
-    - "8080:8080"
-  volumes:
-    - ~/.dockercfg:/root/.dockercfg
-    - "/var/run/docker.sock:/var/run/docker.sock"
-  env_file: .env
-  user: root
-  environment:
-    EMPIRE_DATABASE_URL: postgres://postgres:postgres@db/postgres?sslmode=disable
-    DOCKER_HOST: unix:///var/run/docker.sock
-    EMPIRE_X_SHOW_ATTACHED: 'true'
-db:
-  image: postgres
+version: '2'
+
+services:
+  server:
+    build: .
+    command: server -automigrate=true
+    links:
+      - db:db
+    ports:
+      - "8080:8080"
+    volumes:
+      - ~/.dockercfg:/root/.dockercfg
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    env_file: .env
+    user: root
+    environment:
+      EMPIRE_DATABASE_URL: postgres://postgres:postgres@db/postgres?sslmode=disable
+      DOCKER_HOST: unix:///var/run/docker.sock
+      EMPIRE_X_SHOW_ATTACHED: 'true'
+  db:
+    image: postgres

--- a/empire_test.go
+++ b/empire_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/remind101/empire"
+	"github.com/remind101/empire/dbtest"
 )
 
 func Example() {
 	// Open a postgres connection.
-	db, _ := empire.OpenDB("postgres://localhost/empire?sslmode=disable")
+	db, _ := empire.OpenDB(*dbtest.DatabaseURL)
 
 	// Migrate the database schema.
 	_ = db.MigrateUp()

--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ejholmes/flock"
 	"github.com/remind101/empire"
+	"github.com/remind101/empire/dbtest"
 	"github.com/remind101/empire/pkg/dockerutil"
 	"github.com/remind101/empire/pkg/image"
 	"github.com/remind101/empire/procfile"
@@ -24,16 +25,10 @@ import (
 	"github.com/remind101/pkg/reporter"
 )
 
-var (
-	// DatabaseURL is a connection string for the postgres database to use
-	// during integration tests.
-	DatabaseURL = "postgres://localhost/empire?sslmode=disable"
-)
-
 // NewEmpire returns a new Empire instance suitable for testing. It ensures that
 // the database is clean before returning.
 func NewEmpire(t testing.TB) *empire.Empire {
-	db, err := empire.OpenDB(DatabaseURL)
+	db, err := empire.NewDB(dbtest.Open(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	_ "github.com/lib/pq"
+	"github.com/remind101/empire/dbtest"
 	"github.com/remind101/migrate"
 	"github.com/stretchr/testify/assert"
 )
 
 // Tests migrating the database down, then back up again.
 func TestMigrations(t *testing.T) {
-	db, err := OpenDB("postgres://localhost/empire?sslmode=disable")
+	db, err := NewDB(dbtest.Open(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/pg/lock/lock_test.go
+++ b/pkg/pg/lock/lock_test.go
@@ -1,18 +1,18 @@
 package lock
 
 import (
-	"database/sql"
 	"testing"
 	"time"
 
 	_ "github.com/lib/pq"
+	"github.com/remind101/empire/dbtest"
 	"github.com/stretchr/testify/assert"
 )
 
 const testKey = 1234
 
 func TestAdvisoryLock(t *testing.T) {
-	db := newDB(t)
+	db := dbtest.Open(t)
 	defer db.Close()
 
 	l, err := NewAdvisoryLock(db, testKey)
@@ -26,7 +26,7 @@ func TestAdvisoryLock(t *testing.T) {
 }
 
 func TestAdvisoryLock_Locked(t *testing.T) {
-	db := newDB(t)
+	db := dbtest.Open(t)
 	defer db.Close()
 
 	a, err := NewAdvisoryLock(db, testKey)
@@ -69,7 +69,7 @@ func TestAdvisoryLock_Locked(t *testing.T) {
 }
 
 func TestAdvisoryLock_CancelPending(t *testing.T) {
-	db := newDB(t)
+	db := dbtest.Open(t)
 	defer db.Close()
 
 	a, err := NewAdvisoryLock(db, testKey)
@@ -123,7 +123,7 @@ func TestAdvisoryLock_CancelPending(t *testing.T) {
 }
 
 func TestAdvisoryLock_Timeout(t *testing.T) {
-	db := newDB(t)
+	db := dbtest.Open(t)
 	defer db.Close()
 
 	a, err := NewAdvisoryLock(db, testKey)
@@ -143,7 +143,7 @@ func TestAdvisoryLock_Timeout(t *testing.T) {
 }
 
 func TestAdvisoryLock_Unlocked(t *testing.T) {
-	db := newDB(t)
+	db := dbtest.Open(t)
 	defer db.Close()
 
 	l, err := NewAdvisoryLock(db, testKey)
@@ -169,7 +169,7 @@ func TestAdvisoryLock_Unlocked(t *testing.T) {
 }
 
 func TestAdvisoryLock_Used(t *testing.T) {
-	db := newDB(t)
+	db := dbtest.Open(t)
 	defer db.Close()
 
 	l, err := NewAdvisoryLock(db, testKey)
@@ -187,12 +187,4 @@ func TestAdvisoryLock_Used(t *testing.T) {
 	}()
 	err = l.Lock()
 	assert.NoError(t, err)
-}
-
-func newDB(t testing.TB) *sql.DB {
-	db, err := sql.Open("postgres", "postgres://localhost/empire?sslmode=disable")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return db
 }

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	docker "github.com/fsouza/go-dockerclient"
 	_ "github.com/lib/pq"
+	"github.com/remind101/empire/dbtest"
 	"github.com/remind101/empire/pkg/bytesize"
 	"github.com/remind101/empire/twelvefactor"
 	"github.com/stretchr/testify/assert"
@@ -1692,10 +1693,7 @@ func TestScheduler_Run_Attached(t *testing.T) {
 }
 
 func newDB(t testing.TB) *sql.DB {
-	db, err := sql.Open("postgres", "postgres://localhost/empire?sslmode=disable")
-	if err != nil {
-		t.Fatal(err)
-	}
+	db := dbtest.Open(t)
 	if _, err := db.Exec(`TRUNCATE TABLE stacks`); err != nil {
 		t.Fatal(err)
 	}

--- a/scheduler/ecs/lb/ports_test.go
+++ b/scheduler/ecs/lb/ports_test.go
@@ -1,15 +1,15 @@
 package lb
 
 import (
-	"database/sql"
 	"testing"
 
 	_ "github.com/lib/pq"
+	"github.com/remind101/empire/dbtest"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDBPortAllocator_Get(t *testing.T) {
-	db := newDB(t)
+	db := dbtest.Open(t)
 	a := &DBPortAllocator{
 		db: db,
 	}
@@ -20,12 +20,4 @@ func TestDBPortAllocator_Get(t *testing.T) {
 
 	err = a.Put(port)
 	assert.NoError(t, err)
-}
-
-func newDB(t testing.TB) *sql.DB {
-	db, err := sql.Open("postgres", "postgres://localhost/empire?sslmode=disable")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return db
 }


### PR DESCRIPTION
This might be a little easier for newcomers to run the tests, without banging your head against cgo dependencies.

This also makes it easier to point the tests at a different postgres dastabase using the `db.url` flag with `go test`.