### PR TITLE
Remove 1024 limit on cpu shares

### DIFF
--- a/constraints_test.go
+++ b/constraints_test.go
@@ -18,7 +18,8 @@ func TestConstraints_UnmarshalJSON(t *testing.T) {
 	}{
 		{"512:1KB", Constraints{512, 1024, 0}, nil},
 		{"512:1KB:nproc=512", Constraints{512, 1024, 512}, nil},
-		{"1025:1KB", Constraints{}, constraints.ErrInvalidCPUShare},
+		{"1025:1KB", Constraints{1025, 1024, 0}, nil},
+		{"0:1KB", Constraints{}, constraints.ErrInvalidCPUShare},
 
 		{"1024", Constraints{}, constraints.ErrInvalidConstraint},
 	}

--- a/pkg/constraints/constraints.go
+++ b/pkg/constraints/constraints.go
@@ -3,7 +3,7 @@
 //
 // <cpushare>:<memory limit>
 //
-// CPUShare can be any number between 2 and 1024. For more details on how the
+// CPUShare can be any number greater than 1. For more details on how the
 // --cpu-shares flag works in Docker/cgroups, see
 // https://docs.docker.com/reference/run/#cpu-share-constraint
 //
@@ -29,7 +29,7 @@ import (
 const ConstraintsSeparator = ":"
 
 var (
-	ErrInvalidCPUShare   = errors.New("CPUShare must be a value between 2 and 1024")
+	ErrInvalidCPUShare   = errors.New("CPUShare must be greater than 1")
 	ErrInvalidMemory     = errors.New("invalid memory format")
 	ErrInvalidConstraint = errors.New("invalid constraints format")
 )
@@ -42,7 +42,7 @@ type CPUShare int
 
 // NewCPUShare casts i to a CPUShare and ensures its validity.
 func NewCPUShare(i int) (CPUShare, error) {
-	if i < 2 || i > 1024 {
+	if i < 2 {
 		return 0, ErrInvalidCPUShare
 	}
 

--- a/pkg/constraints/constraints_test.go
+++ b/pkg/constraints/constraints_test.go
@@ -13,7 +13,8 @@ func TestCPUShare_ParseCPUShare(t *testing.T) {
 		err error
 	}{
 		{"1024", 1024, nil},
-		{"1025", 0, ErrInvalidCPUShare},
+		{"1", 0, ErrInvalidCPUShare},
+		{"1025", 1025, nil},
 	}
 
 	for _, tt := range tests {
@@ -106,7 +107,8 @@ func TestConstraints_Parse(t *testing.T) {
 	}{
 		{"512:1KB", Constraints{512, 1024, 0}, nil},
 		{"512:1KB:nproc=512", Constraints{512, 1024, 512}, nil},
-		{"1025:1KB", Constraints{}, ErrInvalidCPUShare},
+		{"2048:1KB:nproc=512", Constraints{2048, 1024, 512}, nil},
+		{"0:1KB", Constraints{}, ErrInvalidCPUShare},
 
 		{"1024", Constraints{}, ErrInvalidConstraint},
 		{"1024:1KB:nproc", Constraints{}, ErrInvalidConstraint},


### PR DESCRIPTION
* Is your change backwards compatible? Would this require any migration steps? Will any changes be required in the [CLI](https://github.com/remind101/empire/tree/master/cmd/emp)?
Yes, all existing valid constraints will still be valid.
* Does your change require changes to the documentation? Does the quickstart guide need to be updated?
I don't think so. The comments are updated, the error message is updated, and I can't find a reference to the old limit in the quickstart guide.
* Did you add appropriate test coverage? Submissions that add features or change core functionality will not be accepted without sufficient tests. We favor stability over anything else.
tests were updated appropriately
* Did you update the CHANGELOG?
Not yet