### PR TITLE
Configurable instance port pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Processes can now be scaled down to a negative value to prevent AWS resources from being created. [#1064](https://github.com/remind101/empire/pull/1064)
 * AWS resources for scheduled processes are now always created, unless scaled down to a negative value. [#1064](https://github.com/remind101/empire/pull/1064)
 * Empire now supports reporting its own errors to [Rollbar](https://rollbar.com) in addition to Honeybadger. [#1075](https://github.com/remind101/empire/pull/1075)
+* It's now possible to configure the pool of ports that the `Custom::InstancePort` resource allocates ports from. [#1096](https://github.com/remind101/empire/pull/1096)
 
 ## 0.12.0 (2017-03-10)
 

--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -37,7 +37,19 @@ import (
 // DB ===================================
 
 func newDB(c *Context) (*empire.DB, error) {
-	return empire.OpenDB(c.String(FlagDB))
+	db, err := empire.OpenDB(c.String(FlagDB))
+	if err != nil {
+		return nil, err
+	}
+
+	db.Schema = &empire.Schema{
+		InstancePortPool: &empire.InstancePortPool{
+			Start: uint(c.Int(FlagInstancePortPoolStart)),
+			End:   uint(c.Int(FlagInstancePortPoolEnd)),
+		},
+	}
+
+	return db, nil
 }
 
 // Empire ===============================

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -71,6 +71,9 @@ const (
 	FlagEC2SubnetsPrivate = "ec2.subnets.private"
 	FlagEC2SubnetsPublic  = "ec2.subnets.public"
 
+	FlagInstancePortPoolStart = "instance-port-pool.start"
+	FlagInstancePortPoolEnd   = "instance-port-pool.end"
+
 	FlagRoute53InternalZoneID = "route53.zoneid.internal"
 
 	FlagCloudFormationStackNameTemplate = "cloudformation.stack-name-template"
@@ -358,6 +361,18 @@ var EmpireFlags = []cli.Flag{
 		Value:  &cli.StringSlice{},
 		Usage:  "The comma separated public subnet ids",
 		EnvVar: "EMPIRE_EC2_SUBNETS_PUBLIC",
+	},
+	cli.IntFlag{
+		Name:   FlagInstancePortPoolStart,
+		Value:  empire.DefaultInstancePortPoolStart,
+		Usage:  "The start of the range of instance ports to allocate from.",
+		EnvVar: "EMPIRE_INSTANCE_PORT_POOL_START",
+	},
+	cli.IntFlag{
+		Name:   FlagInstancePortPoolEnd,
+		Value:  empire.DefaultInstancePortPoolEnd,
+		Usage:  "The end of the range of instance ports to allocate from.",
+		EnvVar: "EMPIRE_INSTANCE_PORT_POOL_END",
 	},
 	cli.StringFlag{
 		Name:   FlagSecret,

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -59,13 +59,13 @@ type Migration struct {
 	Down func(tx *sql.Tx) error
 }
 
-// byID implements the sort.Interface interface for sorting migrations by
+// ByID implements the sort.Interface interface for sorting migrations by
 // ID.
-type byID []Migration
+type ByID []Migration
 
-func (m byID) Len() int           { return len(m) }
-func (m byID) Less(i, j int) bool { return m[i].ID < m[j].ID }
-func (m byID) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+func (m ByID) Len() int           { return len(m) }
+func (m ByID) Less(i, j int) bool { return m[i].ID < m[j].ID }
+func (m ByID) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
 
 // Migrator performs migrations.
 type Migrator struct {
@@ -277,16 +277,16 @@ func Queries(queries []string) func(*sql.Tx) error {
 // When the direction is "Up", the migrations will be sorted by ID ascending.
 // When the direction is "Down", the migrations will be sorted by ID descending.
 func sortMigrations(dir MigrationDirection, migrations []Migration) []Migration {
-	var m byID
+	var m ByID
 	for _, migration := range migrations {
 		m = append(m, migration)
 	}
 
 	switch dir {
 	case Up:
-		sort.Sort(byID(m))
+		sort.Sort(ByID(m))
 	default:
-		sort.Sort(sort.Reverse(byID(m)))
+		sort.Sort(sort.Reverse(ByID(m)))
 	}
 
 	return m

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -16,6 +16,8 @@ func TestMigrations(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	migrations := DefaultSchema.migrations()
+
 	err = db.migrator.Exec(migrate.Up, migrations...)
 	assert.NoError(t, err)
 
@@ -30,13 +32,13 @@ func TestMigrations(t *testing.T) {
 }
 
 func TestLatestSchema(t *testing.T) {
-	assert.Equal(t, 20, latestSchema())
+	assert.Equal(t, 20, DefaultSchema.latestSchema())
 }
 
 func TestNoDuplicateMigrations(t *testing.T) {
 	visited := make(map[int]bool)
 	expectedID := 1
-	for _, m := range migrations {
+	for _, m := range DefaultSchema.migrations() {
 		if visited[m.ID] {
 			t.Fatalf("Migration %d appears more than once", m.ID)
 		}


### PR DESCRIPTION
This adds options for configuring the range of EC2 instance ports that Empire manages and allocates to applications that use legacy ELB's to prevent port conflicts.

This makes it easier to run multiple Empire daemons that schedule work into a single ECS cluster. Each Empire daemon can now specify it's own range of instance ports to allocate from to prevent overlap.

Note that, once configured, changing the flags will have no effect, so this only applies to new installations of Empire. Previous installations will continue to use the 9000-10000 range.