### PR TITLE
Allow empire to redirect oauth callbacks to another host

### DIFF
--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -46,6 +46,8 @@ const (
 	FlagGithubDeploymentsImageTemplate = "github.deployments.template"
 	FlagGithubDeploymentsTugboatURL    = "github.deployments.tugboat.url"
 
+	FlagOAuthRedirectUrl = "oauth.redirect.url"
+
 	FlagConveyorURL = "conveyor.url"
 
 	FlagDB = "db"
@@ -159,6 +161,12 @@ var Commands = []cli.Command{
 				Value:  "",
 				Usage:  "The location of the public key for this service provider. (e.g. file:///etc/empire/saml.cert)",
 				EnvVar: "EMPIRE_SAML_CERT",
+			},
+			cli.StringFlag{
+				Name:   FlagOAuthRedirectUrl,
+				Value:  "",
+				Usage:  "Redirect location for the actual server for Github OAuth token exchange",
+				EnvVar: "EMPIRE_OAUTH_REDIRECT_URL",
 			},
 			cli.StringFlag{
 				Name:   FlagGithubClient,

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -73,6 +73,7 @@ func runServer(c *cli.Context) {
 
 func newServer(c *Context, e *empire.Empire) http.Handler {
 	var opts server.Options
+	opts.OauthRedirectURL = c.String(FlagOAuthRedirectUrl)
 	opts.GitHub.Webhooks.Secret = c.String(FlagGithubWebhooksSecret)
 	opts.GitHub.Deployments.Environments = strings.Split(c.String(FlagGithubDeploymentsEnvironments), ",")
 	opts.GitHub.Deployments.ImageBuilder = newImageBuilder(c)

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 
@@ -57,9 +58,10 @@ func New(e *empire.Empire, options Options) *Server {
 
 	if options.OauthRedirectURL != "" {
 		parsedUrl, err := url.Parse(options.OauthRedirectURL)
-		if err == nil {
-			s.OauthRedirectURL = parsedUrl
+		if err != nil {
+			log.Fatal(err)
 		}
+		s.OauthRedirectURL = parsedUrl
 	}
 	if options.GitHub.Webhooks.Secret != "" {
 		// Mount GitHub webhooks
@@ -109,7 +111,7 @@ func (s *Server) handler(r *http.Request) http.Handler {
 		return s.Heroku
 	}
 
-	if s.OauthRedirectURL != nil && r.URL.Path =="/oauth/exchange" {
+	if r.URL.Path =="/oauth/exchange" && r.FormValue("code") != "" && s.OauthRedirectURL != nil   {
 		return http.HandlerFunc(s.redirectOauth)
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -19,6 +19,7 @@ var (
 )
 
 type Options struct {
+	OauthRedirectURL string
 	GitHub struct {
 		// Deployments
 		Webhooks struct {
@@ -47,11 +48,19 @@ type Server struct {
 
 	// If provided, enables the SAML integration.
 	ServiceProvider *saml.ServiceProvider
+
+	OauthRedirectURL *url.URL
 }
 
 func New(e *empire.Empire, options Options) *Server {
 	s := &Server{}
 
+	if options.OauthRedirectURL != "" {
+		parsedUrl, err := url.Parse(options.OauthRedirectURL)
+		if err == nil {
+			s.OauthRedirectURL = parsedUrl
+		}
+	}
 	if options.GitHub.Webhooks.Secret != "" {
 		// Mount GitHub webhooks
 		s.GitHubWebhooks = github.New(e, github.Options{
@@ -75,6 +84,21 @@ func (s *Server) Handler(r *http.Request) http.Handler {
 	return h
 }
 
+func (s *Server) redirectOauth(w http.ResponseWriter, req *http.Request) {
+	// Shallow copy the existing URL
+	newDest := req.URL
+	// Replace the hostname with the provided hostname
+	newDest.Host = s.OauthRedirectURL.Host
+	// If we've specified a scheme, use that as well
+	if s.OauthRedirectURL.Scheme != "" {
+		newDest.Scheme = s.OauthRedirectURL.Scheme
+	} else {
+		newDest.Scheme = "https"
+	}
+	// Redirect the original request to the new location
+	http.Redirect(w, req, newDest.String(), http.StatusTemporaryRedirect)
+}
+
 func (s *Server) handler(r *http.Request) http.Handler {
 	if r.Header.Get("X-GitHub-Event") != "" {
 		return s.GitHubWebhooks
@@ -83,6 +107,10 @@ func (s *Server) handler(r *http.Request) http.Handler {
 	// Route to Heroku API.
 	if r.Header.Get("Accept") == heroku.AcceptHeader {
 		return s.Heroku
+	}
+
+	if s.OauthRedirectURL != nil && r.URL.Path =="/oauth" {
+		return http.HandlerFunc(s.redirectOauth)
 	}
 
 	switch r.URL.Path {

--- a/server/server.go
+++ b/server/server.go
@@ -109,7 +109,7 @@ func (s *Server) handler(r *http.Request) http.Handler {
 		return s.Heroku
 	}
 
-	if s.OauthRedirectURL != nil && r.URL.Path =="/oauth" {
+	if s.OauthRedirectURL != nil && r.URL.Path =="/oauth/exchange" {
 		return http.HandlerFunc(s.redirectOauth)
 	}
 


### PR DESCRIPTION
Our OAuth setup uses the same token for Empire V1 and Empire V2.  However, the token is associated with a callback URL that can only target one server, V1 _or_ V2, and it currently points at V1.  This new setting will allow the V1 server to redirect the OAuth callbacks to the V2 server so it can handle them.  

Includes changes from #1158 so that the build doesn't fail.  That PR should be merged first.  