### PR TITLE
Support a web-flow for Github OAuth

### DIFF
--- a/cmd/emp/auth.go
+++ b/cmd/emp/auth.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"net"
+	"net/http"
+	"runtime"
+	"sync"
+
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -85,6 +93,185 @@ func runCreds(cmd *Command, args []string) {
 	fmt.Println(user, pass)
 }
 
+var cmdWebLogin = &Command{
+	Run:      runWebLogin,
+	Usage:    "weblogin",
+	Category: "emp",
+	NumArgs:  0,
+	Short:    "Trigger a web-authentication workflow",
+	Long: `
+Ask the empire server to provide a URL that will trigger the web authentication 
+workflow, then open that URL in a browser and wait for authentication to 
+complete by providing token via a callback URL
+`,
+}
+
+type OAuthWebFlow struct {
+	wg *sync.WaitGroup
+	srv *http.Server
+	token string
+	port int
+	startUrl string
+}
+
+func (wf*OAuthWebFlow) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/oauth/token":
+		wf.handleOAuthToken(w, r)
+		return
+
+	case "/oauth/failure":
+		wf.handleOAuthError(w, r)
+		return
+
+	case "/started":
+		fmt.Fprintf(w, "OK!")
+		return
+	}
+}
+
+func (wf*OAuthWebFlow) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	defer wf.wg.Done() // let main know we are done cleaning up
+	wf.token = r.FormValue("token")
+	fmt.Fprintf(w, "You may close this browser window and return to your empire client\n")
+}
+
+func (wf*OAuthWebFlow) handleOAuthError(w http.ResponseWriter, r *http.Request) {
+	defer wf.wg.Done() // let main know we are done cleaning up
+	fmt.Fprintf(w, r.FormValue("err"))
+}
+
+func (wf*OAuthWebFlow) waitForToken() {
+	// Wait for success or failure
+	wf.wg.Wait()
+	// Shut down the http server
+	wf.srv.Shutdown(context.Background())
+
+	if wf.token == "" {
+		printFatal("No token was received, check your browser for an error")
+	}
+}
+
+func newWebFlow() *OAuthWebFlow {
+	// Create the base object
+	wf := &OAuthWebFlow{
+		wg: &sync.WaitGroup{},
+	}
+	wf.wg.Add(1)
+
+	{
+		// Bind to a free local port
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			printFatal(err.Error())
+		}
+
+		wf.port = listener.Addr().(*net.TCPAddr).Port
+
+		wf.srv = &http.Server{
+			Handler: wf,
+		}
+
+		// Start the server, record the port on which we're listening
+		go func() {
+			err = wf.srv.Serve(listener)
+			if err != nil && err != http.ErrServerClosed {
+				panic(err)
+			}
+		}()
+	}
+
+
+	// Wait for the server to start up
+	{
+		client := http.Client{ Timeout: 5 * time.Millisecond, }
+		startedUrl := fmt.Sprintf("http://localhost:%d/started", wf.port)
+		for {
+			_, err := client.Get(startedUrl)
+			if err == nil {
+				break;
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+
+	// Generate the starting URL to initiate the web flow in the browser
+	{
+		u, err := url.Parse(client.URL)
+		if err != nil {
+			panic(err)
+		}
+		u.Path = "/oauth/start"
+		q, err := url.ParseQuery(u.RawQuery)
+		if err != nil {
+			panic(err)
+		}
+		q.Add("port", fmt.Sprintf("%d", wf.port))
+		u.RawQuery = q.Encode()
+		wf.startUrl = u.String()
+	}
+
+	return wf
+}
+
+
+func openBrowser(url string) {
+	var err error
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+	if err != nil {
+		printFatal(err.Error())
+	}
+}
+
+
+
+func runWebLogin(cmd *Command, args []string) {
+	// Creating a web flow automatically starts the
+	wf := newWebFlow()
+
+	// Currently the start URL is the Empire API server. However, a better use experience would probably involve
+	// Opening the browser to a localhost address and having the webFlow handler write out some HTML that will
+	// create a oop-up window for the web flow, which can then be reliably closed by HTML/JS written by
+	// handleOAuthToken
+	go openBrowser(wf.startUrl)
+
+	wf.waitForToken()
+
+	// Use the token directly as part of the basic-auth header, with the special $token$ username
+	// This tells the server to treat the password as like the token it would have received from
+	// the original username/password authentication endpoint
+	address, tokenString, err := attemptLogin("$token$", wf.token, "")
+	if err != nil {
+		printFatal(err.Error())
+	}
+
+	// We don't have the email associated with the token, but we can get it from the JWT
+	// We're passing a nonsense keyFunc because we're not actually going to attempt to
+	// validate the signature
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+		return "", nil
+	})
+	// We can't validate the signature as the client, so ignore ONLY that specific error
+	if err != nil && err.(*jwt.ValidationError).Errors != jwt.ValidationErrorSignatureInvalid {
+		printFatal(err.Error())
+	}
+	// Cast the crap out of this because JWT claims are almost completely freeform in terms of typing
+	email := token.Claims["User"].(map[string]interface{})["Email"].(string)
+
+	// Save the credentials to disk using the shared logic with the old `login` command
+	persistCredentials(address, email, tokenString)
+	fmt.Println("Logged in.")
+}
+
 var cmdLogin = &Command{
 	Run:      runLogin,
 	Usage:    "login",
@@ -107,6 +294,7 @@ Example:
 
 func runLogin(cmd *Command, args []string) {
 	cmd.AssertNumArgsCorrect(args)
+	fmt.Println("The login command is deprecated and will stop working in Nov 2020.  Please use weblogin.")
 
 	oldEmail := client.Username
 	var email string
@@ -151,7 +339,13 @@ func runLogin(cmd *Command, args []string) {
 		}
 	}
 
-	nrc, err = hkclient.LoadNetRc()
+
+	persistCredentials(address, email, token)
+	fmt.Println("Logged in.")
+}
+
+func persistCredentials(address string, email string, token string) {
+	nrc, err := hkclient.LoadNetRc()
 	if err != nil {
 		printFatal("loading netrc: " + err.Error())
 	}
@@ -160,7 +354,6 @@ func runLogin(cmd *Command, args []string) {
 	if err != nil {
 		printFatal("saving new token: " + err.Error())
 	}
-	fmt.Println("Logged in.")
 }
 
 func readPassword(prompt string) (password string, err error) {

--- a/cmd/emp/main.go
+++ b/cmd/emp/main.go
@@ -149,6 +149,7 @@ var commands = []*Command{
 	cmdCreds,
 	cmdGet,
 	cmdLogin,
+	cmdWebLogin,
 	cmdLogout,
 	cmdMaintenance,
 	cmdMaintenanceEnable,

--- a/cmd/empire/main.go
+++ b/cmd/empire/main.go
@@ -36,6 +36,7 @@ const (
 	FlagSAMLCert           = "saml.cert"
 	FlagGithubClient       = "github.client.id"
 	FlagGithubClientSecret = "github.client.secret"
+	FlagGithubClientRedirectURL = "github.client.redirect.url"
 	FlagGithubOrg          = "github.organization"
 	FlagGithubApiURL       = "github.api.url"
 	FlagGithubTeam         = "github.team.id"
@@ -45,8 +46,6 @@ const (
 	FlagGithubDeploymentsImageBuilder  = "github.deployments.image_builder"
 	FlagGithubDeploymentsImageTemplate = "github.deployments.template"
 	FlagGithubDeploymentsTugboatURL    = "github.deployments.tugboat.url"
-
-	FlagOAuthRedirectUrl = "oauth.redirect.url"
 
 	FlagConveyorURL = "conveyor.url"
 
@@ -163,12 +162,6 @@ var Commands = []cli.Command{
 				EnvVar: "EMPIRE_SAML_CERT",
 			},
 			cli.StringFlag{
-				Name:   FlagOAuthRedirectUrl,
-				Value:  "",
-				Usage:  "Redirect location for the actual server for Github OAuth token exchange",
-				EnvVar: "EMPIRE_OAUTH_REDIRECT_URL",
-			},
-			cli.StringFlag{
 				Name:   FlagGithubClient,
 				Value:  "",
 				Usage:  "The client id for the GitHub OAuth application",
@@ -179,6 +172,12 @@ var Commands = []cli.Command{
 				Value:  "",
 				Usage:  "The client secret for the GitHub OAuth application",
 				EnvVar: "EMPIRE_GITHUB_CLIENT_SECRET",
+			},
+			cli.StringFlag{
+				Name:   FlagGithubClientRedirectURL,
+				Value:  "",
+				Usage:  "The base redirect URL for the GitHub OAuth application",
+				EnvVar: "EMPIRE_GITHUB_CLIENT_REDIRECT_URL",
 			},
 			cli.StringFlag{
 				Name:   FlagGithubOrg,

--- a/cmd/empire/server.go
+++ b/cmd/empire/server.go
@@ -68,12 +68,6 @@ func runServer(c *cli.Context) {
 
 	s := newServer(ctx, e)
 	log.Printf("Starting on port %s", port)
-	go func() {
-		err = http.ListenAndServeTLS(":8443", "server.crt", "server.key", s)
-		if (err != nil) {
-			log.Fatal(err)
-		}
-	}()
 	log.Fatal(http.ListenAndServe(":"+port, s))
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"golang.org/x/oauth2"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 

--- a/tests/cli/login_test.go
+++ b/tests/cli/login_test.go
@@ -33,7 +33,7 @@ func TestLogin(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := string(out), "Enter email: Logged in.\n"; got != want {
+	if got, want := string(out), "The login command is deprecated and will stop working in Nov 2020.  Please use weblogin.\nEnter email: Logged in.\n"; got != want {
 		t.Fatalf("%q", got)
 	}
 }
@@ -54,7 +54,7 @@ func TestLoginUnauthorized(t *testing.T) {
 		t.Fatal("Expected an error")
 	}
 
-	if got, want := string(out), "Enter email: error: Request not authenticated, API token is missing, invalid or expired Log in with `emp login`.\n"; got != want {
+	if got, want := string(out), "The login command is deprecated and will stop working in Nov 2020.  Please use weblogin.\nEnter email: error: Request not authenticated, API token is missing, invalid or expired Log in with `emp login`.\n"; got != want {
 		t.Fatalf("%q", got)
 	}
 }
@@ -75,7 +75,7 @@ func TestLoginTwoFactor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := string(out), "Enter email: Enter two-factor auth code: Logged in.\n"; got != want {
+	if got, want := string(out), "The login command is deprecated and will stop working in Nov 2020.  Please use weblogin.\nEnter email: Enter two-factor auth code: Logged in.\n"; got != want {
 		t.Fatalf("%q", got)
 	}
 }


### PR DESCRIPTION
The existing Github auth endpoint used by Empire is being deprecated and will be unavailable after November 2020.  This PR adds support for the OAuth web-flow recommended by Github to replace the use of the endpoint for command line apps