### PR TITLE
Custom::ECSService: don't clobber DesiredCount

### DIFF
--- a/pkg/cloudformation/customresources/types.go
+++ b/pkg/cloudformation/customresources/types.go
@@ -16,6 +16,19 @@ func Int(v int64) *IntValue {
 	return &i
 }
 
+// Eq returns true of other is the same _value_ as i.
+func (i *IntValue) Eq(other *IntValue) bool {
+	if i == nil {
+		return other == nil
+	}
+
+	if other == nil {
+		return i == nil
+	}
+
+	return *i == *other
+}
+
 func (i *IntValue) UnmarshalJSON(b []byte) error {
 	var si int64
 	if err := json.Unmarshal(b, &si); err == nil {

--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -177,12 +177,18 @@ func (p *ECSServiceResource) Create(ctx context.Context, req customresources.Req
 
 func (p *ECSServiceResource) Update(ctx context.Context, req customresources.Request) (interface{}, error) {
 	properties := req.ResourceProperties.(*ECSServiceProperties)
+	oldProperties := req.OldResourceProperties.(*ECSServiceProperties)
 	data := make(map[string]string)
+
+	var desiredCount *int64
+	if !properties.DesiredCount.Eq(oldProperties.DesiredCount) {
+		desiredCount = properties.DesiredCount.Value()
+	}
 
 	resp, err := p.ecs.UpdateService(&ecs.UpdateServiceInput{
 		Service:        aws.String(req.PhysicalResourceId),
 		Cluster:        properties.Cluster,
-		DesiredCount:   properties.DesiredCount.Value(),
+		DesiredCount:   desiredCount,
 		TaskDefinition: properties.TaskDefinition,
 	})
 	if err != nil {


### PR DESCRIPTION
If you're using Custom::ECSService with application autoscaling, anytime the Custom::ECSService resource is updated, the UpdateService call would clobber the currently set DesiredCount on the service.

This changes the behavior such that DesiredCount is only updated on the ECS service if DesiredCount is changed in the CloudFormation resource properties. This makes it easier to use Custom::ECSService with auto scaling.