### PR TITLE
Log/Instrument authentication failures

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -29,6 +29,7 @@ const (
 
 	FlagServerAuth              = "server.auth"
 	FlagServerSessionExpiration = "server.session.expiration"
+	FlagServerRealIp            = "server.realip"
 
 	FlagSAMLMetadata       = "saml.metadata"
 	FlagSAMLKey            = "saml.key"
@@ -134,6 +135,12 @@ var Commands = []cli.Command{
 				Value:  0,
 				Usage:  "The maximum amount of time that sessions and access tokens exist for. For security, it's a good idea to set this to a low value, like `24h`. Refer to the ParseDuration docs for details on acceptable values (https://golang.org/pkg/time/#ParseDuration). By default, sessions do not expire.",
 				EnvVar: "EMPIRE_SERVER_SESSION_EXPIRATION",
+			},
+			cli.StringSliceFlag{
+				Name:   FlagServerRealIp,
+				Value:  &cli.StringSlice{},
+				Usage:  "Determines the headers that can be trusted to determine the real ip. By default, no headers are trusted and the ip is extracted from the remote address. If you're using ELB, you should set this to X-Forwarded-For. If you're using something like nginx + real_ip module, you can set this to X-Real-Ip.",
+				EnvVar: "EMPIRE_SERVER_REAL_IP",
 			},
 			cli.StringFlag{
 				Name:   FlagSAMLMetadata,

--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -927,6 +927,10 @@
               {
                 "Name": "EMPIRE_X_SHOW_ATTACHED",
                 "Value": "true"
+              },
+              {
+                "Name": "EMPIRE_SERVER_REAL_IP",
+                "Value": "X-Forwarded-For"
               }
             ],
             "Command": ["server", "-automigrate=true"],

--- a/internal/realip/realip.go
+++ b/internal/realip/realip.go
@@ -1,0 +1,71 @@
+package realip
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"strings"
+)
+
+var cidrs []*net.IPNet
+
+func init() {
+	lancidrs := []string{
+		"127.0.0.1/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.168.0.0/16", "::1/128", "fc00::/7",
+	}
+
+	cidrs = make([]*net.IPNet, len(lancidrs))
+
+	for i, it := range lancidrs {
+		_, cidrnet, err := net.ParseCIDR(it)
+		if err != nil {
+			log.Fatalf("ParseCIDR error: %v", err) // assuming I did it right above
+		}
+
+		cidrs[i] = cidrnet
+	}
+}
+
+func isLocalAddress(addr string) bool {
+	for i := range cidrs {
+		myaddr := net.ParseIP(addr)
+		if cidrs[i].Contains(myaddr) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Request.RemoteAddress contains port, which we want to remove i.e.:
+// "[::1]:58292" => "[::1]"
+func ipAddrFromRemoteAddr(s string) string {
+	idx := strings.LastIndex(s, ":")
+	if idx == -1 {
+		return s
+	}
+	return s[:idx]
+}
+
+// RealIP return client's real public IP address
+// from http request headers.
+func RealIP(r *http.Request) string {
+	hdr := r.Header
+	hdrRealIP := hdr.Get("X-Real-Ip")
+	hdrForwardedFor := hdr.Get("X-Forwarded-For")
+
+	if len(hdrForwardedFor) == 0 && len(hdrRealIP) == 0 {
+		return ipAddrFromRemoteAddr(r.RemoteAddr)
+	}
+
+	// X-Forwarded-For is potentially a list of addresses separated with ","
+	for _, addr := range strings.Split(hdrForwardedFor, ",") {
+		// return first non-local address
+		addr = strings.TrimSpace(addr)
+		if len(addr) > 0 && !isLocalAddress(addr) {
+			return addr
+		}
+	}
+
+	return hdrRealIP
+}

--- a/internal/realip/realip.go
+++ b/internal/realip/realip.go
@@ -1,11 +1,15 @@
 package realip
 
 import (
+	"context"
 	"log"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 )
+
+var DefaultResolver = &Resolver{}
 
 var cidrs []*net.IPNet
 
@@ -47,19 +51,67 @@ func ipAddrFromRemoteAddr(s string) string {
 	return s[:idx]
 }
 
+// Resolver is used to resolve the real ip address for an http request.
+type Resolver struct {
+	// Can be set to true if you have a trusted proxy or load balancer
+	// setting this header.
+	XRealIp bool
+
+	// Can be set to true if you have a trusted proxy or load balancer
+	// appending ip's to this header.
+	XForwardedFor bool
+}
+
 // RealIP return client's real public IP address
 // from http request headers.
-func RealIP(r *http.Request) string {
-	hdr := r.Header
-	hdrRealIP := hdr.Get("X-Real-Ip")
-	hdrForwardedFor := hdr.Get("X-Forwarded-For")
+func (r *Resolver) RealIP(req *http.Request) string {
+	var hdrRealIP string
+	if r.XRealIp {
+		hdrRealIP = req.Header.Get("X-Real-Ip")
+	}
+
+	var hdrForwardedFor string
+	if r.XForwardedFor {
+		hdrForwardedFor = req.Header.Get("X-Forwarded-For")
+	}
 
 	if len(hdrForwardedFor) == 0 && len(hdrRealIP) == 0 {
-		return ipAddrFromRemoteAddr(r.RemoteAddr)
+		return ipAddrFromRemoteAddr(req.RemoteAddr)
 	}
 
 	// X-Forwarded-For is potentially a list of addresses separated with ","
-	for _, addr := range strings.Split(hdrForwardedFor, ",") {
+	forwarded := sort.StringSlice(strings.Split(hdrForwardedFor, ","))
+
+	// This will ignore the X-Forwarded-For entries matching a load balancer
+	// and use the first (from right to left) untrused address as the real
+	// ip. This is done to prevent spoofing X-Forwarded-For.
+	//
+	// For example, let's say you wanted try to spoof your ip to make it
+	// look like a request came from an office ip (204.28.121.211). You
+	// would make a request like this:
+	//
+	//   curl https://www.example.com/debug -H "X-Forwarded-For: 204.28.121.211"
+	//
+	// The load balancer would then tag on the connecting ip, as well as the
+	// ip address of the load balancer itself. The application would receive
+	// an X-Forwarded-For header like the following:
+	//
+	//   "X-Forwarded-For": [
+	//     "204.28.121.211, 49.228.250.246, 10.128.21.180"
+	//   ]
+	//
+	// This will look at each ip from right to left, and use the first
+	// "untrusted" address as the real ip.
+	//
+	// 1. The first ip, 10.128.21.180, is the loadbalancer ip address and is
+	//    considered trusted because it's a LAN cidr.
+	// 2. The second ip, 49.228.250.246, is untrusted, so this is determined to
+	//    be the real ip address.
+	//
+	// By doing this, the spoofed ip (204.28.121.211) is ignored.
+	reverse(forwarded)
+
+	for _, addr := range forwarded {
 		// return first non-local address
 		addr = strings.TrimSpace(addr)
 		if len(addr) > 0 && !isLocalAddress(addr) {
@@ -69,3 +121,35 @@ func RealIP(r *http.Request) string {
 
 	return hdrRealIP
 }
+
+// Middleware is a simple http.Handler middleware that extracts the RealIP from
+// the request and set it on the request context. Anything downstream can then
+// simply call realip.RealIP to extract the real ip from the request.
+func Middleware(h http.Handler, r *Resolver) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ip := r.RealIP(req)
+		h.ServeHTTP(w, req.WithContext(context.WithValue(req.Context(), realIPKey, ip)))
+	})
+}
+
+// Extracts the real ip from the request context.
+func RealIP(req *http.Request) string {
+	ip, ok := req.Context().Value(realIPKey).(string)
+	if !ok {
+		// Fallback to a secure resolver.
+		return DefaultResolver.RealIP(req)
+	}
+	return ip
+}
+
+// reverse reverses a slice of strings.
+func reverse(ss []string) {
+	last := len(ss) - 1
+	for i := 0; i < len(ss)/2; i++ {
+		ss[i], ss[last-i] = ss[last-i], ss[i]
+	}
+}
+
+type key int
+
+var realIPKey key = 0

--- a/internal/realip/realip_test.go
+++ b/internal/realip/realip_test.go
@@ -1,0 +1,86 @@
+package realip
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIsLocalAddr(t *testing.T) {
+	testData := map[string]bool{
+		"127.0.0.0":   true,
+		"10.0.0.0":    true,
+		"169.254.0.0": true,
+		"192.168.0.0": true,
+		"::1":         true,
+		"fc00::":      true,
+
+		"172.15.0.0": false,
+		"172.16.0.0": true,
+		"172.31.0.0": true,
+		"172.32.0.0": false,
+
+		"147.12.56.11": false,
+	}
+
+	for addr, isLocal := range testData {
+		if isLocalAddress(addr) != isLocal {
+			format := "%s should "
+			if !isLocal {
+				format += "not "
+			}
+			format += "be local address"
+
+			t.Errorf(format, addr)
+		}
+	}
+}
+
+func TestIpAddrFromRemoteAddr(t *testing.T) {
+	testData := map[string]string{
+		"127.0.0.1:8888": "127.0.0.1",
+		"ip:port":        "ip",
+		"ip":             "ip",
+		"12:34::0":       "12:34:",
+	}
+
+	for remoteAddr, expectedAddr := range testData {
+		if actualAddr := ipAddrFromRemoteAddr(remoteAddr); actualAddr != expectedAddr {
+			t.Errorf("ipAddrFromRemoteAddr of %s should be %s but get %s", remoteAddr, expectedAddr, actualAddr)
+		}
+	}
+}
+
+func TestRealIP(t *testing.T) {
+	newRequest := func(remoteAddr, hdrRealIP, hdrForwardedFor string) *http.Request {
+		h := http.Header{}
+		h["X-Real-Ip"] = []string{hdrRealIP}
+		h["X-Forwarded-For"] = []string{hdrForwardedFor}
+		return &http.Request{
+			RemoteAddr: remoteAddr,
+			Header:     h,
+		}
+	}
+
+	remoteAddr := "144.12.54.87"
+	anotherRemoteAddr := "119.14.55.11"
+	localAddr := "127.0.0.0"
+
+	testData := []struct {
+		expected string
+		request  *http.Request
+	}{
+		{remoteAddr, newRequest(remoteAddr, "", "")}, // no header
+		{remoteAddr, newRequest("", "", remoteAddr)}, // X-Forwarded-For: remoteAddr
+		{remoteAddr, newRequest("", remoteAddr, "")}, // X-RealIP: remoteAddr
+
+		// X-Forwarded-For: localAddr, remoteAddr, anotherRemoteAddr
+		{remoteAddr, newRequest("", "", strings.Join([]string{localAddr, remoteAddr, anotherRemoteAddr}, ", "))},
+	}
+
+	for _, v := range testData {
+		if actual := RealIP(v.request); v.expected != actual {
+			t.Errorf("expected %s but get %s", v.expected, actual)
+		}
+	}
+}

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
+	"github.com/remind101/empire/internal/realip"
 	"github.com/remind101/pkg/httpx"
 	"github.com/remind101/pkg/logger"
 )
@@ -31,6 +32,8 @@ func LogRequests(h http.Handler) http.Handler {
 		logger.Info(ctx, "request.start",
 			"method", r.Method,
 			"path", r.URL.Path,
+			"user_agent", r.Header.Get("User-Agent"),
+			"remote_ip", realip.RealIP(r),
 		)
 
 		h.ServeHTTP(w, r)

--- a/server/middleware/middleware.go
+++ b/server/middleware/middleware.go
@@ -14,12 +14,15 @@ import (
 // * Log requests
 // * Recover from panics.
 // * Add the request id to the context.
-func Common(h http.Handler) http.Handler {
+func Common(h http.Handler, r *realip.Resolver) http.Handler {
 	// Log requests to the embedded logger.
 	h = LogRequests(h)
 
 	// Prefix log messages with the request id.
 	h = PrefixRequestID(h)
+
+	// Parse out the real ip address of the request.
+	h = realip.Middleware(h, r)
 
 	// Add information about the request to reported errors.
 	return WithRequest(h)


### PR DESCRIPTION
This can be helpful for audit logging, and generating alerts on authentication failures. If a request fails to authenticate, you'll see a log line like:

```console
msg=authentication.failure request_id=7caf77ca-fdc3-4ddc-8c75-6ea0b2f319be username=ejholmes remote_ip=172.19.0.1 err="auth: forbidden"
```

Additionally, it extends the `request.start` log line with some additional fields that can be useful for debugging/auditing (user agent, remote ip):

```console
lvl=info msg=request.start request_id=67803998-4a38-42a4-9fd8-c56fb292e2e7 method=GET path=/apps user_agent="hk/0.12.0 (darwin; amd64) heroku-go/0.10.2 (darwin; amd64)" remote_ip=172.19.0.1
```