### PR TITLE
Produce statically-linked emp and empire binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 **Improvements**
 
+* [cmd/empire] Produce statically-linked binaries
+* [cmd/emp] Produce statically-linked binaries
 * [cmd/empire] The internal upper bound constraint for CPU shares was removed. [#1124](https://github.com/remind101/empire/pull/1124)
 
 ## 0.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 **Improvements**
 
-* [cmd/empire] Produce statically-linked binaries
 * [cmd/emp] Produce statically-linked binaries
 * [cmd/empire] The internal upper bound constraint for CPU shares was removed. [#1124](https://github.com/remind101/empire/pull/1124)
 

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,18 @@ clean:
 	rm -rf build/*
 
 build/empire:
-	go build -o build/empire ./cmd/empire
+	# Setting -tags netgo will force the binary to use the Go networking
+	# libraries instead of system libraries, for more consistent behavior.
+	# The -ldflags setting will enable compiling a static binary that's
+	# portable regardless of whether libc is available.
+	go build -ldflags '-extldflags "-static"' -tags netgo -o build/empire ./cmd/empire
 
 build/emp:
-	go build -o build/emp ./cmd/emp
+	# Setting -tags netgo will force the binary to use the Go networking
+	# libraries instead of system libraries, for more consistent behavior.
+	# The -ldflags setting will enable compiling a static binary that's
+	# portable regardless of whether libc is available.
+	go build -ldflags '-extldflags "-static"' -tags netgo -o build/emp ./cmd/emp
 
 bootstrap: cmds
 	createdb empire || true

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,7 @@ clean:
 	rm -rf build/*
 
 build/empire:
-	# Setting -tags netgo will force the binary to use the Go networking
-	# libraries instead of system libraries, for more consistent behavior.
-	# The -ldflags setting will enable compiling a static binary that's
-	# portable regardless of whether libc is available.
-	go build -ldflags '-extldflags "-static"' -tags netgo -o build/empire ./cmd/empire
+	go build -o build/empire ./cmd/empire
 
 build/emp:
 	# Setting -tags netgo will force the binary to use the Go networking


### PR DESCRIPTION
This change sets flags on the linker to ensure that all libraries are
statically linked. It also forces the compiler to use the Go
implementations of networking libraries (the default).

Making these changes allows the binaries to be run without libc in a
scratch Docker container, or in distributions like Alpine that don't
include libc.

Fixes #1068