### PR TITLE
Fix emp run lockup in 0.13

### DIFF
--- a/server/heroku/processes.go
+++ b/server/heroku/processes.go
@@ -3,13 +3,11 @@ package heroku
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/remind101/empire"
 	"github.com/remind101/empire/pkg/heroku"
 	"github.com/remind101/empire/pkg/hijack"
 	"github.com/remind101/empire/pkg/stdcopy"
-	streamhttp "github.com/remind101/empire/pkg/stream/http"
 	"github.com/remind101/empire/pkg/timex"
 	"github.com/remind101/empire/server/auth"
 )
@@ -111,8 +109,6 @@ func (h *Server) PostProcess(w http.ResponseWriter, r *http.Request) error {
 			Header:   header,
 		}
 		defer stream.Close()
-		// Prevent the ELB idle connection timeout to close the connection.
-		defer close(streamhttp.Heartbeat(stream, 10*time.Second))
 
 		opts.Stdin = stream
 


### PR DESCRIPTION
Fixes #1113 

In 0.13, stdout/stderr for `emp run` was split using the stdcopy package. Unfortunately, this doesn't play well with streamhttp.Heartbeat, which sends null characters and causes the emp client to lockup.

This removes the heartbeat, since it's mostly unnecessary, and causes other weird side effects (e.g. if you're using tmux, the pane will get "active" because it thinks there's output).

If using an ELB in front of the Empire daemon, the best thing to do is set a high idle timeout (maximum is 60 minutes) to prevent emp run sessions with no output from being killed. This is already the default recommendation in docs/cloudformation.json.