### PR TITLE
Adds `read_only` flag to extended procfile

### DIFF
--- a/processes.go
+++ b/processes.go
@@ -85,6 +85,9 @@ type Process struct {
 	// The amount of CPU share to give.
 	CPUShare constraints.CPUShare `json:"CPUShare,omitempty"`
 
+	// Whether the containers root filesystem is read only.
+	ReadOnly bool `json:"ReadOnly,omitempty"`
+
 	// The allow number of unix processes within the container.
 	Nproc constraints.Nproc `json:"Nproc,omitempty"`
 

--- a/procfile/README.md
+++ b/procfile/README.md
@@ -97,3 +97,12 @@ ecs:
 ```
 
 See http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement.html for details.
+
+
+**ReadOnly**
+
+Identical to the `--read-only` flag of `docker run`, this will mount the containers root filesystem as readonly, which can have various performance/security benefits.
+
+```yaml
+read_only: true
+```

--- a/procfile/procfile.go
+++ b/procfile/procfile.go
@@ -32,6 +32,7 @@ type Process struct {
 	Ports       []Port            `yaml:"ports,omitempty"`
 	Environment map[string]string `yaml:"environment,omitempty"`
 	ECS         *ECS              `yaml:"ecs,omitempty"`
+	ReadOnly    bool              `yaml:"read_only,omitempty"`
 }
 
 // ECS specific options.

--- a/registry.go
+++ b/registry.go
@@ -120,6 +120,7 @@ func formationFromExtendedProcfile(p procfile.ExtendedProcfile) (Formation, erro
 			Ports:       ports,
 			Environment: process.Environment,
 			ECS:         process.ECS,
+			ReadOnly:    process.ReadOnly,
 		}
 	}
 

--- a/releases.go
+++ b/releases.go
@@ -379,6 +379,7 @@ func newSchedulerProcess(release *Release, name string, p Process) (*twelvefacto
 		Exposure:  exposure,
 		Schedule:  processSchedule(name, p),
 		ECS:       p.ECS,
+		ReadonlyRootFilesystem: p.ReadOnly,
 	}, nil
 }
 

--- a/scheduler/cloudformation/template.go
+++ b/scheduler/cloudformation/template.go
@@ -775,16 +775,17 @@ func (t *EmpireTemplate) ContainerDefinition(app *twelvefactor.Manifest, p *twel
 	}
 
 	return &ecs.ContainerDefinition{
-		Name:             aws.String(p.Type),
-		Cpu:              aws.Int64(int64(p.CPUShares)),
-		Command:          command,
-		Image:            aws.String(p.Image.String()),
-		Essential:        aws.Bool(true),
-		Memory:           aws.Int64(int64(p.Memory / bytesize.MB)),
-		Environment:      sortedEnvironment(twelvefactor.Env(app, p)),
-		LogConfiguration: t.LogConfiguration,
-		DockerLabels:     labels,
-		Ulimits:          ulimits,
+		Name:                   aws.String(p.Type),
+		Cpu:                    aws.Int64(int64(p.CPUShares)),
+		Command:                command,
+		Image:                  aws.String(p.Image.String()),
+		Essential:              aws.Bool(true),
+		Memory:                 aws.Int64(int64(p.Memory / bytesize.MB)),
+		Environment:            sortedEnvironment(twelvefactor.Env(app, p)),
+		LogConfiguration:       t.LogConfiguration,
+		DockerLabels:           labels,
+		Ulimits:                ulimits,
+		ReadonlyRootFilesystem: aws.Bool(p.ReadonlyRootFilesystem),
 	}
 }
 

--- a/twelvefactor/twelvefactor.go
+++ b/twelvefactor/twelvefactor.go
@@ -67,6 +67,9 @@ type Process struct {
 	// Can be used to setup a CRON schedule to run this task periodically.
 	Schedule Schedule
 
+	// Whether the containers root file system should be read only.
+	ReadonlyRootFilesystem bool
+
 	// Any ECS specific configuration.
 	ECS *procfile.ECS
 


### PR DESCRIPTION
Related to https://github.com/remind101/empire/issues/813

Arguably, most applications that are suitable for running within containers should be using a readonly root filesystem (there are exceptions, like apps that might need to do some configuration at boot time).

This adds a `read_only` option to the extended procfile, which is identical to the `read_only` option in `docker-compose.yml` and the `--read-only` flag for `docker run`.

Eventually, I'd like to add support for the `tmpfs` option in docker-compose.yml, but `tmpfs` doesn't seem to be supported in ECS at the moment.