### PR TITLE
Fix pull by digest in Docker scheduling backend

### DIFF
--- a/pkg/dockerutil/dockerutil_test.go
+++ b/pkg/dockerutil/dockerutil_test.go
@@ -10,6 +10,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestPullImageOptions(t *testing.T) {
+	img, _ := image.Decode("remind101/acme-inc:latest")
+	options, err := PullImageOptions(img)
+	assert.NoError(t, err)
+	assert.Equal(t, "remind101/acme-inc", options.Repository)
+	assert.Equal(t, "", options.Registry)
+	assert.Equal(t, "latest", options.Tag)
+
+	img, _ = image.Decode("busybox:latest")
+	options, err = PullImageOptions(img)
+	assert.NoError(t, err)
+	assert.Equal(t, "busybox", options.Repository)
+	assert.Equal(t, "", options.Registry)
+	assert.Equal(t, "latest", options.Tag)
+
+	img, _ = image.Decode("quay.io/remind101/acme-inc:latest")
+	options, err = PullImageOptions(img)
+	assert.NoError(t, err)
+	assert.Equal(t, "remind101/acme-inc", options.Repository)
+	assert.Equal(t, "quay.io", options.Registry)
+	assert.Equal(t, "latest", options.Tag)
+
+	img, _ = image.Decode("busybox@sha256:7d3ce4e482101f0c484602dd6687c826bb8bef6295739088c58e84245845912e")
+	options, err = PullImageOptions(img)
+	assert.NoError(t, err)
+	assert.Equal(t, "busybox", options.Repository)
+	assert.Equal(t, "", options.Registry)
+	assert.Equal(t, "sha256:7d3ce4e482101f0c484602dd6687c826bb8bef6295739088c58e84245845912e", options.Tag)
+}
+
 func TestDecodeJSONMessageStream(t *testing.T) {
 	buf := new(bytes.Buffer)
 	w := DecodeJSONMessageStream(buf)

--- a/scheduler/docker/docker.go
+++ b/scheduler/docker/docker.go
@@ -162,12 +162,13 @@ func (s *Scheduler) Run(ctx context.Context, app *twelvefactor.Manifest) error {
 		labels := twelvefactor.Labels(app, p)
 		labels[runLabel] = Attached
 
-		if err := s.docker.PullImage(ctx, docker.PullImageOptions{
-			Registry:     p.Image.Registry,
-			Repository:   p.Image.Repository,
-			Tag:          p.Image.Tag,
-			OutputStream: replaceNL(p.Stderr),
-		}); err != nil {
+		pullOptions, err := dockerutil.PullImageOptions(p.Image)
+		if err != nil {
+			return err
+		}
+		pullOptions.OutputStream = replaceNL(p.Stderr)
+
+		if err := s.docker.PullImage(ctx, pullOptions); err != nil {
 			return fmt.Errorf("error pulling image: %v", err)
 		}
 


### PR DESCRIPTION
Fixes #1111

A previous change was made in fed3ad5a0b2d2b022b9599c69f115c9e54f994bc, which allowed the registry operations to handle digests, however, that change was not propagated through to the Docker scheduling backend. This refactors that change so that the same behavior can be applied to both locations.