### PR TITLE
Fix CI build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ jobs:
 
     steps:
       - checkout
+      - run:
+          name: Install System Dependencies
+          command: sudo apt-get update -qq && sudo apt-get install -yy libxml2-dev libxmlsec1-dev liblzma-dev pkg-config xmlsec1 postgresql-client
       - run: make vet
 
   docker_image:

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,7 +2,7 @@ FROM golang:1.10.8
 MAINTAINER Eric Holmes <eric@remind101.com>
 
 RUN apt-get update -yy && \
-  apt-get install -yy git make curl libxml2-dev libxmlsec1-dev liblzma-dev pkg-config xmlsec1
+  apt-get install -yy git make curl libxml2-dev libxmlsec1-dev liblzma-dev pkg-config xmlsec1 postgresql-client
 
 WORKDIR /go/src/github.com/remind101/empire
 

--- a/cmd/emp/hkclient/creds.go
+++ b/cmd/emp/hkclient/creds.go
@@ -11,7 +11,7 @@ import (
 )
 
 type NetRc struct {
-	netrc.Netrc
+	*netrc.Netrc
 }
 
 func netRcPath() string {
@@ -26,12 +26,12 @@ func LoadNetRc() (nrc *NetRc, err error) {
 	onrc, err := netrc.ParseFile(netRcPath())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &NetRc{}, nil
+			return &NetRc{&netrc.Netrc{}}, nil
 		}
 		return nil, err
 	}
 
-	return &NetRc{*onrc}, nil
+	return &NetRc{onrc}, nil
 }
 
 func (nrc *NetRc) GetCreds(apiURL *url.URL) (user, pass string, err error) {

--- a/cmd/emp/hkclient/creds_test.go
+++ b/cmd/emp/hkclient/creds_test.go
@@ -1,6 +1,7 @@
 package hkclient
 
 import (
+	"github.com/bgentry/go-netrc/netrc"
 	"os"
 	"reflect"
 	"testing"
@@ -16,7 +17,7 @@ func TestLoadNetRc(t *testing.T) {
 	if nrc == nil {
 		t.Fatal("expected an empty NetRc, got nil")
 	}
-	if !reflect.DeepEqual(*nrc, NetRc{}) {
+	if !reflect.DeepEqual(*nrc, NetRc{&netrc.Netrc{}}) {
 		t.Errorf("expected an empty NetRc, got %v", *nrc)
 	}
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,4 +14,7 @@ services:
     environment:
       TEST_DATABASE_URL: "postgres://postgres:postgres@db/postgres?sslmode=disable"
   db:
-    image: postgres
+    image: postgres:9
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -14,7 +14,8 @@ services:
     environment:
       TEST_DATABASE_URL: "postgres://postgres:postgres@db/postgres?sslmode=disable"
   db:
-    image: postgres:9
+    # Postgres 9
+    image: postgres@sha256:9aa0b86ae3be8de6f922441b913e8914e840c652b6880a642f42f98f5e2aaeaf
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
 

--- a/internal/shellwords/util_posix.go
+++ b/internal/shellwords/util_posix.go
@@ -11,6 +11,9 @@ import (
 
 func shellRun(line string) (string, error) {
 	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "sh"
+	}
 	b, err := exec.Command(shell, "-c", line).Output()
 	if err != nil {
 		return "", errors.New(err.Error() + ":" + string(b))

--- a/server/cloudformation/ecs_test.go
+++ b/server/cloudformation/ecs_test.go
@@ -59,6 +59,10 @@ func TestECSServiceResource_Create(t *testing.T) {
 		ServiceName:  aws.String("acme-inc-web-dxRU5tYsnzt"),
 		Cluster:      aws.String("cluster"),
 		DesiredCount: aws.Int64(1),
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
+		},
 	}).Return(&ecs.CreateServiceOutput{
 		Service: &ecs.Service{
 			ServiceName: aws.String("acme-inc-web-dxRU5tYsnzt"),
@@ -77,6 +81,10 @@ func TestECSServiceResource_Create(t *testing.T) {
 		RequestId:   "411f3f38-565f-4216-a711-aeafd5ba635e",
 		RequestType: customresources.Create,
 		ResourceProperties: &ECSServiceProperties{
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
 			DesiredCount: customresources.Int(1),
@@ -101,6 +109,10 @@ func TestECSServiceResource_Create_Canceled(t *testing.T) {
 		ServiceName:  aws.String("acme-inc-web-dxRU5tYsnzt"),
 		Cluster:      aws.String("cluster"),
 		DesiredCount: aws.Int64(1),
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
+		},
 	}).Return(&ecs.CreateServiceOutput{
 		Service: &ecs.Service{
 			ServiceName: aws.String("acme-inc-web-dxRU5tYsnzt"),
@@ -126,6 +138,10 @@ func TestECSServiceResource_Create_Canceled(t *testing.T) {
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
 			DesiredCount: customresources.Int(1),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 		OldResourceProperties: &ECSServiceProperties{},
 	})
@@ -146,6 +162,10 @@ func TestECSServiceResource_Update(t *testing.T) {
 		Cluster:        aws.String("cluster"),
 		DesiredCount:   aws.Int64(2),
 		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
+		},
 	}).Return(
 		&ecs.UpdateServiceOutput{
 			Service: &ecs.Service{
@@ -169,12 +189,20 @@ func TestECSServiceResource_Update(t *testing.T) {
 			ServiceName:    aws.String("acme-inc-web"),
 			DesiredCount:   customresources.Int(2),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("cluster"),
 			ServiceName:    aws.String("acme-inc-web"),
 			DesiredCount:   customresources.Int(1),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 	})
 	assert.NoError(t, err)
@@ -194,6 +222,10 @@ func TestECSServiceResource_Update_SameDesiredCount(t *testing.T) {
 		Service:        aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
 		Cluster:        aws.String("cluster"),
 		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
+		},
 	}).Return(
 		&ecs.UpdateServiceOutput{
 			Service: &ecs.Service{
@@ -217,12 +249,20 @@ func TestECSServiceResource_Update_SameDesiredCount(t *testing.T) {
 			ServiceName:    aws.String("acme-inc-web"),
 			DesiredCount:   customresources.Int(2),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("cluster"),
 			ServiceName:    aws.String("acme-inc-web"),
 			DesiredCount:   customresources.Int(2),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 	})
 	assert.NoError(t, err)
@@ -244,6 +284,10 @@ func TestECSServiceResource_Update_RequiresReplacement(t *testing.T) {
 		Cluster:        aws.String("clusterB"),
 		DesiredCount:   aws.Int64(2),
 		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
+		},
 	}).Return(&ecs.CreateServiceOutput{
 		Service: &ecs.Service{
 			ServiceName: aws.String("acme-inc-web-dxRU5tYsnzt"),
@@ -267,12 +311,20 @@ func TestECSServiceResource_Update_RequiresReplacement(t *testing.T) {
 			ServiceName:    aws.String("acme-inc-web"),
 			DesiredCount:   customresources.Int(2),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("clusterA"),
 			ServiceName:    aws.String("acme-inc-web"),
 			DesiredCount:   customresources.Int(1),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 	})
 	assert.NoError(t, err)
@@ -296,6 +348,10 @@ func TestECSServiceResource_Update_Placement(t *testing.T) {
 		TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:2"),
 		PlacementConstraints: []*ecs.PlacementConstraint{
 			{Type: aws.String("memberOf"), Expression: aws.String("attribute:ecs.instance-type =~ t2.*")},
+		},
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
 		},
 	}).Return(&ecs.CreateServiceOutput{
 		Service: &ecs.Service{
@@ -323,12 +379,20 @@ func TestECSServiceResource_Update_Placement(t *testing.T) {
 			PlacementConstraints: []ECSPlacementConstraint{
 				{Type: aws.String("memberOf"), Expression: aws.String("attribute:ecs.instance-type =~ t2.*")},
 			},
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:        aws.String("clusterA"),
 			ServiceName:    aws.String("acme-inc-web"),
 			DesiredCount:   customresources.Int(1),
 			TaskDefinition: aws.String("arn:aws:ecs:us-east-1:012345678910:task-definition/acme-inc:1"),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 	})
 	assert.NoError(t, err)
@@ -348,6 +412,10 @@ func TestECSServiceResource_Delete(t *testing.T) {
 		Service:      aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
 		Cluster:      aws.String("cluster"),
 		DesiredCount: aws.Int64(0),
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
+		},
 	}).Return(
 		&ecs.UpdateServiceOutput{
 			Service: &ecs.Service{
@@ -372,11 +440,19 @@ func TestECSServiceResource_Delete(t *testing.T) {
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
 			DesiredCount: customresources.Int(1),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
 			DesiredCount: customresources.Int(1),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 	})
 	assert.NoError(t, err)
@@ -396,6 +472,10 @@ func TestECSServiceResource_Delete_NotActive(t *testing.T) {
 		Service:      aws.String("arn:aws:ecs:us-east-1:012345678901:service/acme-inc-web"),
 		Cluster:      aws.String("cluster"),
 		DesiredCount: aws.Int64(0),
+		DeploymentConfiguration: &ecs.DeploymentConfiguration{
+			MaximumPercent: aws.Int64(100),
+			MinimumHealthyPercent: aws.Int64(80),
+		},
 	}).Return(&ecs.UpdateServiceOutput{}, awserr.New("ServiceNotActiveException", "Service was not ACTIVE", errors.New("")))
 
 	id, data, err := p.Provision(ctx, customresources.Request{
@@ -405,11 +485,19 @@ func TestECSServiceResource_Delete_NotActive(t *testing.T) {
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
 			DesiredCount: customresources.Int(1),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 		OldResourceProperties: &ECSServiceProperties{
 			Cluster:      aws.String("cluster"),
 			ServiceName:  aws.String("acme-inc-web"),
 			DesiredCount: customresources.Int(1),
+			DeploymentConfiguration: &DeploymentConfiguration{
+				MaximumPercent: customresources.Int(100),
+				MinimumHealthyPercent: customresources.Int(80),
+			},
 		},
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
There are some test failures that are happening on all builds, even master.  They appear to be the result of bitrot with the Dockerfiles becoming outdated and not working with updated images.  

This attempts to address some of them by adding some missing precision in the postgres source image, adding the postgresql-client package to the test library, since it depends on `pg_dump` and fixing an outright bug in code that launches and external program when the SHELL environment variable isn't present.