### PR TITLE
Allow passing DeploymentConfiguration to ECS tasks

### DIFF
--- a/server/cloudformation/ecs.go
+++ b/server/cloudformation/ecs.go
@@ -52,14 +52,15 @@ type LoadBalancer struct {
 // ECSServiceProperties represents the properties for the Custom::ECSService
 // resource.
 type ECSServiceProperties struct {
-	ServiceName          *string
-	Cluster              *string
-	DesiredCount         *customresources.IntValue `hash:"ignore"`
-	LoadBalancers        []LoadBalancer
-	Role                 *string
-	TaskDefinition       *string `hash:"ignore"`
-	PlacementConstraints []ECSPlacementConstraint
-	PlacementStrategy    []ECSPlacementStrategy
+	Cluster                 *string
+	DeploymentConfiguration *ecs.DeploymentConfiguration
+	DesiredCount            *customresources.IntValue `hash:"ignore"`
+	LoadBalancers           []LoadBalancer
+	PlacementConstraints    []ECSPlacementConstraint
+	PlacementStrategy       []ECSPlacementStrategy
+	Role                    *string
+	ServiceName             *string
+	TaskDefinition          *string `hash:"ignore"`
 }
 
 func (p *ECSServiceProperties) ReplacementHash() (uint64, error) {
@@ -129,15 +130,16 @@ func (p *ECSServiceResource) Create(ctx context.Context, req customresources.Req
 	}
 
 	resp, err := p.ecs.CreateService(&ecs.CreateServiceInput{
-		ClientToken:          aws.String(clientToken),
-		ServiceName:          serviceName,
-		Cluster:              properties.Cluster,
-		DesiredCount:         properties.DesiredCount.Value(),
-		Role:                 properties.Role,
-		TaskDefinition:       properties.TaskDefinition,
-		LoadBalancers:        loadBalancers,
-		PlacementConstraints: placementConstraints,
-		PlacementStrategy:    placementStrategy,
+		ClientToken:             aws.String(clientToken),
+		Cluster:                 properties.Cluster,
+		DeploymentConfiguration: properties.DeploymentConfiguration,
+		DesiredCount:            properties.DesiredCount.Value(),
+		LoadBalancers:           loadBalancers,
+		PlacementConstraints:    placementConstraints,
+		PlacementStrategy:       placementStrategy,
+		Role:                    properties.Role,
+		ServiceName:             serviceName,
+		TaskDefinition:          properties.TaskDefinition,
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating service: %v", err)


### PR DESCRIPTION
This should read the DeploymentConfiguration from the payload of the
custom resource.