### PR TITLE
Automatically resolve Docker images to immutable digests

### DIFF
--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -23,12 +23,12 @@ import (
 	"github.com/remind101/empire/events/app"
 	"github.com/remind101/empire/events/sns"
 	"github.com/remind101/empire/events/stdout"
-	"github.com/remind101/empire/extractor"
 	"github.com/remind101/empire/logs"
 	"github.com/remind101/empire/pkg/dockerauth"
 	"github.com/remind101/empire/pkg/dockerutil"
 	"github.com/remind101/empire/pkg/troposphere"
 	"github.com/remind101/empire/procfile"
+	"github.com/remind101/empire/registry"
 	"github.com/remind101/empire/scheduler/cloudformation"
 	"github.com/remind101/empire/scheduler/docker"
 	"github.com/remind101/empire/stats"
@@ -86,7 +86,7 @@ func newEmpire(db *empire.DB, c *Context) (*empire.Empire, error) {
 	e := empire.New(db)
 	e.Scheduler = scheduler
 	e.EventStream = empire.AsyncEvents(streams)
-	e.ProcfileExtractor = extractor.PullAndExtract(docker)
+	e.ImageRegistry = registry.DockerDaemon(docker)
 	e.Environment = c.String(FlagEnvironment)
 	e.RunRecorder = runRecorder
 	e.MessagesRequired = c.Bool(FlagMessagesRequired)

--- a/cmd/empire/factories.go
+++ b/cmd/empire/factories.go
@@ -83,10 +83,15 @@ func newEmpire(db *empire.DB, c *Context) (*empire.Empire, error) {
 		return nil, err
 	}
 
+	reg, err := newRegistry(docker, c)
+	if err != nil {
+		return nil, err
+	}
+
 	e := empire.New(db)
 	e.Scheduler = scheduler
 	e.EventStream = empire.AsyncEvents(streams)
-	e.ImageRegistry = registry.DockerDaemon(docker)
+	e.ImageRegistry = reg
 	e.Environment = c.String(FlagEnvironment)
 	e.RunRecorder = runRecorder
 	e.MessagesRequired = c.Bool(FlagMessagesRequired)
@@ -282,6 +287,26 @@ func newDockerClient(c *Context) (*dockerutil.Client, error) {
 	}
 
 	return dockerutil.NewClient(authProvider, host, certPath)
+}
+
+func newRegistry(client *dockerutil.Client, c *Context) (empire.ImageRegistry, error) {
+	r := registry.DockerDaemon(client)
+
+	digests := c.String(FlagDockerDigests)
+	switch digests {
+	case "prefer":
+		r.Digests = registry.DigestsPrefer
+	case "enforce":
+		log.Println("Image digests are enforced")
+		r.Digests = registry.DigestsOnly
+	case "disable":
+		log.Println("Image digests are disabled")
+		r.Digests = registry.DigestsDisable
+	default:
+		return nil, fmt.Errorf("invalid value for %s: %s", FlagDockerDigests, digests)
+	}
+
+	return r, nil
 }
 
 // LogStreamer =========================

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -49,9 +49,10 @@ const (
 
 	FlagDB = "db"
 
-	FlagDockerHost = "docker.socket"
-	FlagDockerCert = "docker.cert"
-	FlagDockerAuth = "docker.auth"
+	FlagDockerHost    = "docker.socket"
+	FlagDockerCert    = "docker.cert"
+	FlagDockerAuth    = "docker.auth"
+	FlagDockerDigests = "docker.digests"
 
 	FlagAWSDebug                       = "aws.debug"
 	FlagS3TemplateBucket               = "s3.templatebucket"
@@ -278,6 +279,12 @@ var EmpireFlags = []cli.Flag{
 		Value:  path.Join(os.Getenv("HOME"), ".dockercfg"),
 		Usage:  "Path to a docker registry auth file (~/.dockercfg)",
 		EnvVar: "DOCKER_AUTH_PATH",
+	},
+	cli.StringFlag{
+		Name:   FlagDockerDigests,
+		Value:  "prefer",
+		Usage:  "Determines how Empire stores Docker image references. By default, Empire will try to resolve a mutable reference (e.g. remind101/acme-inc:master) to an immutable reference using the images content adressable digest (e.g. remind101/acme-inc@sha256:c6f77d2098bc0e32aef3102e71b51831a9083dd9356a0ccadca860596a1e9007) if the Docker daemon supports it. This can be disabled by setting to \"disable\" or enforce digests by setting to \"enforce\".",
+		EnvVar: "DOCKER_DIGESTS",
 	},
 	cli.BoolFlag{
 		Name:   FlagAWSDebug,

--- a/docs/quickstart_using.md
+++ b/docs/quickstart_using.md
@@ -33,7 +33,7 @@ Good - we haven't deployed any apps, so we shouldn't see any. Lets deploy our fi
 
 ```console
 $ emp deploy remind101/acme-inc:master
-Pulling repository remind101/acme-inc
+master: Pulling from remind101/acme-inc
 345c7524bc96: Download complete
 a1dd7097a8e8: Download complete
 23debee88b99: Download complete
@@ -41,11 +41,15 @@ a1dd7097a8e8: Download complete
 c7388ff7ab91: Download complete
 78fb106ed050: Download complete
 133fcef559c4: Download complete
+Digest: sha256:c6f77d2098bc0e32aef3102e71b51831a9083dd9356a0ccadca860596a1e9007
 Status: Downloaded newer image for remind101/acme-inc:master
+Status: Resolved remind101/acme-inc:master to remind101/acme-inc@sha256:c6f77d2098bc0e32aef3102e71b51831a9083dd9356a0ccadca860596a1e9007
+Status: Extracted Procfile from "/go/src/github.com/remind101/acme-inc/Procfile"
 Status: Created new release v1 for acme-inc
+Status: Finished processing events for release v1 of acme-inc
 ```
 
-So what just happened? We just told the Empire API to go out and get the 'master' tagged image from the remind101/acme-inc repository. The Empire daemon then pulled that image down from [hub.docker.com](http://hub.docker.com/), then extracted the *Procfile* from it to analyze what processes were available. Now lets see what apps we're running:
+So what just happened? We just told the Empire API to go out and get the 'master' tagged image from the remind101/acme-inc repository. The Empire daemon then pulled that image down from [hub.docker.com](http://hub.docker.com/), resolved the image to it's content-adressable identifier, then extracted the *Procfile* from it to analyze what processes were available. Now lets see what apps we're running:
 
 ```console
 $ emp apps

--- a/empire.go
+++ b/empire.go
@@ -89,9 +89,8 @@ type Empire struct {
 	// LogsStreamer is the backend used to stream application logs.
 	LogsStreamer LogsStreamer
 
-	// ProcfileExtractor is called during deployments to extract the
-	// Formation from the Procfile in the newly deployed image.
-	ProcfileExtractor ProcfileExtractor
+	// ImageRegistry is used to interract with container images.
+	ImageRegistry ImageRegistry
 
 	// Environment represents the environment this Empire server is responsible for
 	Environment string

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -47,10 +47,33 @@ func (r *dockerDaemon) ExtractProcfile(ctx context.Context, img image.Image, w *
 
 func (r *dockerDaemon) Resolve(ctx context.Context, img image.Image, w *jsonmessage.Stream) (image.Image, error) {
 	if !r.noPull {
+		// From the Docker API docs:
+		//
+		//	Tag or digest. If empty when pulling an image, this
+		//	causes all tags for the given image to be pulled.
+		//
+		// So, we prefer the digest if it's provided.
+		tag := img.Digest
+		if tag == "" {
+			tag = img.Tag
+		}
+
+		// If there's no tag or digest, error out. Providing an empty
+		// tag to DockerPull will pull all images, which we don't want.
+		if tag == "" {
+			return img, fmt.Errorf("no tag or digest provided")
+		}
+
 		if err := r.docker.PullImage(ctx, docker.PullImageOptions{
-			Registry:      img.Registry,
+			// Only required for Docker Engine 1.9 or 1.10 w/ Remote API < 1.21
+			// and Docker Engine < 1.9
+			// This parameter was removed in Docker Engine 1.11
+			//
+			// See https://goo.gl/9y9Bpx
+			Registry: img.Registry,
+
 			Repository:    img.Repository,
-			Tag:           img.Tag,
+			Tag:           tag,
 			OutputStream:  w,
 			RawJSONStream: true,
 		}); err != nil {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,8 +1,9 @@
-package extractor
+package registry
 
 import (
 	"archive/tar"
 	"bytes"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -11,6 +12,7 @@ import (
 	"github.com/remind101/empire/pkg/dockerutil"
 	"github.com/remind101/empire/pkg/httpmock"
 	"github.com/remind101/empire/pkg/image"
+	"github.com/remind101/empire/pkg/jsonmessage"
 )
 
 func TestCMDExtractor(t *testing.T) {
@@ -29,10 +31,11 @@ func TestCMDExtractor(t *testing.T) {
 		client: c,
 	}
 
-	got, err := e.Extract(nil, image.Image{
+	w := jsonmessage.NewStream(ioutil.Discard)
+	got, err := e.ExtractProcfile(nil, image.Image{
 		Tag:        "acme-inc",
 		Repository: "remind101",
-	}, nil)
+	}, w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +47,7 @@ func TestCMDExtractor(t *testing.T) {
 `)
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Extract() => %q; want %q", got, want)
+		t.Errorf("ExtractProcfile() => %q; want %q", got, want)
 	}
 }
 
@@ -73,10 +76,11 @@ func TestProcfileExtractor(t *testing.T) {
 		client: c,
 	}
 
-	got, err := e.Extract(nil, image.Image{
+	w := jsonmessage.NewStream(ioutil.Discard)
+	got, err := e.ExtractProcfile(nil, image.Image{
 		Tag:        "acme-inc",
 		Repository: "remind101",
-	}, nil)
+	}, w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +88,7 @@ func TestProcfileExtractor(t *testing.T) {
 	want := []byte(`web: rails server`)
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Extract() => %q; want %q", got, want)
+		t.Errorf("ExtractProcfile() => %q; want %q", got, want)
 	}
 }
 
@@ -113,10 +117,11 @@ func TestProcfileExtractor_Docker12(t *testing.T) {
 		client: c,
 	}
 
-	got, err := e.Extract(nil, image.Image{
+	w := jsonmessage.NewStream(ioutil.Discard)
+	got, err := e.ExtractProcfile(nil, image.Image{
 		Tag:        "acme-inc",
 		Repository: "remind101",
-	}, nil)
+	}, w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +129,7 @@ func TestProcfileExtractor_Docker12(t *testing.T) {
 	want := []byte(`web: rails server`)
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Extract() => %q; want %q", got, want)
+		t.Errorf("ExtractProcfile() => %q; want %q", got, want)
 	}
 }
 
@@ -157,10 +162,11 @@ func TestProcfileFallbackExtractor(t *testing.T) {
 		newCMDExtractor(c),
 	)
 
-	got, err := e.Extract(nil, image.Image{
+	w := jsonmessage.NewStream(ioutil.Discard)
+	got, err := e.ExtractProcfile(nil, image.Image{
 		Tag:        "acme-inc",
 		Repository: "remind101",
-	}, nil)
+	}, w)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +178,7 @@ func TestProcfileFallbackExtractor(t *testing.T) {
 `)
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Extract() => %q; want %q", got, want)
+		t.Errorf("ExtractProcfile() => %q; want %q", got, want)
 	}
 
 }


### PR DESCRIPTION
Closes https://github.com/remind101/empire/issues/247

With this change, when you deploy an image using a mutable tag (e.g. `emp deploy remind101/acme-inc:latest`), Empire will resolve the image reference to an immutable reference (e.g. `remind101/acme-inc@sha256:c6f77d2098bc0e32aef3102e71b51831a9083dd9356a0ccadca860596a1e9007`) before saving the slug. This has a number of benefits, both for security and for stability.

This was always the intention, but couldn't be done until ECS supported digests (which it now does). 

In this PR, the first commit is a small refactor to change the `ProcfileExtractor` interface to an `ImageRegistry` interface. And then the second commit is a small change that implements digest resolution.