### PR TITLE
Separate stdout/stderr streams for one-off commands

### DIFF
--- a/empiretest/test.go
+++ b/empiretest/test.go
@@ -28,6 +28,13 @@ import (
 	"github.com/remind101/pkg/reporter"
 )
 
+// Marks the test as skipped when running in CI.
+func SkipCI(t testing.TB) {
+	if _, ok := os.LookupEnv("CI"); ok {
+		t.Skip("Skipping test in CI")
+	}
+}
+
 // NewEmpire returns a new Empire instance suitable for testing. It ensures that
 // the database is clean before returning.
 func NewEmpire(t testing.TB) *empire.Empire {

--- a/pkg/stdcopy/stdcopy.go
+++ b/pkg/stdcopy/stdcopy.go
@@ -1,0 +1,190 @@
+package stdcopy
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StdType is the type of standard stream
+// a writer can multiplex to.
+type StdType byte
+
+const (
+	// Stdin represents standard input stream type.
+	Stdin StdType = iota
+	// Stdout represents standard output stream type.
+	Stdout
+	// Stderr represents standard error steam type.
+	Stderr
+	// Systemerr represents errors originating from the system that make it
+	// into the the multiplexed stream.
+	Systemerr
+
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+
+	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
+)
+
+var bufPool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underneath writer.
+// It inserts the prefix header before the buffer,
+// so stdcopy.StdCopy knows where to multiplex the output.
+// It makes stdWriter to implement io.Writer.
+func (w *stdWriter) Write(p []byte) (n int, err error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	if p == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Write(header[:])
+	buf.Write(p)
+
+	n, err = w.Writer.Write(buf.Bytes())
+	n -= stdWriterPrefixLen
+	if n < 0 {
+		n = 0
+	}
+
+	buf.Reset()
+	bufPool.Put(buf)
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(t),
+	}
+}
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, startingBufLen)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		stream := StdType(buf[stdWriterFdIndex])
+		// Check the first byte to know where to write
+		switch stream {
+		case Stdin:
+			fallthrough
+		case Stdout:
+			// Write on stdout
+			out = dstout
+		case Stderr:
+			// Write on stderr
+			out = dsterr
+		case Systemerr:
+			// If we're on Systemerr, we won't write anywhere.
+			// NB: if this code changes later, make sure you don't try to write
+			// to outstream if Systemerr is the stream
+			out = nil
+		default:
+			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+stdWriterPrefixLen > bufLen {
+			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// we might have an error from the source mixed up in our multiplexed
+		// stream. if we do, return it.
+		if stream == Systemerr {
+			return written, fmt.Errorf("error from daemon in stream: %s", string(buf[stdWriterPrefixLen:frameSize+stdWriterPrefixLen]))
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
+		if ew != nil {
+			return 0, ew
+		}
+
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+stdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + stdWriterPrefixLen
+	}
+}

--- a/pkg/stdcopy/stdcopy_test.go
+++ b/pkg/stdcopy/stdcopy_test.go
@@ -1,0 +1,289 @@
+package stdcopy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestNewStdWriter(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	if writer == nil {
+		t.Fatalf("NewStdWriter with an invalid StdType should not return nil.")
+	}
+}
+
+func TestWriteWithUninitializedStdWriter(t *testing.T) {
+	writer := stdWriter{
+		Writer: nil,
+		prefix: byte(Stdout),
+	}
+	n, err := writer.Write([]byte("Something here"))
+	if n != 0 || err == nil {
+		t.Fatalf("Should fail when given an uncomplete or uninitialized StdWriter")
+	}
+}
+
+func TestWriteWithNilBytes(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	n, err := writer.Write(nil)
+	if err != nil {
+		t.Fatalf("Shouldn't have fail when given no data")
+	}
+	if n > 0 {
+		t.Fatalf("Write should have written 0 byte, but has written %d", n)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test StdWrite.Write")
+	n, err := writer.Write(data)
+	if err != nil {
+		t.Fatalf("Error while writing with StdWrite")
+	}
+	if n != len(data) {
+		t.Fatalf("Write should have written %d byte but wrote %d.", len(data), n)
+	}
+}
+
+type errWriter struct {
+	n   int
+	err error
+}
+
+func (f *errWriter) Write(buf []byte) (int, error) {
+	return f.n, f.err
+}
+
+func TestWriteWithWriterError(t *testing.T) {
+	expectedError := errors.New("expected")
+	expectedReturnedBytes := 10
+	writer := NewStdWriter(&errWriter{
+		n:   stdWriterPrefixLen + expectedReturnedBytes,
+		err: expectedError}, Stdout)
+	data := []byte("This won't get written, sigh")
+	n, err := writer.Write(data)
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error.")
+	}
+	if n != expectedReturnedBytes {
+		t.Fatalf("Didn't get expected written bytes %d, got %d.",
+			expectedReturnedBytes, n)
+	}
+}
+
+func TestWriteDoesNotReturnNegativeWrittenBytes(t *testing.T) {
+	writer := NewStdWriter(&errWriter{n: -1}, Stdout)
+	data := []byte("This won't get written, sigh")
+	actual, _ := writer.Write(data)
+	if actual != 0 {
+		t.Fatalf("Expected returned written bytes equal to 0, got %d", actual)
+	}
+}
+
+func getSrcBuffer(stdOutBytes, stdErrBytes []byte) (buffer *bytes.Buffer, err error) {
+	buffer = new(bytes.Buffer)
+	dstOut := NewStdWriter(buffer, Stdout)
+	_, err = dstOut.Write(stdOutBytes)
+	if err != nil {
+		return
+	}
+	dstErr := NewStdWriter(buffer, Stderr)
+	_, err = dstErr.Write(stdErrBytes)
+	return
+}
+
+func TestStdCopyWriteAndRead(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, buffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedTotalWritten := len(stdOutBytes) + len(stdErrBytes)
+	if written != int64(expectedTotalWritten) {
+		t.Fatalf("Expected to have total of %d bytes written, got %d", expectedTotalWritten, written)
+	}
+}
+
+type customReader struct {
+	n            int
+	err          error
+	totalCalls   int
+	correctCalls int
+	src          *bytes.Buffer
+}
+
+func (f *customReader) Read(buf []byte) (int, error) {
+	f.totalCalls++
+	if f.totalCalls <= f.correctCalls {
+		return f.src.Read(buf)
+	}
+	return f.n, f.err
+}
+
+func TestStdCopyReturnsErrorReadingHeader(t *testing.T) {
+	expectedError := errors.New("error")
+	reader := &customReader{
+		err: expectedError}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, reader)
+	if written != 0 {
+		t.Fatalf("Expected 0 bytes read, got %d", written)
+	}
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error")
+	}
+}
+
+func TestStdCopyReturnsErrorReadingFrame(t *testing.T) {
+	expectedError := errors.New("error")
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := &customReader{
+		correctCalls: 1,
+		n:            stdWriterPrefixLen + 1,
+		err:          expectedError,
+		src:          buffer}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, reader)
+	if written != 0 {
+		t.Fatalf("Expected 0 bytes read, got %d", written)
+	}
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error")
+	}
+}
+
+func TestStdCopyDetectsCorruptedFrame(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader := &customReader{
+		correctCalls: 1,
+		n:            stdWriterPrefixLen + 1,
+		err:          io.EOF,
+		src:          buffer}
+	written, err := StdCopy(ioutil.Discard, ioutil.Discard, reader)
+	if written != startingBufLen {
+		t.Fatalf("Expected %d bytes read, got %d", startingBufLen, written)
+	}
+	if err != nil {
+		t.Fatal("Didn't get nil error")
+	}
+}
+
+func TestStdCopyWithInvalidInputHeader(t *testing.T) {
+	dstOut := NewStdWriter(ioutil.Discard, Stdout)
+	dstErr := NewStdWriter(ioutil.Discard, Stderr)
+	src := strings.NewReader("Invalid input")
+	_, err := StdCopy(dstOut, dstErr, src)
+	if err == nil {
+		t.Fatal("StdCopy with invalid input header should fail.")
+	}
+}
+
+func TestStdCopyWithCorruptedPrefix(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	src := bytes.NewReader(data)
+	written, err := StdCopy(nil, nil, src)
+	if err != nil {
+		t.Fatalf("StdCopy should not return an error with corrupted prefix.")
+	}
+	if written != 0 {
+		t.Fatalf("StdCopy should have written 0, but has written %d", written)
+	}
+}
+
+func TestStdCopyReturnsWriteErrors(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedError := errors.New("expected")
+
+	dstOut := &errWriter{err: expectedError}
+
+	written, err := StdCopy(dstOut, ioutil.Discard, buffer)
+	if written != 0 {
+		t.Fatalf("StdCopy should have written 0, but has written %d", written)
+	}
+	if err != expectedError {
+		t.Fatalf("Didn't get expected error, got %v", err)
+	}
+}
+
+func TestStdCopyDetectsNotFullyWrittenFrames(t *testing.T) {
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dstOut := &errWriter{n: startingBufLen - 10}
+
+	written, err := StdCopy(dstOut, ioutil.Discard, buffer)
+	if written != 0 {
+		t.Fatalf("StdCopy should have return 0 written bytes, but returned %d", written)
+	}
+	if err != io.ErrShortWrite {
+		t.Fatalf("Didn't get expected io.ErrShortWrite error")
+	}
+}
+
+// TestStdCopyReturnsErrorFromSystem tests that StdCopy correctly returns an
+// error, when that error is muxed into the Systemerr stream.
+func TestStdCopyReturnsErrorFromSystem(t *testing.T) {
+	// write in the basic messages, just so there's some fluff in there
+	stdOutBytes := []byte(strings.Repeat("o", startingBufLen))
+	stdErrBytes := []byte(strings.Repeat("e", startingBufLen))
+	buffer, err := getSrcBuffer(stdOutBytes, stdErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// add in an error message on the Systemerr stream
+	systemErrBytes := []byte(strings.Repeat("S", startingBufLen))
+	systemWriter := NewStdWriter(buffer, Systemerr)
+	_, err = systemWriter.Write(systemErrBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now copy and demux. we should expect an error containing the string we
+	// wrote out
+	_, err = StdCopy(ioutil.Discard, ioutil.Discard, buffer)
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), string(systemErrBytes)) {
+		t.Fatal("expected error to contain message")
+	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	w := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test line for testing stdwriter performance\n")
+	data = bytes.Repeat(data, 100)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := w.Write(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/runner.go
+++ b/runner.go
@@ -70,6 +70,9 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 		return err
 	}
 	for _, p := range a.Processes {
+		p.Stdin = opts.Stdin
+		p.Stdout = opts.Stdout
+		p.Stderr = opts.Stderr
 		p.Labels["empire.user"] = opts.User.Name
 
 		// Add additional environment variables to the process.
@@ -78,5 +81,5 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 		}
 	}
 
-	return r.Scheduler.Run(ctx, a, opts.Input, opts.Output)
+	return r.Scheduler.Run(ctx, a)
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -2,7 +2,6 @@ package empire
 
 import (
 	"fmt"
-	"io"
 	"sync"
 
 	"github.com/remind101/empire/pkg/timex"
@@ -63,10 +62,14 @@ func (m *FakeScheduler) Stop(ctx context.Context, instanceID string) error {
 	return nil
 }
 
-func (m *FakeScheduler) Run(ctx context.Context, app *twelvefactor.Manifest, in io.Reader, out io.Writer) error {
-	if out != nil {
-		for _, p := range app.Processes {
-			fmt.Fprintf(out, "Fake output for `%s` on %s\n", p.Command, app.Name)
+func (m *FakeScheduler) Run(ctx context.Context, app *twelvefactor.Manifest) error {
+	for _, p := range app.Processes {
+		if p.Stderr != nil {
+			fmt.Fprintf(p.Stdout, "Attaching to container\n")
+		}
+
+		if p.Stdout != nil {
+			fmt.Fprintf(p.Stdout, "Fake output for `%s` on %s\n", p.Command, app.Name)
 		}
 	}
 	return nil

--- a/scheduler/cloudformation/cloudformation_test.go
+++ b/scheduler/cloudformation/cloudformation_test.go
@@ -1546,7 +1546,7 @@ func TestScheduler_Run_Detached(t *testing.T) {
 				Command: []string{"bundle exec rake db:migrate"},
 			},
 		},
-	}, nil, nil)
+	})
 	assert.NoError(t, err)
 
 	e.AssertExpectations(t)
@@ -1663,11 +1663,12 @@ func TestScheduler_Run_Attached(t *testing.T) {
 
 	stdin := strings.NewReader("ls\n")
 	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
 	d.On("AttachToContainer", docker.AttachToContainerOptions{
 		Container:    "4c01db0b339c",
 		InputStream:  stdin,
 		OutputStream: stdout,
-		ErrorStream:  stdout,
+		ErrorStream:  stderr,
 		Logs:         true,
 		Stream:       true,
 		Stdin:        true,
@@ -1683,12 +1684,15 @@ func TestScheduler_Run_Attached(t *testing.T) {
 			&twelvefactor.Process{
 				Type:    "run",
 				Command: []string{"bundle", "exec", "rake", "db:migrate"},
+				Stdin:   stdin,
+				Stdout:  stdout,
+				Stderr:  stderr,
 			},
 		},
-	}, stdin, stdout)
+	})
 	assert.NoError(t, err)
 
-	assert.Equal(t, "Attaching to task/fdf2c302-468c-4e55-b884-5331d816e7fb...\r\n", stdout.String())
+	assert.Equal(t, "Attaching to task/fdf2c302-468c-4e55-b884-5331d816e7fb...\r\n", stderr.String())
 
 	e.AssertExpectations(t)
 	c.AssertExpectations(t)

--- a/scheduler/docker/docker.go
+++ b/scheduler/docker/docker.go
@@ -72,14 +72,19 @@ func RunAttachedWithDocker(s twelvefactor.Scheduler, client *dockerutil.Client) 
 
 // Run runs attached processes using the docker scheduler, and detached
 // processes using the wrapped scheduler.
-func (s *AttachedScheduler) Run(ctx context.Context, app *twelvefactor.Manifest, in io.Reader, out io.Writer) error {
+func (s *AttachedScheduler) Run(ctx context.Context, app *twelvefactor.Manifest) error {
+	if len(app.Processes) != 1 {
+		return fmt.Errorf("docker: cannot run mutliple processes with attached scheduler")
+	}
+
+	p := app.Processes[0]
 	// Attached means stdout, stdin is attached.
-	attached := out != nil || in != nil
+	attached := p.Stdin != nil || p.Stdout != nil || p.Stderr != nil
 
 	if attached {
-		return s.dockerScheduler.Run(ctx, app, in, out)
+		return s.dockerScheduler.Run(ctx, app)
 	} else {
-		return s.Scheduler.Run(ctx, app, in, out)
+		return s.Scheduler.Run(ctx, app)
 	}
 }
 
@@ -146,14 +151,14 @@ func NewScheduler(client *dockerutil.Client) *Scheduler {
 	}
 }
 
-func (s *Scheduler) Run(ctx context.Context, app *twelvefactor.Manifest, in io.Reader, out io.Writer) error {
-	attached := out != nil || in != nil
-
-	if !attached {
-		return errors.New("cannot run detached processes with Docker scheduler")
-	}
-
+func (s *Scheduler) Run(ctx context.Context, app *twelvefactor.Manifest) error {
 	for _, p := range app.Processes {
+		attached := p.Stdin != nil || p.Stdout != nil || p.Stderr != nil
+
+		if !attached {
+			return errors.New("cannot run detached processes with Docker scheduler")
+		}
+
 		labels := twelvefactor.Labels(app, p)
 		labels[runLabel] = Attached
 
@@ -161,7 +166,7 @@ func (s *Scheduler) Run(ctx context.Context, app *twelvefactor.Manifest, in io.R
 			Registry:     p.Image.Registry,
 			Repository:   p.Image.Repository,
 			Tag:          p.Image.Tag,
-			OutputStream: replaceNL(out),
+			OutputStream: replaceNL(p.Stderr),
 		}); err != nil {
 			return fmt.Errorf("error pulling image: %v", err)
 		}
@@ -199,13 +204,12 @@ func (s *Scheduler) Run(ctx context.Context, app *twelvefactor.Manifest, in io.R
 		if err := s.docker.StartContainer(ctx, container.ID, nil); err != nil {
 			return fmt.Errorf("error starting container: %v", err)
 		}
-		defer tryClose(out)
 
 		if err := s.docker.AttachToContainer(ctx, docker.AttachToContainerOptions{
 			Container:    container.ID,
-			InputStream:  in,
-			OutputStream: out,
-			ErrorStream:  out,
+			InputStream:  p.Stdin,
+			OutputStream: p.Stdout,
+			ErrorStream:  p.Stderr,
 			Logs:         true,
 			Stream:       true,
 			Stdin:        true,
@@ -313,14 +317,6 @@ func envKeys(env map[string]string) []string {
 	}
 
 	return s
-}
-
-func tryClose(w io.Writer) error {
-	if w, ok := w.(io.Closer); ok {
-		return w.Close()
-	}
-
-	return nil
 }
 
 // replaceNL returns an io.Writer that will replace "\n" with "\r\n" in the

--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -106,8 +106,16 @@ func (h *Server) PostProcess(w http.ResponseWriter, r *http.Request) error {
 		// Prevent the ELB idle connection timeout to close the connection.
 		defer close(streamhttp.Heartbeat(stream, 10*time.Second))
 
-		opts.Input = stream
-		opts.Output = stream
+		opts.Stdin = stream
+
+		// TODO(ejholmes): Currently, both stdout and stderr are written
+		// to the same stream, which means the client cannot
+		// differentiate from stdout/stderr. In the future, this
+		// endpoint should support a new Content-Type header that
+		// multiplexes stdout/stderr so the client can demux them before
+		// printing to the console.
+		opts.Stdout = stream
+		opts.Stderr = stream
 
 		if err := h.Run(ctx, opts); err != nil {
 			if stream.Hijacked {

--- a/tests/cli/run_test.go
+++ b/tests/cli/run_test.go
@@ -1,8 +1,14 @@
 package cli_test
 
-import "testing"
+import (
+	"testing"
 
-func testRunDetached(t *testing.T) {
+	"github.com/remind101/empire/empiretest"
+)
+
+func TestRunDetached(t *testing.T) {
+	empiretest.SkipCI(t)
+
 	run(t, []Command{
 		DeployCommand("latest", "v1"),
 		{
@@ -12,12 +18,14 @@ func testRunDetached(t *testing.T) {
 	})
 }
 
-func testRunAttached(t *testing.T) {
+func TestRunAttached(t *testing.T) {
+	empiretest.SkipCI(t)
+
 	run(t, []Command{
 		DeployCommand("latest", "v1"),
 		{
 			"run migration -a acme-inc",
-			"Fake output for `migration` on acme-inc",
+			"Attaching to container\nFake output for `[migration]` on acme-inc",
 		},
 	})
 }

--- a/tests/empire/empire_test.go
+++ b/tests/empire/empire_test.go
@@ -331,7 +331,7 @@ func TestEmpire_Run(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil).Return(nil)
+	}).Return(nil)
 
 	err = e.Run(context.Background(), empire.RunOpts{
 		User:    user,
@@ -339,8 +339,9 @@ func TestEmpire_Run(t *testing.T) {
 		Command: empire.MustParseCommand("bundle exec rake db:migrate"),
 
 		// Detached Process
-		Output: nil,
-		Input:  nil,
+		Stdin:  nil,
+		Stdout: nil,
+		Stderr: nil,
 
 		Env: map[string]string{
 			"TERM": "xterm",
@@ -409,7 +410,7 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil).Return(nil)
+	}).Return(nil)
 
 	constraints := empire.NamedConstraints["2X"]
 	err = e.Run(context.Background(), empire.RunOpts{
@@ -418,8 +419,9 @@ func TestEmpire_Run_WithConstraints(t *testing.T) {
 		Command: empire.MustParseCommand("bundle exec rake db:migrate"),
 
 		// Detached Process
-		Output: nil,
-		Input:  nil,
+		Stdin:  nil,
+		Stdout: nil,
+		Stderr: nil,
 
 		Env: map[string]string{
 			"TERM": "xterm",
@@ -462,8 +464,9 @@ func TestEmpire_Run_WithAllowCommandProcfile(t *testing.T) {
 		Command: empire.MustParseCommand("bundle exec rake db:migrate"),
 
 		// Detached Process
-		Output: nil,
-		Input:  nil,
+		Stdin:  nil,
+		Stdout: nil,
+		Stderr: nil,
 
 		Env: map[string]string{
 			"TERM": "xterm",
@@ -515,7 +518,7 @@ func TestEmpire_Run_WithAllowCommandProcfile(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil).Return(nil)
+	}).Return(nil)
 
 	err = e.Run(context.Background(), empire.RunOpts{
 		User:    user,
@@ -523,8 +526,9 @@ func TestEmpire_Run_WithAllowCommandProcfile(t *testing.T) {
 		Command: empire.MustParseCommand("rake db:migrate"),
 
 		// Detached Process
-		Output: nil,
-		Input:  nil,
+		Stdin:  nil,
+		Stdout: nil,
+		Stderr: nil,
 
 		Env: map[string]string{
 			"TERM": "xterm",
@@ -700,7 +704,7 @@ func (m *mockScheduler) Submit(_ context.Context, app *twelvefactor.Manifest, ss
 	return args.Error(0)
 }
 
-func (m *mockScheduler) Run(_ context.Context, app *twelvefactor.Manifest, in io.Reader, out io.Writer) error {
-	args := m.Called(app, in, out)
+func (m *mockScheduler) Run(_ context.Context, app *twelvefactor.Manifest) error {
+	args := m.Called(app)
 	return args.Error(0)
 }

--- a/twelvefactor/twelvefactor.go
+++ b/twelvefactor/twelvefactor.go
@@ -69,6 +69,10 @@ type Process struct {
 
 	// Any ECS specific configuration.
 	ECS *procfile.ECS
+
+	// Input/Output streams.
+	Stdin          io.Reader
+	Stdout, Stderr io.Writer
 }
 
 // Schedule represents a Schedule for scheduled tasks that run periodically.
@@ -161,7 +165,7 @@ type Task struct {
 // Scheduler is an interface for interfacing with Services.
 type Scheduler interface {
 	// Run runs a process.
-	Run(ctx context.Context, app *Manifest, in io.Reader, out io.Writer) error
+	Run(ctx context.Context, app *Manifest) error
 
 	// Submit submits an app, creating it or updating it as necessary.
 	// When StatusStream is nil, Submit should return as quickly as possible,
@@ -205,8 +209,8 @@ func (t *transformer) Submit(ctx context.Context, app *Manifest, ss StatusStream
 	return t.Scheduler.Submit(ctx, t.Transform(app), ss)
 }
 
-func (t *transformer) Run(ctx context.Context, app *Manifest, in io.Reader, out io.Writer) error {
-	return t.Scheduler.Run(ctx, t.Transform(app), in, out)
+func (t *transformer) Run(ctx context.Context, app *Manifest) error {
+	return t.Scheduler.Run(ctx, t.Transform(app))
 }
 
 // Env merges the App environment with any environment variables provided


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/1044

This separates stdout from stderr in `emp run`, so that `emp run` can be used with existing UNIX tools more easily.

Implementation wise, the endpoint for running one-offs now multiplexes stdout/stderr over the same TCP connection, and the client de-multiplexes it before writing it to the terminal's stdout/stderr. The multiplex/de-multiplex is done using the [stdcopy](https://github.com/remind101/empire/blob/stdcopy/pkg/stdcopy/stdcopy.go), which is pulled from Docker's internals.

This is 100% backwards compatible. Older clients will receive the combined stream, while newer clients (those that send `X-Multiplex: 1` in the headers), will get a multiplexed stream. And inversely, new clients talking with an older daemon will continue to handle the combined stream.