### PR TITLE
Fix regression: create a default placeholder image.

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -47,6 +47,9 @@ func NewApp(name string) *App {
 		Name:        name,
 		Environment: make(map[string]string),
 		Formation:   make(Formation),
+		Image: &image.Image{
+			Repository: "#none",
+		},
 	}
 }
 


### PR DESCRIPTION
We regressed when we added the rollback functionality. 
To fix the regression we will always create a default placeholder IMAGE file for new apps.

	modified:   apps.go