### PR TITLE
Set the default scheduler to cloudformation

### DIFF
--- a/docs/cloudformation.json
+++ b/docs/cloudformation.json
@@ -59,9 +59,9 @@
     },
     "Scheduler": {
       "Type": "String",
-      "Default": "",
+      "Default": "cloudformation",
       "Description": "The scheduling backend to use to run applications. The default is to run applications with ECS.",
-      "AllowedValues": ["", "cloudformation"]
+      "AllowedValues": ["cloudformation"]
     },
     "AmiId" : {
       "Type": "AWS::EC2::Image::Id",


### PR DESCRIPTION
When going through the [Quickstart Installing](https://empire.readthedocs.io/en/latest/quickstart_installing/), the example CloudFormation stack that is run has a `Scheduler` field that is by default set to `""`. Running this gives you a stack that doesn't work ([discussed](https://empirepaas.slack.com/archives/C08JP3PSA/p1513245614000305) on Slack) with only a hint of the error from the CloudWatch logs. The [Scheduler code](https://github.com/remind101/empire/blob/7867007f0b974b899cea28e36c42c0d282c7db96/cmd/empire/factories.go#L124) only allows the value `cloudformation` and by default raises an exception, so I see no reason for `""` be there, at least not for the default configuration.