### PR TITLE
A safer way to get the commit SHA

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -36,7 +36,7 @@ type App struct {
 	Image *image.Image
 
 	// The app repo's git commit hash related to this Docker image.
-	Hash string
+	GitSHA string
 
 	// The process formation for this application.
 	Formation Formation

--- a/empire.go
+++ b/empire.go
@@ -561,6 +561,9 @@ type DeployOpts struct {
 	// App is the app that is being deployed to.
 	App *App
 
+	// The application repo's git commit hash for this image.
+	GitSHA string
+
 	// Image is the image that's being deployed.
 	Image image.Image
 
@@ -652,6 +655,7 @@ func (e *Empire) deploy(ctx context.Context, opts DeployOpts) (*Release, error) 
 		return nil, err
 	}
 
+	app.GitSHA = opts.GitSHA
 	app.Image = &slug.Image
 	app.Formation = formation.Merge(app.Formation)
 

--- a/server/github/deployer.go
+++ b/server/github/deployer.go
@@ -75,6 +75,7 @@ func (d *EmpireDeployer) Deploy(ctx context.Context, event events.Deployment, w 
 	}
 	_, err = d.empire.Deploy(ctx, empire.DeployOpts{
 		Image:   img,
+		GitSHA:  event.Deployment.Sha,
 		Output:  empire.NewDeploymentStream(p),
 		User:    &empire.User{Name: event.Deployment.Creator.Login},
 		Stream:  true,

--- a/server/github/deployer_test.go
+++ b/server/github/deployer_test.go
@@ -38,6 +38,7 @@ func TestEmpireDeployer_Deploy(t *testing.T) {
 			Repository: "remind101/acme-inc",
 			Tag:        "abcd123",
 		},
+		GitSHA:     "abcd123",
 		Stream: true,
 		Message: `GitHub deployment 53252 of remind101/acme-inc to test
 

--- a/storage/github/github.go
+++ b/storage/github/github.go
@@ -89,9 +89,6 @@ func (s *Storage) ReleasesCreate(app *empire.App, event empire.Event) (*empire.R
 	// Auto increment the version number for this new release.
 	app.Version = app.Version + 1
 
-	// Set the App hash from event.String().
-	app.Hash = strings.Split(event.String(), ":")[1]
-
 	// Get details about the ref we want to update.
 	ref, _, err := s.github.Git.GetRef(s.Owner, s.Repo, s.Ref)
 	if err != nil {
@@ -356,12 +353,15 @@ func (s *Storage) treeEntries(app *empire.App) ([]github.TreeEntry, error) {
 			Mode:    github.String(BlobPerms),
 			Content: github.String(app.Image.String()),
 		})
+	}
+
+	if app.GitSHA != "" {
 		// The app repo's git commit hash related to this Docker image.
 		entries = append(entries, github.TreeEntry{
 			Path:    github.String(s.Path(app.Name, FileHash)),
 			Type:    github.String("blob"),
 			Mode:    github.String(BlobPerms),
-			Content: github.String(app.Hash),
+			Content: github.String(app.GitSHA),
 		})
 	}
 


### PR DESCRIPTION
	modified:   empire.go
	modified:   server/github/deployer.go
	modified:   storage/github/github.go