### PR TITLE
Releases format

### DIFF
--- a/cmd/emp/releases.go
+++ b/cmd/emp/releases.go
@@ -116,7 +116,6 @@ func listReleases(w io.Writer, versions []string) {
 func abbrevEmailReleases(rels []*Release) {
 	domains := make(map[string]int)
 	for _, r := range rels {
-		r.Who = r.User.Email
 		if a := strings.SplitN(r.Who, "@", 2); len(a) == 2 {
 			domains["@"+a[1]]++
 		}
@@ -156,7 +155,7 @@ func (a releasesByVersion) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a releasesByVersion) Less(i, j int) bool { return a[i].Version < a[j].Version }
 
 func newRelease(rel *heroku.Release) *Release {
-	return &Release{*rel, "", ""}
+	return &Release{*rel, "", rel.User.Id}
 }
 
 var cmdReleaseInfo = &Command{

--- a/cmd/emp/util.go
+++ b/cmd/emp/util.go
@@ -187,7 +187,7 @@ type prettyTime struct {
 
 func (s prettyTime) String() string {
 	if time.Now().Sub(s.Time) < 12*30*24*time.Hour {
-		return s.Local().Format("Jan _2 15:04")
+		return s.Local().Format("Jan _2 15:04 (MST)")
 	}
 	return s.Local().Format("Jan _2  2006")
 }

--- a/releases.go
+++ b/releases.go
@@ -22,6 +22,9 @@ type Release struct {
 
 	// The time that this release was created.
 	CreatedAt *time.Time
+
+    // Committer username and email
+	UserId, UserEmail string
 }
 
 // BeforeCreate sets created_at before inserting.

--- a/server/heroku/releases.go
+++ b/server/heroku/releases.go
@@ -16,6 +16,13 @@ func newRelease(r *empire.Release) *Release {
 		Version:     r.App.Version,
 		Description: r.Description,
 		CreatedAt:   *r.CreatedAt,
+		User: struct {
+			Id    string `json:"id"`
+			Email string `json:"email"`
+		}{
+			Id:    r.UserId,
+			Email: r.UserEmail,
+		},
 	}
 	if r.App.Image != nil {
 		release.Slug = &struct {

--- a/storage/github/github.go
+++ b/storage/github/github.go
@@ -188,6 +188,8 @@ func (s *Storage) Releases(q empire.ReleasesQuery) ([]*empire.Release, error) {
 			App:         app,
 			Description: strings.TrimSpace(desc),
 			CreatedAt:   commit.Commit.Committer.Date,
+			UserId:      *commit.Commit.Committer.Name,
+			UserEmail:   *commit.Commit.Committer.Email,
 		})
 	}
 

--- a/storage/github/github.go
+++ b/storage/github/github.go
@@ -188,8 +188,8 @@ func (s *Storage) Releases(q empire.ReleasesQuery) ([]*empire.Release, error) {
 			App:         app,
 			Description: strings.TrimSpace(desc),
 			CreatedAt:   commit.Commit.Committer.Date,
-			UserId:      *commit.Commit.Committer.Name,
-			UserEmail:   *commit.Commit.Committer.Email,
+			UserId:      *commit.Commit.Author.Name,
+			UserEmail:   *commit.Commit.Author.Email,
 		})
 	}
 


### PR DESCRIPTION
Add the timezone and the author's name to the releases output.

The TZ change is exclusively a client change; for the author to be visible both the client and server must be upgraded (no error if any isn't).

Example output
```
$ emp-local releases -a acme-inc
v2  Russell B…  Feb 25 22:40 (-03)  setting up the repo structure
v3  Fake McFa…  Feb 26 00:36 (-03)  Deployed remind101/acme-inc:latest
v4  Fake McFa…  Feb 26 00:47 (-03)  Deployed remind101/acme-inc:latest
v5  Fake McFa…  Feb 26 01:24 (-03)  Deployed remind101/acme-inc:latest
v6  Fake McFa…  Feb 26 01:29 (-03)  Deployed remind101/acme-inc:latest
v7  Fake McFa…  Feb 26 01:49 (-03)  Deployed remind101/acme-inc:latest
v8  Fake McFa…  Mar 13 17:02 (-03)  Changed environment variables on acme-inc (TACO)

$ TZ=EST emp-local releases -a acme-inc
v2  Russell B…  Feb 25 20:40 (EST)  setting up the repo structure
v3  Fake McFa…  Feb 25 22:36 (EST)  Deployed remind101/acme-inc:latest
v4  Fake McFa…  Feb 25 22:47 (EST)  Deployed remind101/acme-inc:latest
v5  Fake McFa…  Feb 25 23:24 (EST)  Deployed remind101/acme-inc:latest
v6  Fake McFa…  Feb 25 23:29 (EST)  Deployed remind101/acme-inc:latest
v7  Fake McFa…  Feb 25 23:49 (EST)  Deployed remind101/acme-inc:latest
v8  Fake McFa…  Mar 13 15:02 (EST)  Changed environment variables on acme-inc (TACO
```

The reason for using author instead of committer for user id and email is that the merge might be done by other person; in our case a bot, getting:
```
$ emp-staging releases -a r101-etl
v325  GitHub      Feb 19 19:19 (-03)  Migrate batch 8 to empire v2 (#1999)
v326  GitHub App  Feb 19 21:26 (-03)  Deployed remind101/r101-etl:3b8b609f5b7b5fcd322f30905b9d6d1e9d1df4b8
```
instead of the expected
```
$ emp-staging releases -a r101-etl
v325  Russell B…  Feb 19 19:19 (-03)  Migrate batch 8 to empire v2 (#1999)
v326  dalyons     Feb 19 21:26 (-03)  Deployed remind101/r101-etl:3b8b609f5b7b5fcd322f30905b9d6d1e9d1df4b8
```