### PR TITLE
Remove outdated MAINTAINER lines from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.10.8
-MAINTAINER Eric Holmes <eric@remind101.com>
 
 LABEL version 0.13.0
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,4 @@
 FROM golang:1.10.8
-MAINTAINER Eric Holmes <eric@remind101.com>
 
 RUN apt-get update -yy && \
   apt-get install -yy git make curl libxml2-dev libxmlsec1-dev liblzma-dev pkg-config xmlsec1 postgresql-client


### PR DESCRIPTION
Eric no longer works at Remind, and this field is deprecated. Given that
this repository is maintained by the remind101 org, I'm just removing
the line completely.