### PR TITLE
Allows --events.backend flag to take multiple backends

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -411,9 +411,9 @@ var EmpireFlags = []cli.Flag{
 		Usage:  "The location of the logs to stream",
 		EnvVar: "EMPIRE_LOGS_STREAMER",
 	},
-	cli.StringFlag{
+	cli.StringSliceFlag{
 		Name:   FlagEventsBackend,
-		Value:  "",
+		Value:  &cli.StringSlice{},
 		Usage:  "The backend implementation to use to send event notifactions",
 		EnvVar: "EMPIRE_EVENTS_BACKEND",
 	},


### PR DESCRIPTION
This allows you to configure multiple event stream backends (e.g. stdout + sns)