### PR TITLE
Update docs for scheduled processes

### DIFF
--- a/docs/deploying_an_application.md
+++ b/docs/deploying_an_application.md
@@ -191,7 +191,7 @@ v54.scheduled-job.9b649d34-b4f5-4fb7-bfe2-889d80dbd3c9  1X  RUNNING  11s  "./bin
 v54.web.fd130482-675f-4611-a599-eb0da1879a10            1X  RUNNING   9m  "./bin/web"
 ```
 
-Refer to http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/ScheduledEvents.html for details on the cron expression syntax.
+Refer to http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for details on the cron expression syntax.
 
 ## Run only processes
 

--- a/procfile/README.md
+++ b/procfile/README.md
@@ -39,10 +39,10 @@ command: ./bin/web
 
 **Cron**
 
-When provided, signifies that the process is a scheduled process. The value should be a valid cron expression.
+When provided, signifies that the process is a scheduled process. The value should be a valid cron expression. See http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html for details on the cron syntax used in Procfiles.
 
 ```yaml
-cron: * * * * * * // Run once every minute
+cron: * * * * ? * // Run once every minute
 ```
 
 **Noservice**


### PR DESCRIPTION
Updates the Procfile docs to use CloudWatch scheduled events syntax. This was already correct in the 'Deploying an Application' docs, but had not been updated in the Procfile specific readme.

This also updates the url for scheduled events.