### PR TITLE
Workaround new long ARNs

### DIFF
--- a/pkg/arn/arn.go
+++ b/pkg/arn/arn.go
@@ -63,7 +63,7 @@ func (a *ARN) String() string {
 // SplitResource splits the Resource section of an ARN into its type and id
 // components.
 func SplitResource(r string) (resource, id string, err error) {
-	p := strings.Split(r, "/")
+	p := strings.SplitN(r, "/", 2)
 
 	if len(p) != 2 {
 		err = ErrInvalidResource

--- a/pkg/arn/arn_test.go
+++ b/pkg/arn/arn_test.go
@@ -23,6 +23,14 @@ func TestParse(t *testing.T) {
 			Account:  "249285743859",
 			Resource: "service/acme-inc:web",
 		}},
+		{"arn:aws:ecs:us-east-1:249285743859:service/my-cluster/acme-inc:web", ARN{
+			ARN:      "arn",
+			AWS:      "aws",
+			Service:  "ecs",
+			Region:   "us-east-1",
+			Account:  "249285743859",
+			Resource: "service/my-cluster/acme-inc:web",
+		}},
 	}
 
 	for i, tt := range tests {
@@ -41,6 +49,7 @@ func TestSplitResource(t *testing.T) {
 		err          error
 	}{
 		{"service/acme-inc", "service", "acme-inc", nil},
+		{"service/my-cluster-name/acme-inc", "service", "my-cluster-name/acme-inc", nil},
 		{"service", "", "", ErrInvalidResource},
 	}
 


### PR DESCRIPTION
This patch should work around the new long ARNs that AWS are creating by default now (not next year as I had thought in https://github.com/remind101/empire/issues/1156).  It seems if you don't explicitly opt-out of the long ARNs you get them now, but you can opt out again manually.

We're actually using this server-side fix rebased to an older empire version, but it should also work in latest master I hope...