### PR TITLE
Add flag for stack name template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Empire now supports a new (experimental) feature to enable attached processes to be ran with ECS. [#1043](https://github.com/remind101/empire/pull/1043)
 * Empire now supports "maintenance mode" for applications. [#1086](https://github.com/remind101/empire/pull/1086)
+* Added a new configuration option for controlling the generated CloudFormation stack names. [#1094](https://github.com/remind101/empire/pull/1094)
 
 **Bugs**
 

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -73,6 +73,8 @@ const (
 
 	FlagRoute53InternalZoneID = "route53.zoneid.internal"
 
+	FlagCloudFormationStackNameTemplate = "cloudformation.stack-name-template"
+
 	FlagSNSTopic           = "sns.topic"
 	FlagCloudWatchLogGroup = "cloudwatch.loggroup"
 
@@ -374,6 +376,12 @@ var EmpireFlags = []cli.Flag{
 		Value:  "",
 		Usage:  "The route53 zone ID of the internal 'empire.' zone.",
 		EnvVar: "EMPIRE_ROUTE53_INTERNAL_ZONE_ID",
+	},
+	cli.StringFlag{
+		Name:   FlagCloudFormationStackNameTemplate,
+		Value:  "",
+		Usage:  "If provided, this should be a Go text/template that will be used to generate a CloudFormation stack name for an application. If not provided, and the `--" + FlagEnvironment + "` flag is provided, that will be used as a prefix to the stack name.",
+		EnvVar: "EMPIRE_CLOUDFORMATION_STACK_NAME_TEMPLATE",
 	},
 	cli.StringFlag{
 		Name:   FlagLogsStreamer,


### PR DESCRIPTION
Previously, the `--environment` flag was used to generate a template for determining the CloudFormation stack name for an application. This can be a little constraining and overloaded the responsibilities of `--environment`.

With this change, you can now directly specify a stack name template like this:

```console
EMPIRE_CLOUDFORMATION_STACK_NAME_TEMPLATE="my-custom-prefix-{{.Name}}"
```

Empire will still fallback to including `--environment` in the prefix if `--cloudformation.stack-name-template` isn't provided.