### PR TITLE
Add opts.Env to proc.Environment for task runner.

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -61,6 +61,16 @@ func (r *runnerService) Run(ctx context.Context, opts RunOpts) error {
 		proc.SetConstraints(*opts.Constraints)
 	}
 
+	// initialize the proc environment map with string keys and string values.
+	if proc.Environment == nil {
+		proc.Environment = make(map[string]string)
+	}
+
+	// Add additional environment variables to the app.
+	for k, v := range opts.Env {
+		proc.Environment[k] = v
+	}
+
 	app.Formation = Formation{procName: proc}
 
 	return r.engine.Run(ctx, app, opts.IO)


### PR DESCRIPTION
This should fix the issue we have with the terminal width environment
var not being forwarded / set.

tested in staging
